### PR TITLE
feat: in-app updater + bug fixes — v1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ legacy-mStorage/
 
 # Generated installer output
 installer/
+
+# Ai input
+QUERY.md

--- a/installer.iss
+++ b/installer.iss
@@ -7,7 +7,7 @@
 ; Output: installer\mStorage_Setup.exe
 
 #define AppName        "mStorage"
-#define AppVersion     "1.1.1"
+#define AppVersion     "1.2.0"
 #define AppPublisher   "Seshu Tarapatla"
 #define AppURL         "https://github.com/SeshuTarapatla/mStorage"
 #define AppExeName     "m_storage.exe"
@@ -40,6 +40,9 @@ WizardStyle=modern
 MinVersion=10.0
 ; Install to Program Files, requires UAC — app appears in Apps & features for all users
 PrivilegesRequired=admin
+; Close the running app automatically before installing so it can overwrite the exe.
+CloseApplications=yes
+CloseApplicationsFilter={#AppExeName}
 ArchitecturesInstallIn64BitMode=x64compatible
 
 [Languages]

--- a/lib/core/services/archive_service.dart
+++ b/lib/core/services/archive_service.dart
@@ -65,15 +65,22 @@ class ArchiveService {
     return b.buffer.asUint8List();
   }
 
-  /// Packages [fileEntries] (sourcePath, archiveName) pairs into a STORE ZIP.
-  /// Each file is stored under its [archiveName], allowing in-archive renaming
-  /// (e.g., to `<title>.mp4`). Progress is reported inline during streaming.
+  /// Packages [fileEntries] (sourcePath, archiveName) pairs into a ZIP.
+  /// When [password] is set, delegates to 7za for AES-256 encryption via stdin
+  /// (avoids copying large video files). Falls back to the pure Dart STORE
+  /// writer when no password is required.
   static Future<void> createZip({
     required List<(String, String)> fileEntries,
     required String outputPath,
     String password = '',
     void Function(double)? onProgress,
   }) async {
+    if (password.isNotEmpty) {
+      await _createEncryptedZip(fileEntries, outputPath, password, onProgress);
+      return;
+    }
+    // No password — use fast streaming Dart writer.
+
     int totalBytes = 0;
     for (final (path, _) in fileEntries) {
       try {
@@ -181,6 +188,43 @@ class ArchiveService {
     } finally {
       await out.close();
     }
+  }
+
+  // ---------------------------------------------------------------------------
+
+  static Future<void> _createEncryptedZip(
+    List<(String, String)> fileEntries,
+    String outputPath,
+    String password,
+    void Function(double)? onProgress,
+  ) async {
+    final sevenZ = await sevenZipPath;
+    int totalBytes = 0;
+    for (final (path, _) in fileEntries) {
+      try {
+        totalBytes += await File(path).length();
+      } catch (_) {}
+    }
+    int processed = 0;
+    for (final (sourcePath, archiveName) in fileEntries) {
+      final process = await Process.start(sevenZ, [
+        'a', '-tzip', '-p$password', '-mem=AES256', outputPath, '-si$archiveName',
+      ]);
+      await for (final chunk in File(sourcePath).openRead()) {
+        process.stdin.add(chunk);
+        processed += chunk.length;
+        if (onProgress != null && totalBytes > 0) {
+          onProgress((processed / totalBytes).clamp(0.0, 0.99));
+        }
+      }
+      await process.stdin.close();
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        final err = await process.stderr.transform(utf8.decoder).join();
+        throw Exception('7za encryption failed (exit $exitCode): $err');
+      }
+    }
+    onProgress?.call(1.0);
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/features/catalog/catalog_notifier.dart
+++ b/lib/features/catalog/catalog_notifier.dart
@@ -347,15 +347,21 @@ class DownloadHistoryNotifier extends Notifier<List<DownloadRecord>> {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_kHistoryKey) ?? '[]';
     try {
-      final list = (jsonDecode(raw) as List)
+      final decoded = jsonDecode(raw) as List;
+      final seen = <String>{};
+      final list = decoded
           .map((e) => DownloadRecord.fromJson(e as Map<String, dynamic>))
+          .where((r) => seen.add(r.filePath))
           .toList();
       if (!_disposed) state = list;
+      if (list.length < decoded.length) await _persist(list);
     } catch (_) {}
   }
 
   Future<void> add(DownloadRecord record) async {
-    final updated = [record, ...state].take(100).toList();
+    final updated = [record, ...state.where((r) => r.filePath != record.filePath)]
+        .take(100)
+        .toList();
     state = updated;
     await _persist(updated);
   }

--- a/lib/features/catalog/widgets/webview_overlay.dart
+++ b/lib/features/catalog/widgets/webview_overlay.dart
@@ -265,6 +265,26 @@ class _WebViewOverlayState extends State<WebViewOverlay> {
                       color: kBgColor,
                       child: Center(child: CircularProgressIndicator(color: palette.primary)),
                     ),
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 7),
+                      color: kBgColor.withValues(alpha: 0.82),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.keyboard_rounded, size: 14, color: palette.primary),
+                          const SizedBox(width: 7),
+                          Text(
+                            'If the Download button doesn\'t respond, press  Shift + D  as an alternative',
+                            style: TextStyle(fontSize: 13, color: palette.primary, fontWeight: FontWeight.w500),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
                   ]),
               ),
             ),

--- a/lib/features/decode/decode_screen.dart
+++ b/lib/features/decode/decode_screen.dart
@@ -41,7 +41,13 @@ class _DecodeScreenState extends ConsumerState<DecodeScreen> {
     });
   }
 
-  void _onVideoDropped(String path) => setState(() => _videoPath = path);
+  void _onVideoDropped(String path) {
+    final decState = ref.read(decodeProvider);
+    if (!decState.isRunning && decState.step != DecodeStep.idle) {
+      ref.read(decodeProvider.notifier).reset();
+    }
+    setState(() => _videoPath = path);
+  }
 
   void _clearAll() => setState(() => _videoPath = null);
 
@@ -99,9 +105,7 @@ class _DecodeScreenState extends ConsumerState<DecodeScreen> {
     });
 
     final customDir = settings.decodeOutputDirectory;
-    final displayOutDir = customDir.isNotEmpty
-        ? customDir
-        : (_videoPath != null ? p.dirname(_videoPath!) : '');
+    final displayOutDir = customDir.isNotEmpty ? customDir : AppDirectories.decoded;
 
     // First video in extracted files, for "Open in Player" shortcut
     final firstVideo = state.extractedFiles.where((f) {
@@ -163,7 +167,13 @@ class _DecodeScreenState extends ConsumerState<DecodeScreen> {
               allowedExtensions: const ['mp4'],
               onFilePicked: _onVideoDropped,
               onTap: _pickVideo,
-              onClear: () => setState(() => _videoPath = null),
+              onClear: () {
+                final step = ref.read(decodeProvider).step;
+                if (step == DecodeStep.done || step == DecodeStep.error) {
+                  ref.read(decodeProvider.notifier).reset();
+                }
+                setState(() => _videoPath = null);
+              },
             ).animate().fadeIn(duration: 300.ms).slideY(begin: 0.05),
 
             const SizedBox(height: 16),

--- a/lib/features/decode/decode_screen.dart
+++ b/lib/features/decode/decode_screen.dart
@@ -222,6 +222,16 @@ class _DecodeScreenState extends ConsumerState<DecodeScreen> {
               ).animate().fadeIn(delay: 200.ms),
             ],
 
+            if (!state.isRunning && state.step != DecodeStep.done &&
+                settings.password.isEmpty)
+              PasswordWarningBanner(
+                accentColor: accent,
+                message: 'No password set — decoding will fail if the file is password-protected.',
+                onGoToSettings: () => ref
+                    .read(activeTabProvider.notifier)
+                    .state = AppTab.settings,
+              ).animate().fadeIn(duration: 300.ms),
+
             if (!state.isRunning && state.step != DecodeStep.done)
               _DecodeButton(
                 enabled: _videoPath != null,

--- a/lib/features/encode/encode_screen.dart
+++ b/lib/features/encode/encode_screen.dart
@@ -50,9 +50,12 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
   }
 
   void _onVideoDropped(String path) {
+    final encState = ref.read(encodeProvider);
+    final wasFinished = !encState.isRunning && encState.step != EncodeStep.idle;
+    if (wasFinished) ref.read(encodeProvider.notifier).reset();
     setState(() {
       _videoPath = path;
-      if (_titleCtrl.text.isEmpty) {
+      if (_titleCtrl.text.isEmpty || wasFinished) {
         _titleCtrl.text = p.basenameWithoutExtension(path);
       }
     });
@@ -106,6 +109,12 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
       }
     }
 
+    if (videoPath != null) {
+      final encState = ref.read(encodeProvider);
+      if (!encState.isRunning && encState.step != EncodeStep.idle) {
+        ref.read(encodeProvider.notifier).reset();
+      }
+    }
     setState(() {
       if (videoPath != null) {
         _videoPath = videoPath;
@@ -204,11 +213,7 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
     final accent = _palette.primary;
 
     final customDir = settings.encodeOutputDirectory;
-    final displayOutDir = customDir.isNotEmpty
-        ? customDir
-        : (_videoPath != null
-            ? p.join(p.dirname(_videoPath!), 'output')
-            : '');
+    final displayOutDir = customDir.isNotEmpty ? customDir : AppDirectories.encoded;
 
     final anyFieldSet = _videoPath != null || _posterPath != null || _srtPath != null;
 
@@ -255,10 +260,16 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
                   onFilePicked: _onVideoDropped,
                   onTap: _pickVideo,
                   onMultiFileDrop: _routeFiles,
-                  onClear: () => setState(() {
-                    _videoPath = null;
-                    _titleCtrl.clear();
-                  }),
+                  onClear: () {
+                    final step = ref.read(encodeProvider).step;
+                    if (step == EncodeStep.done || step == EncodeStep.error) {
+                      ref.read(encodeProvider.notifier).reset();
+                    }
+                    setState(() {
+                      _videoPath = null;
+                      _titleCtrl.clear();
+                    });
+                  },
                 ).animate().fadeIn(duration: 300.ms).slideY(begin: 0.05),
 
                 const SizedBox(height: 20),

--- a/lib/features/encode/encode_screen.dart
+++ b/lib/features/encode/encode_screen.dart
@@ -9,6 +9,7 @@ import '../../core/models/encode_config.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
+import '../shell/app_shell.dart';
 import '../shell/widgets/shared_widgets.dart';
 import 'encode_notifier.dart';
 import 'widgets/drop_zone.dart';
@@ -390,6 +391,18 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
                       _clearAll();
                     },
                   ).animate().fadeIn().scaleXY(begin: 0.95),
+
+                // Password warning
+                if ((encodeState.step == EncodeStep.idle ||
+                        encodeState.step == EncodeStep.error) &&
+                    settings.password.isEmpty)
+                  PasswordWarningBanner(
+                    accentColor: accent,
+                    message: 'No password set — encoded file will not be encrypted.',
+                    onGoToSettings: () => ref
+                        .read(activeTabProvider.notifier)
+                        .state = AppTab.settings,
+                  ).animate().fadeIn(duration: 300.ms),
 
                 // Encode button
                 if (encodeState.step == EncodeStep.idle ||

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -14,6 +14,7 @@ import '../../core/providers/player_request_provider.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
+import '../shell/app_shell.dart';
 import '../shell/widgets/shared_widgets.dart';
 
 const _kVideoExts = ['mp4', 'mkv', 'mov', 'avi', 'webm'];
@@ -54,7 +55,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   bool _syncplayFound = false;
   String? _syncplayPath;
   String? _vlcPath;
-
   // Syncplay process & log
   Process? _syncplayProcess;
   final List<String> _syncplayLogs = [];
@@ -75,12 +75,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       _configureForHighRes();
     }
     HardwareKeyboard.instance.addHandler(_handleKeyEvent);
+
+    // Consume any request that was set before this State was created (tab switch).
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final path = ref.read(playerOpenRequestProvider);
       if (path != null) {
-        _openVideo(path);
         ref.read(playerOpenRequestProvider.notifier).state = null;
+        _openVideo(path);
       }
     });
   }
@@ -161,18 +163,16 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     await Process.start(_vlcPath!, [_videoPath!]);
   }
 
-  Future<void> _openVideo(String path) async {
+  void _openVideo(String path) {
     setState(() => _videoPath = path);
-    // Wait one frame so the Video widget is mounted before opening media.
-    // Calling open() before VideoController's first render leaves it in a
-    // broken state where playback silently fails on first app launch.
-    final frameReady = Completer<void>();
-    WidgetsBinding.instance.addPostFrameCallback((_) => frameReady.complete());
-    await frameReady.future;
-    if (!mounted) return;
-    await _player.open(Media(path));
-    if (mounted) _player.play();
-    if (mounted) ref.read(settingsProvider.notifier).setLastVideoPath(path);
+    // Defer open() one frame so the Video widget is mounted before media_kit
+    // tries to attach to it (avoids silent playback failure on first launch).
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      await _player.open(Media(path));
+      if (mounted) _player.play();
+      if (mounted) ref.read(settingsProvider.notifier).setLastVideoPath(path);
+    });
   }
 
   void _closeVideo() {
@@ -194,7 +194,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       allowedExtensions: _kVideoExts,
     );
     if (result != null && result.files.isNotEmpty) {
-      await _openVideo(result.files.first.path!);
+      _openVideo(result.files.first.path!);
     }
   }
 
@@ -244,10 +244,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     final accent = _palette.primary;
     final settings = ref.watch(settingsProvider);
 
+    // Guard: inactive State's listener must not consume — it would clear the
+    // provider before the newly-created active State's initState callback runs.
     ref.listen<String?>(playerOpenRequestProvider, (_, path) {
-      if (path != null) {
-        _openVideo(path);
+      if (path != null && ref.read(activeTabProvider) == AppTab.player) {
         ref.read(playerOpenRequestProvider.notifier).state = null;
+        _openVideo(path);
       }
     });
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -3,6 +3,8 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import '../../core/services/catalog_cache_manager.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
@@ -11,6 +13,8 @@ import '../catalog/catalog_notifier.dart';
 import '../catalog/imdb_service.dart';
 import '../catalog/widgets/catalog_card.dart';
 import '../shell/widgets/shared_widgets.dart';
+import '../updater/update_model.dart';
+import '../updater/update_notifier.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
@@ -25,12 +29,16 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   bool _showPassword = false;
   String? _cacheMessage;
   Timer? _cacheMessageTimer;
+  String? _appVersion;
 
   @override
   void initState() {
     super.initState();
     _passwordCtrl =
         TextEditingController(text: ref.read(settingsProvider).password);
+    PackageInfo.fromPlatform().then((info) {
+      if (mounted) setState(() => _appVersion = info.version);
+    });
   }
 
   @override
@@ -38,6 +46,170 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     _passwordCtrl.dispose();
     _cacheMessageTimer?.cancel();
     super.dispose();
+  }
+
+  void _showChangelog(UpdateInfo info) {
+    final accent = _palette.primary;
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: kSurfaceColor,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: Text(
+          "What's new in v${info.version}",
+          style: const TextStyle(color: kTextPrimary, fontSize: 16),
+        ),
+        content: SizedBox(
+          width: 480,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 300),
+            child: Markdown(
+              data: info.releaseNotes.isNotEmpty ? info.releaseNotes : '_No release notes available._',
+              shrinkWrap: true,
+              padding: const EdgeInsets.only(top: 4),
+              styleSheet: MarkdownStyleSheet(
+                p: const TextStyle(fontSize: 12, color: kTextSecondary, height: 1.6),
+                h1: TextStyle(fontSize: 15, fontWeight: FontWeight.w700, color: accent),
+                h2: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: accent),
+                h3: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: kTextPrimary),
+                strong: const TextStyle(fontWeight: FontWeight.w600, color: kTextPrimary),
+                em: const TextStyle(fontStyle: FontStyle.italic, color: kTextSecondary),
+                code: const TextStyle(fontSize: 11, color: kTextPrimary, fontFamily: 'monospace'),
+                codeblockDecoration: BoxDecoration(
+                  color: kSurface2Color,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                listBullet: const TextStyle(fontSize: 12, color: kTextSecondary),
+                horizontalRuleDecoration: const BoxDecoration(
+                  border: Border(top: BorderSide(color: kBorderColor)),
+                ),
+              ),
+            ),
+          ),
+        ),
+
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text('Close', style: TextStyle(color: accent)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUpdateControl(UpdateState updateState) {
+    final accent = _palette.primary;
+    switch (updateState.status) {
+      case UpdateStatus.idle:
+        return _ActionButton(
+          label: 'Check Now',
+          accent: accent,
+          onTap: () => ref.read(updateProvider.notifier).checkForUpdate(),
+        );
+      case UpdateStatus.upToDate:
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _ActionButton(
+              label: 'Check Now',
+              accent: accent,
+              onTap: () => ref.read(updateProvider.notifier).checkForUpdate(),
+            ),
+            const SizedBox(height: 4),
+            Text('Already up to date',
+                style: TextStyle(fontSize: 11, color: accent)),
+          ],
+        );
+      case UpdateStatus.checking:
+        return SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2, color: accent),
+        );
+      case UpdateStatus.available:
+        final info = updateState.info!;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _ActionButton(
+              label: 'Download v${info.version}',
+              accent: accent,
+              onTap: () => ref.read(updateProvider.notifier).downloadUpdate(),
+            ),
+            if (info.releaseNotes.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              GestureDetector(
+                onTap: () => _showChangelog(info),
+                child: Text(
+                  'View changelog',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: accent,
+                    decoration: TextDecoration.underline,
+                    decorationColor: accent,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        );
+      case UpdateStatus.downloading:
+        return SizedBox(
+          width: 140,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Downloading ${(updateState.downloadProgress * 100).round()}%',
+                    style: TextStyle(fontSize: 11, color: accent),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: updateState.downloadProgress,
+                  backgroundColor: accent.withValues(alpha: 0.15),
+                  valueColor: AlwaysStoppedAnimation(accent),
+                  minHeight: 3,
+                ),
+              ),
+            ],
+          ),
+        );
+      case UpdateStatus.readyToInstall:
+        return _ActionButton(
+          label: 'Install Now',
+          accent: accent,
+          onTap: () => ref.read(updateProvider.notifier).launchInstaller(),
+        );
+      case UpdateStatus.error:
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              updateState.errorMessage ?? 'Unknown error',
+              style: const TextStyle(fontSize: 11, color: kDanger),
+              textAlign: TextAlign.end,
+            ),
+            const SizedBox(height: 4),
+            _ActionButton(
+              label: 'Retry',
+              accent: accent,
+              onTap: () => ref.read(updateProvider.notifier).checkForUpdate(),
+            ),
+          ],
+        );
+    }
   }
 
   Future<void> _confirmClearCache() async {
@@ -117,6 +289,24 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   Widget build(BuildContext context) {
     final settings = ref.watch(settingsProvider);
     final accent = _palette.primary;
+    final updateState = ref.watch(updateProvider);
+    final updatePending = updateState.status == UpdateStatus.available ||
+        updateState.status == UpdateStatus.downloading ||
+        updateState.status == UpdateStatus.readyToInstall;
+
+    final updatesGroup = _SettingsGroup(
+      label: 'Updates',
+      accent: accent,
+      children: [
+        _SettingRow(
+          icon: Icons.system_update_rounded,
+          title: 'Check for Updates',
+          subtitle: 'mStorage v${_appVersion ?? '...'}  ·  Currently installed',
+          accent: accent,
+          control: _buildUpdateControl(updateState),
+        ),
+      ],
+    ).animate().fadeIn(duration: 300.ms, delay: 40.ms);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(28),
@@ -130,6 +320,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             color: accent,
           ),
           const SizedBox(height: 32),
+
+          if (updatePending) ...[
+            updatesGroup,
+            const SizedBox(height: 20),
+          ],
 
           // ── General ──────────────────────────────────────────────────────
           _SettingsGroup(
@@ -343,6 +538,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           const SizedBox(height: 20),
 
+          if (!updatePending) ...[
+            // ── Updates ────────────────────────────────────────────────────
+            updatesGroup,
+            const SizedBox(height: 20),
+          ],
+
           // ── Cache ─────────────────────────────────────────────────────────
           _SettingsGroup(
             label: 'Cache',
@@ -427,9 +628,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               children: [
                 Divider(color: kBorderColor, height: 1),
                 const SizedBox(height: 16),
-                const Text(
-                  'mStorage  v1.0.0',
-                  style: TextStyle(
+                Text(
+                  'mStorage  v${_appVersion ?? '...'}',
+                  style: const TextStyle(
                       fontSize: 12,
                       fontWeight: FontWeight.w600,
                       color: kTextMuted),

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import '../../core/services/gh_auth_service.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
+import '../updater/update_model.dart';
+import '../updater/update_notifier.dart';
 import '../admin/admin_screen.dart';
 import '../decode/decode_notifier.dart';
 import '../encode/encode_notifier.dart';
@@ -71,6 +74,102 @@ class _AppShellState extends ConsumerState<AppShell>
     super.dispose();
   }
 
+  void _showUpdateDialog(BuildContext context, UpdateInfo info, TabPalette palette) {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: kSurfaceColor,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: palette.primary.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Icon(Icons.system_update_rounded, color: palette.primary, size: 20),
+            ),
+            const SizedBox(width: 12),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Update available',
+                    style: TextStyle(color: kTextPrimary, fontSize: 15, fontWeight: FontWeight.w600)),
+                Text('v${info.version} is ready to download',
+                    style: const TextStyle(color: kTextSecondary, fontSize: 12, fontWeight: FontWeight.normal)),
+              ],
+            ),
+          ],
+        ),
+        content: info.releaseNotes.isNotEmpty
+            ? SizedBox(
+                width: 420,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text("What's new",
+                        style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: palette.primary, letterSpacing: 0.8)),
+                    const SizedBox(height: 8),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxHeight: 200),
+                      child: Markdown(
+                        data: info.releaseNotes,
+                        shrinkWrap: true,
+                        padding: const EdgeInsets.only(top: 4),
+                        styleSheet: _mdStyle(palette),
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            : null,
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(ctx);
+              ref.read(updateProvider.notifier).dismissForToday();
+            },
+            child: const Text('Later', style: TextStyle(color: kTextMuted)),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(ctx);
+              ref.read(activeTabProvider.notifier).state = AppTab.settings;
+              ref.read(updateProvider.notifier).downloadUpdate();
+            },
+            style: TextButton.styleFrom(foregroundColor: palette.primary),
+            child: Text('Update Now',
+                style: TextStyle(color: palette.primary, fontWeight: FontWeight.w600)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  MarkdownStyleSheet _mdStyle(TabPalette palette) => MarkdownStyleSheet(
+        p: const TextStyle(fontSize: 12, color: kTextSecondary, height: 1.6),
+        h1: TextStyle(fontSize: 15, fontWeight: FontWeight.w700, color: palette.primary),
+        h2: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: palette.primary),
+        h3: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: kTextPrimary),
+        strong: const TextStyle(fontWeight: FontWeight.w600, color: kTextPrimary),
+        em: const TextStyle(fontStyle: FontStyle.italic, color: kTextSecondary),
+        code: const TextStyle(fontSize: 11, color: kTextPrimary, fontFamily: 'monospace'),
+        codeblockDecoration: BoxDecoration(
+          color: kSurface2Color,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        blockquoteDecoration: BoxDecoration(
+          border: Border(left: BorderSide(color: palette.primary, width: 3)),
+        ),
+        listBullet: const TextStyle(fontSize: 12, color: kTextSecondary),
+        horizontalRuleDecoration: const BoxDecoration(
+          border: Border(top: BorderSide(color: kBorderColor)),
+        ),
+      );
+
   Widget _screenFor(AppTab tab) => switch (tab) {
     AppTab.encode   => const EncodeScreen(),
     AppTab.decode   => const DecodeScreen(),
@@ -90,6 +189,17 @@ class _AppShellState extends ConsumerState<AppShell>
       if (prev != null && prev != next) {
         setState(() => _exitingTab = prev);
         _ctrl.forward(from: 0);
+      }
+    });
+
+    // Show update dialog once on the day a new version is detected.
+    ref.listen(updateProvider, (prev, next) {
+      if (prev?.status != UpdateStatus.available &&
+          next.status == UpdateStatus.available &&
+          !next.dismissedToday) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _showUpdateDialog(context, next.info!, palette);
+        });
       }
     });
 
@@ -333,6 +443,7 @@ class _SidebarState extends ConsumerState<_Sidebar> {
     final encodeRunning = ref.watch(encodeProvider).isRunning;
     final decodeRunning = ref.watch(decodeProvider).isRunning;
     final isAdmin = ref.watch(ghAuthProvider).valueOrNull ?? false;
+    final updateStatus = ref.watch(updateProvider).status;
 
     final items = isAdmin ? [..._baseItems, _adminItem] : _baseItems;
 
@@ -355,6 +466,10 @@ class _SidebarState extends ConsumerState<_Sidebar> {
               isHovered: _hovered == item.$1,
               isRunning: (item.$1 == AppTab.encode && encodeRunning) ||
                   (item.$1 == AppTab.decode && decodeRunning),
+              hasBadge: item.$1 == AppTab.settings &&
+                  (updateStatus == UpdateStatus.available ||
+                   updateStatus == UpdateStatus.downloading ||
+                   updateStatus == UpdateStatus.readyToInstall),
               palette: item.$1.palette,
               onTap: () =>
                   ref.read(activeTabProvider.notifier).state = item.$1,
@@ -374,6 +489,7 @@ class _SidebarItem extends StatelessWidget {
   final bool isActive;
   final bool isHovered;
   final bool isRunning;
+  final bool hasBadge;
   final TabPalette palette;
   final VoidCallback onTap;
   final ValueChanged<bool> onHover;
@@ -388,6 +504,7 @@ class _SidebarItem extends StatelessWidget {
     required this.palette,
     required this.onTap,
     required this.onHover,
+    this.hasBadge = false,
   });
 
   @override
@@ -457,6 +574,16 @@ class _SidebarItem extends StatelessWidget {
                       )
                           .animate(onPlay: (c) => c.repeat(reverse: true))
                           .fade(begin: 0.3, end: 1.0, duration: 600.ms),
+                    ),
+                  if (hasBadge)
+                    Positioned(
+                      top: -1,
+                      right: -1,
+                      child: Icon(
+                        Icons.download_rounded,
+                        size: 15,
+                        color: palette.primary,
+                      ),
                     ),
                 ],
               ),

--- a/lib/features/shell/widgets/shared_widgets.dart
+++ b/lib/features/shell/widgets/shared_widgets.dart
@@ -110,6 +110,71 @@ class ErrorBanner extends StatelessWidget {
   }
 }
 
+class PasswordWarningBanner extends StatelessWidget {
+  final Color accentColor;
+  final String message;
+  final VoidCallback onGoToSettings;
+
+  const PasswordWarningBanner({
+    super.key,
+    required this.accentColor,
+    required this.message,
+    required this.onGoToSettings,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: accentColor.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: accentColor.withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: accentColor.withValues(alpha: 0.5),
+                  blurRadius: 10,
+                  spreadRadius: 1,
+                ),
+              ],
+            ),
+            child: Icon(Icons.lock_open_rounded, color: accentColor, size: 16),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(fontSize: 13, color: accentColor),
+            ),
+          ),
+          TextButton(
+            onPressed: onGoToSettings,
+            style: TextButton.styleFrom(
+              foregroundColor: accentColor,
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            ),
+            child: Text(
+              'Set password',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+                color: accentColor,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class OutDirRow extends StatelessWidget {
   final String dir;
   final Color accentColor;

--- a/lib/features/updater/update_model.dart
+++ b/lib/features/updater/update_model.dart
@@ -1,0 +1,50 @@
+enum UpdateStatus {
+  idle,
+  checking,
+  upToDate,
+  available,
+  downloading,
+  readyToInstall,
+  error,
+}
+
+class UpdateInfo {
+  final String version;
+  final String releaseNotes;
+  final String assetUrl;
+  final String assetName;
+  final String? installerPath;
+
+  const UpdateInfo({
+    required this.version,
+    required this.releaseNotes,
+    required this.assetUrl,
+    required this.assetName,
+    this.installerPath,
+  });
+
+  UpdateInfo withInstallerPath(String path) => UpdateInfo(
+        version: version,
+        releaseNotes: releaseNotes,
+        assetUrl: assetUrl,
+        assetName: assetName,
+        installerPath: path,
+      );
+}
+
+class UpdateState {
+  final UpdateStatus status;
+  final UpdateInfo? info;
+  final double downloadProgress;
+  final String? errorMessage;
+  // True when the user already dismissed the popup today — show badge only.
+  final bool dismissedToday;
+
+  const UpdateState({
+    this.status = UpdateStatus.idle,
+    this.info,
+    this.downloadProgress = 0.0,
+    this.errorMessage,
+    this.dismissedToday = false,
+  });
+}

--- a/lib/features/updater/update_notifier.dart
+++ b/lib/features/updater/update_notifier.dart
@@ -1,0 +1,97 @@
+import 'dart:async' show unawaited;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:window_manager/window_manager.dart';
+import 'update_model.dart';
+import 'update_service.dart';
+
+const _kDismissedDateKey = 'update_dismissed_date';
+
+final updateProvider =
+    NotifierProvider<UpdateNotifier, UpdateState>(UpdateNotifier.new);
+
+class UpdateNotifier extends Notifier<UpdateState> {
+  final _service = UpdateService();
+
+  @override
+  UpdateState build() => const UpdateState();
+
+  static String _today() => DateTime.now().toIso8601String().substring(0, 10);
+
+  Future<bool> _isDismissedToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    return (prefs.getString(_kDismissedDateKey) ?? '') == _today();
+  }
+
+  Future<void> dismissForToday() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kDismissedDateKey, _today());
+    state = UpdateState(
+      status: state.status,
+      info: state.info,
+      dismissedToday: true,
+    );
+  }
+
+  Future<void> checkForUpdate() async {
+    if (state.status == UpdateStatus.checking) return;
+    state = const UpdateState(status: UpdateStatus.checking);
+
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      final update = await _service.checkForUpdate(packageInfo.version);
+      if (update == null) {
+        state = const UpdateState(status: UpdateStatus.upToDate);
+      } else {
+        final dismissed = await _isDismissedToday();
+        state = UpdateState(
+          status: UpdateStatus.available,
+          info: update,
+          dismissedToday: dismissed,
+        );
+      }
+    } catch (e) {
+      state = UpdateState(
+        status: UpdateStatus.error,
+        errorMessage: e.toString().replaceFirst('Exception: ', ''),
+      );
+    }
+  }
+
+  Future<void> downloadUpdate() async {
+    final info = state.info;
+    if (info == null) return;
+    state = UpdateState(status: UpdateStatus.downloading, info: info);
+
+    try {
+      final path = await _service.downloadUpdate(info, (progress) {
+        state = UpdateState(
+          status: UpdateStatus.downloading,
+          info: info,
+          downloadProgress: progress,
+        );
+      });
+      state = UpdateState(
+        status: UpdateStatus.readyToInstall,
+        info: info.withInstallerPath(path),
+      );
+    } catch (e) {
+      state = UpdateState(
+        status: UpdateStatus.error,
+        info: info,
+        errorMessage: 'Download failed: ${e.toString().replaceFirst('Exception: ', '')}',
+      );
+    }
+  }
+
+  Future<void> launchInstaller() async {
+    final path = state.info?.installerPath;
+    if (path == null) return;
+    await _service.launchInstaller(path);
+    // Exit so the installer can overwrite the running executable.
+    unawaited(windowManager.close());
+  }
+
+  void dismiss() => state = const UpdateState();
+}

--- a/lib/features/updater/update_service.dart
+++ b/lib/features/updater/update_service.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'update_model.dart';
+
+class UpdateService {
+  static const _owner = 'SeshuTarapatla';
+  static const _repo = 'mStorage';
+
+  static bool isNewer(String latest, String current) {
+    final l = _parseVersion(latest);
+    final c = _parseVersion(current);
+    for (int i = 0; i < 3; i++) {
+      final lv = i < l.length ? l[i] : 0;
+      final cv = i < c.length ? c[i] : 0;
+      if (lv > cv) return true;
+      if (lv < cv) return false;
+    }
+    return false;
+  }
+
+  static List<int> _parseVersion(String v) {
+    return v.replaceFirst(RegExp(r'^v'), '').split('.').map((s) => int.tryParse(s) ?? 0).toList();
+  }
+
+  Future<UpdateInfo?> checkForUpdate(String currentVersion) async {
+    final response = await http.get(
+      Uri.parse('https://api.github.com/repos/$_owner/$_repo/releases/latest'),
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'mStorage-app',
+      },
+    );
+
+    if (response.statusCode == 404) return null; // no releases yet
+    if (response.statusCode != 200) {
+      throw Exception('GitHub API returned ${response.statusCode}');
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    final tagName = json['tag_name'] as String? ?? '';
+    final latestVersion = tagName.replaceFirst(RegExp(r'^v'), '');
+
+    if (!isNewer(latestVersion, currentVersion)) return null;
+
+    final assets = (json['assets'] as List? ?? []).cast<Map<String, dynamic>>();
+    final asset = assets.firstWhere(
+      (a) => (a['name'] as String? ?? '').endsWith('.exe'),
+      orElse: () => {},
+    );
+
+    final assetUrl = asset['browser_download_url'] as String? ?? '';
+    if (assetUrl.isEmpty) throw Exception('No .exe asset found in release');
+
+    return UpdateInfo(
+      version: latestVersion,
+      releaseNotes: json['body'] as String? ?? '',
+      assetUrl: assetUrl,
+      assetName: asset['name'] as String? ?? 'mStorage_Setup.exe',
+    );
+  }
+
+  Future<String> downloadUpdate(
+    UpdateInfo info,
+    void Function(double) onProgress,
+  ) async {
+    final tmpDir = await getTemporaryDirectory();
+    final updateDir = Directory(p.join(tmpDir.path, 'mstorage_update'));
+
+    // Remove any stale installers before downloading.
+    if (updateDir.existsSync()) {
+      for (final f in updateDir.listSync().whereType<File>()) {
+        try {
+          f.deleteSync();
+        } catch (_) {}
+      }
+    }
+    await updateDir.create(recursive: true);
+
+    final destPath = p.join(updateDir.path, info.assetName);
+    final client = http.Client();
+    try {
+      final request = http.Request('GET', Uri.parse(info.assetUrl));
+      final response = await client.send(request);
+      final total = response.contentLength ?? 0;
+      final sink = File(destPath).openWrite();
+      int received = 0;
+
+      try {
+        await for (final chunk in response.stream) {
+          sink.add(chunk);
+          received += chunk.length;
+          if (total > 0) onProgress(received / total);
+        }
+      } finally {
+        await sink.flush();
+        await sink.close();
+      }
+    } finally {
+      client.close();
+    }
+
+    return destPath;
+  }
+
+  Future<void> launchInstaller(String installerPath) async {
+    await Process.start(
+      installerPath,
+      [],
+      mode: ProcessStartMode.detached,
+      runInShell: false,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show unawaited;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:media_kit/media_kit.dart';
@@ -5,6 +6,7 @@ import 'package:window_manager/window_manager.dart';
 import 'core/services/settings_service.dart';
 import 'core/theme/app_theme.dart';
 import 'features/shell/app_shell.dart';
+import 'features/updater/update_notifier.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -30,6 +32,11 @@ void main() async {
   );
 
   runApp(UncontrolledProviderScope(container: container, child: const MStorageApp()));
+
+  // Background update check after first frame — single HTTP call, non-blocking.
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    unawaited(container.read(updateProvider.notifier).checkForUpdate());
+  });
 }
 
 class MStorageApp extends ConsumerWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.2.0+4
+version: 0.2.0+4
 
 environment:
   sdk: ^3.11.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 0.2.0+4
+version: 1.2.0+5
 
 environment:
   sdk: ^3.11.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.1.1+3
+version: 1.2.0+4
 
 environment:
   sdk: ^3.11.5
@@ -54,6 +54,10 @@ dependencies:
   # Native key injection (Google Photos in-WebView download workaround)
   win32: ^5.15.0
   ffi: ^2.2.0
+
+  # In-app updater
+  package_info_plus: ^8.1.0
+  flutter_markdown: ^0.7.4
 
   # Icons
   cupertino_icons: ^1.0.8

--- a/scripts/reset_update_dismiss.ps1
+++ b/scripts/reset_update_dismiss.ps1
@@ -1,0 +1,18 @@
+# Clears the update dismissal date so the update popup shows again on next launch.
+# Usage: .\scripts\reset_update_dismiss.ps1
+
+$prefsPath = "$env:APPDATA\com.seshu\m_storage\shared_preferences.json"
+
+if (-not (Test-Path $prefsPath)) {
+    Write-Host "shared_preferences.json not found — app hasn't been run yet." -ForegroundColor Yellow
+    exit 0
+}
+
+$json = Get-Content $prefsPath -Raw | ConvertFrom-Json
+if ($json.PSObject.Properties.Name -contains "flutter.update_dismissed_date") {
+    $json.PSObject.Properties.Remove("flutter.update_dismissed_date")
+    $json | ConvertTo-Json -Compress | Set-Content $prefsPath
+    Write-Host "Done — update dismissal cleared. Run the app to see the popup again." -ForegroundColor Green
+} else {
+    Write-Host "Nothing to clear — dismissal date was not set." -ForegroundColor Cyan
+}


### PR DESCRIPTION
## What's New in v1.2.0

### Features
- **In-app updater** — automatically checks for updates and notifies with one-click download and install
- **Password warning** — Encode and Decode pages show a contextual warning when no password is set, with a direct link to Settings
- **Download hint banner** — Catalog shows a hint banner when browsing downloadable entries

### Fixes
- **Password encryption** — AES-256 encrypted ZIP encoding now works correctly
- **Output directory display** — Encode and Decode pages now show the correct output path
- **State reset** — Encode/Decode state properly resets when a new video is dropped after job completion
- **Player auto-load** — Play buttons in Decode and Catalog now correctly open and play the video in the Player tab
- **Download history deduplication** — Re-downloading the same file no longer creates duplicate entries

## Test plan
- [ ] Encode with and without password
- [ ] Decode encoded file
- [ ] Play button from Decode and Catalog loads video in Player
- [ ] Password warning banner appears and navigates to Settings
- [ ] Download same file twice — only one entry in history
- [ ] Updater detects new release and shows dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)