### PR TITLE
feat: v1.2.1

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+RELEASE NOTE RULES — follow these exactly for every release:
+
+1. Always open with "## What's New" (this heading is auto-stripped in-app; keep all content under sub-sections)
+2. Use only these section headers, and only include sections that have entries:
+     ### Features      — new user-facing capabilities
+     ### Fixes         — bug fixes
+     ### Improvements  — enhancements to existing behaviour
+3. Each bullet format:  - **Label** — Description
+     - Label: the feature/fix name or affected area (title case)
+     - Em dash (—) separator, not a hyphen
+     - Description: sentence case, no trailing period, one line, focus on user impact
+4. No installation instructions — GitHub's assets section covers downloads
+5. No version number in the body — GitHub shows the tag
+-->
+
+## What's New
+
+### Features
+- **Name** — Description of what it does and why it matters
+
+### Fixes
+- **Area** — What was wrong and how it was resolved
+
+### Improvements
+- **Area** — What was enhanced

--- a/installer.iss
+++ b/installer.iss
@@ -7,7 +7,7 @@
 ; Output: installer\mStorage_Setup.exe
 
 #define AppName        "mStorage"
-#define AppVersion     "1.2.0"
+#define AppVersion     "1.2.1"
 #define AppPublisher   "Seshu Tarapatla"
 #define AppURL         "https://github.com/SeshuTarapatla/mStorage"
 #define AppExeName     "m_storage.exe"

--- a/lib/core/models/settings_model.dart
+++ b/lib/core/models/settings_model.dart
@@ -10,6 +10,7 @@ class AppSettings {
   final String syncplayRoom;
   final int startupTab;
   final String lastVideoPath;
+  final List<int>? tabOrder;
 
   const AppSettings({
     this.password = '',
@@ -23,6 +24,7 @@ class AppSettings {
     this.syncplayRoom = '',
     this.startupTab = 0,
     this.lastVideoPath = '',
+    this.tabOrder,
   });
 
   AppSettings copyWith({
@@ -37,6 +39,7 @@ class AppSettings {
     String? syncplayRoom,
     int? startupTab,
     String? lastVideoPath,
+    List<int>? tabOrder,
   }) {
     return AppSettings(
       password: password ?? this.password,
@@ -53,6 +56,7 @@ class AppSettings {
       syncplayRoom: syncplayRoom ?? this.syncplayRoom,
       startupTab: startupTab ?? this.startupTab,
       lastVideoPath: lastVideoPath ?? this.lastVideoPath,
+      tabOrder: tabOrder ?? this.tabOrder,
     );
   }
 }

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -26,6 +26,7 @@ const _kSyncplayUsername = 'syncplay_username';
 const _kSyncplayRoom = 'syncplay_room';
 const _kStartupTab = 'startup_tab';
 const _kLastVideoPath = 'last_video_path';
+const _kTabOrder = 'tab_order';
 
 class SettingsNotifier extends Notifier<AppSettings> {
   late SharedPreferences _prefs;
@@ -47,6 +48,10 @@ class SettingsNotifier extends Notifier<AppSettings> {
       syncplayRoom: _prefs.getString(_kSyncplayRoom) ?? '',
       startupTab: _prefs.getInt(_kStartupTab) ?? 0,
       lastVideoPath: _prefs.getString(_kLastVideoPath) ?? '',
+      tabOrder: _prefs.getString(_kTabOrder)
+          ?.split(',')
+          .map(int.parse)
+          .toList(),
     );
   }
 
@@ -103,6 +108,29 @@ class SettingsNotifier extends Notifier<AppSettings> {
   Future<void> setStartupTab(int value) async {
     state = state.copyWith(startupTab: value);
     await _prefs.setInt(_kStartupTab, value);
+  }
+
+  Future<void> setTabOrder(List<int> value) async {
+    state = state.copyWith(tabOrder: value);
+    await _prefs.setString(_kTabOrder, value.join(','));
+  }
+
+  Future<void> resetTabOrder() async {
+    await _prefs.remove(_kTabOrder);
+    state = AppSettings(
+      password: state.password,
+      encodeOutputDirectory: state.encodeOutputDirectory,
+      decodeOutputDirectory: state.decodeOutputDirectory,
+      catalogDownloadDirectory: state.catalogDownloadDirectory,
+      preserveAspectRatio: state.preserveAspectRatio,
+      maskDurationSeconds: state.maskDurationSeconds,
+      syncplayPort: state.syncplayPort,
+      syncplayUsername: state.syncplayUsername,
+      syncplayRoom: state.syncplayRoom,
+      startupTab: state.startupTab,
+      lastVideoPath: state.lastVideoPath,
+      tabOrder: null,
+    );
   }
 
   Future<void> resetAll() async {

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -40,9 +40,10 @@ class _AdminScreenState extends State<AdminScreen> {
   final _genreFocusNode = FocusNode();
 
   // ── Extra sheet fields (not from IMDB) ───────────────────────────────────
-  final _videoUrlCtrl = TextEditingController();
-  final _languageCtrl = TextEditingController();
-  final _sizeMbCtrl   = TextEditingController();
+  final _videoUrlCtrl    = TextEditingController();
+  final _languageCtrl    = TextEditingController();
+  final _languageFocusNode = FocusNode();
+  final _sizeMbCtrl      = TextEditingController();
   bool _encoded = true;
   bool _show    = true;
 
@@ -84,6 +85,7 @@ class _AdminScreenState extends State<AdminScreen> {
     _genreFocusNode.dispose();
     _videoUrlCtrl.dispose();
     _languageCtrl.dispose();
+    _languageFocusNode.dispose();
     _sizeMbCtrl.dispose();
     _pasteErrorTimer?.cancel();
     _flashTimer?.cancel();
@@ -1139,10 +1141,7 @@ class _AdminScreenState extends State<AdminScreen> {
                 hint: 'video_url  (Google Photos album link)'),
           ),
           const SizedBox(width: 8),
-          Expanded(
-            child: _extrasField(
-                controller: _languageCtrl, hint: 'language'),
-          ),
+          Expanded(child: _languageAutocomplete()),
           const SizedBox(width: 8),
           SizedBox(
             width: 90,
@@ -1169,6 +1168,72 @@ class _AdminScreenState extends State<AdminScreen> {
       ],
     );
   }
+
+  static const _languageOptions = ['English', 'Hindi', 'Telugu'];
+
+  Widget _languageAutocomplete() => RawAutocomplete<String>(
+        textEditingController: _languageCtrl,
+        focusNode: _languageFocusNode,
+        optionsBuilder: (TextEditingValue v) {
+          if (v.text.isEmpty) return _languageOptions;
+          return _languageOptions.where(
+              (o) => o.toLowerCase().contains(v.text.toLowerCase()));
+        },
+        optionsViewBuilder: (context, onSelected, options) => Align(
+          alignment: Alignment.topLeft,
+          child: Material(
+            color: kSurfaceColor,
+            elevation: 4,
+            borderRadius: BorderRadius.circular(8),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 120),
+              child: ListView.builder(
+                padding: EdgeInsets.zero,
+                shrinkWrap: true,
+                itemCount: options.length,
+                itemBuilder: (context, index) {
+                  final option = options.elementAt(index);
+                  return InkWell(
+                    onTap: () => onSelected(option),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 8),
+                      child: Text(option,
+                          style:
+                              TextStyle(fontSize: 12, color: kTextPrimary)),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+        fieldViewBuilder: (context, controller, focusNode, onSubmitted) =>
+            TextField(
+          controller: controller,
+          focusNode: focusNode,
+          onSubmitted: (_) => onSubmitted(),
+          style: TextStyle(fontSize: 12, color: kTextPrimary),
+          decoration: InputDecoration(
+            hintText: 'language',
+            hintStyle: TextStyle(fontSize: 12, color: kTextMuted),
+            filled: true,
+            fillColor: kSurfaceColor,
+            isDense: true,
+            border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide(color: kBorderColor)),
+            enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide(color: kBorderColor)),
+            focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide(color: _adminPalette.primary)),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+          ),
+        ),
+      );
 
   Widget _extrasField({
     required TextEditingController controller,

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import '../../core/services/catalog_cache_manager.dart';
+import '../../core/models/settings_model.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
@@ -296,6 +297,129 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     });
   }
 
+  static (IconData, String) _tabInfo(AppTab tab) => switch (tab) {
+        AppTab.encode   => (Icons.upload_rounded,        'Encode'),
+        AppTab.decode   => (Icons.download_rounded,      'Decode'),
+        AppTab.player   => (Icons.play_circle_rounded,   'Player'),
+        AppTab.catalog  => (Icons.photo_library_rounded, 'Catalog'),
+        AppTab.settings => (Icons.settings_rounded,      'Settings'),
+        AppTab.admin    => (Icons.admin_panel_settings_rounded, 'Admin'),
+      };
+
+  static List<int> _effectiveOrder(AppSettings settings) {
+    if (settings.tabOrder != null) return settings.tabOrder!;
+    const base = [
+      AppTab.encode,
+      AppTab.decode,
+      AppTab.player,
+      AppTab.catalog,
+      AppTab.settings,
+    ];
+    final startupIdx =
+        settings.startupTab.clamp(0, AppTab.settings.index);
+    return [
+      startupIdx,
+      ...base.map((t) => t.index).where((i) => i != startupIdx),
+    ];
+  }
+
+  Widget _buildLayoutSection(AppSettings settings, Color accent) {
+    final order = _effectiveOrder(settings);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.reorder_rounded, color: accent, size: 20),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Page Order',
+                        style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w500,
+                            color: kTextPrimary)),
+                    const SizedBox(height: 2),
+                    const Text('Drag to reorder sidebar pages.',
+                        style: TextStyle(fontSize: 12, color: kTextSecondary)),
+                  ],
+                ),
+              ),
+              if (settings.tabOrder != null)
+                _ActionButton(
+                  label: 'Reset',
+                  accent: accent,
+                  onTap: () async {
+                    final n = ref.read(settingsProvider.notifier);
+                    await n.resetTabOrder();
+                    await n.setStartupTab(0);
+                  },
+                ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Container(
+            decoration: BoxDecoration(
+              color: kSurface2Color,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: kBorderColor),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: SizedBox(
+              height: 44.0 * order.length,
+              child: ReorderableListView.builder(
+                buildDefaultDragHandles: false,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: order.length,
+                onReorder: (oldIndex, newIndex) {
+                  if (newIndex > oldIndex) newIndex--;
+                  final newOrder = [...order];
+                  newOrder.insert(newIndex, newOrder.removeAt(oldIndex));
+                  ref.read(settingsProvider.notifier).setTabOrder(newOrder);
+                },
+                itemBuilder: (context, index) {
+                  final tab = AppTab.values[order[index]];
+                  final (icon, label) = _tabInfo(tab);
+                  return Container(
+                    key: ValueKey(order[index]),
+                    height: 44,
+                    decoration: index < order.length - 1
+                        ? const BoxDecoration(
+                            border: Border(
+                                bottom: BorderSide(color: kBorderColor)))
+                        : null,
+                    child: Row(
+                      children: [
+                        ReorderableDragStartListener(
+                          index: index,
+                          child: const Padding(
+                            padding: EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 12),
+                            child: Icon(Icons.drag_handle_rounded,
+                                color: kTextMuted, size: 18),
+                          ),
+                        ),
+                        Icon(icon, color: accent, size: 16),
+                        const SizedBox(width: 10),
+                        Text(label,
+                            style: const TextStyle(
+                                fontSize: 13, color: kTextPrimary)),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Future<void> _confirmReset() async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -400,6 +524,15 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               ),
             ],
           ).animate().fadeIn(duration: 300.ms, delay: 40.ms),
+
+          const SizedBox(height: 20),
+
+          // ── Layout ───────────────────────────────────────────────────────
+          _SettingsGroup(
+            label: 'Layout',
+            accent: accent,
+            children: [_buildLayoutSection(settings, accent)],
+          ).animate().fadeIn(duration: 300.ms, delay: 60.ms),
 
           const SizedBox(height: 20),
 

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -116,11 +116,7 @@ class _AppShellState extends ConsumerState<AppShell>
                     ConstrainedBox(
                       constraints: const BoxConstraints(maxHeight: 200),
                       child: Markdown(
-                        data: info.releaseNotes
-                            .split('\n')
-                            .skipWhile((l) => l.trimLeft().startsWith('#'))
-                            .join('\n')
-                            .trimLeft(),
+                        data: info.releaseNotes,
                         shrinkWrap: true,
                         padding: const EdgeInsets.only(top: 4),
                         styleSheet: _mdStyle(palette),

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -449,12 +449,21 @@ class _SidebarState extends ConsumerState<_Sidebar> {
     final isAdmin = ref.watch(ghAuthProvider).valueOrNull ?? false;
     final updateStatus = ref.watch(updateProvider).status;
 
-    final startupTab = AppTab.values[
-        ref.watch(settingsProvider).startupTab.clamp(0, AppTab.settings.index)];
-    final base = [
-      ..._baseItems.where((i) => i.$1 == startupTab),
-      ..._baseItems.where((i) => i.$1 != startupTab),
-    ];
+    final settings = ref.watch(settingsProvider);
+    final List<(AppTab, IconData, String)> base;
+    if (settings.tabOrder != null) {
+      base = settings.tabOrder!
+          .where((i) => i <= AppTab.settings.index)
+          .map((i) => _baseItems.firstWhere((item) => item.$1.index == i))
+          .toList();
+    } else {
+      final startupTab =
+          AppTab.values[settings.startupTab.clamp(0, AppTab.settings.index)];
+      base = [
+        ..._baseItems.where((i) => i.$1 == startupTab),
+        ..._baseItems.where((i) => i.$1 != startupTab),
+      ];
+    }
     final items = isAdmin ? [...base, _adminItem] : base;
 
     return AnimatedContainer(

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -449,7 +449,13 @@ class _SidebarState extends ConsumerState<_Sidebar> {
     final isAdmin = ref.watch(ghAuthProvider).valueOrNull ?? false;
     final updateStatus = ref.watch(updateProvider).status;
 
-    final items = isAdmin ? [..._baseItems, _adminItem] : _baseItems;
+    final startupTab = AppTab.values[
+        ref.watch(settingsProvider).startupTab.clamp(0, AppTab.settings.index)];
+    final base = [
+      ..._baseItems.where((i) => i.$1 == startupTab),
+      ..._baseItems.where((i) => i.$1 != startupTab),
+    ];
+    final items = isAdmin ? [...base, _adminItem] : base;
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 300),

--- a/lib/features/updater/update_service.dart
+++ b/lib/features/updater/update_service.dart
@@ -25,9 +25,16 @@ class UpdateService {
     return v.replaceFirst(RegExp(r'^v'), '').split('.').map((s) => int.tryParse(s) ?? 0).toList();
   }
 
+  static String _stripLeadingHeadings(String body) => body
+      .split('\n')
+      .skipWhile((l) => l.trimLeft().startsWith('#'))
+      .join('\n')
+      .trimLeft();
+
   Future<UpdateInfo?> checkForUpdate(String currentVersion) async {
     final response = await http.get(
-      Uri.parse('https://api.github.com/repos/$_owner/$_repo/releases/latest'),
+      Uri.parse(
+          'https://api.github.com/repos/$_owner/$_repo/releases?per_page=100'),
       headers: {
         'Accept': 'application/vnd.github+json',
         'User-Agent': 'mStorage-app',
@@ -39,22 +46,57 @@ class UpdateService {
       throw Exception('GitHub API returned ${response.statusCode}');
     }
 
-    final json = jsonDecode(response.body) as Map<String, dynamic>;
-    final tagName = json['tag_name'] as String? ?? '';
-    final latestVersion = tagName.replaceFirst(RegExp(r'^v'), '');
+    final releases =
+        (jsonDecode(response.body) as List).cast<Map<String, dynamic>>();
+    if (releases.isEmpty) return null;
 
-    final assets = (json['assets'] as List? ?? []).cast<Map<String, dynamic>>();
+    // GitHub returns releases sorted newest-first.
+    final latest = releases.first;
+    final latestVersion =
+        (latest['tag_name'] as String? ?? '').replaceFirst(RegExp(r'^v'), '');
+
+    final assets =
+        (latest['assets'] as List? ?? []).cast<Map<String, dynamic>>();
     final asset = assets.firstWhere(
       (a) => (a['name'] as String? ?? '').endsWith('.exe'),
       orElse: () => {},
     );
     final assetUrl = asset['browser_download_url'] as String? ?? '';
 
-    // Always return info so the caller has release notes even when up to date.
-    // assetUrl may be empty when not an update — notifier validates before download.
+    if (!isNewer(latestVersion, currentVersion)) {
+      // Up to date — return latest release notes only (no version header needed).
+      return UpdateInfo(
+        version: latestVersion,
+        releaseNotes: _stripLeadingHeadings(latest['body'] as String? ?? ''),
+        assetUrl: assetUrl,
+        assetName: asset['name'] as String? ?? 'mStorage_Setup.exe',
+      );
+    }
+
+    // Collect every release newer than the installed version, newest-first.
+    final newer = releases.where((r) {
+      final v =
+          (r['tag_name'] as String? ?? '').replaceFirst(RegExp(r'^v'), '');
+      return isNewer(v, currentVersion);
+    }).toList();
+
+    // Build consolidated changelog: single version → plain body,
+    // multiple versions → stacked sections with version headers.
+    final String notes;
+    if (newer.length == 1) {
+      notes = _stripLeadingHeadings(newer.first['body'] as String? ?? '');
+    } else {
+      notes = newer.map((r) {
+        final v =
+            (r['tag_name'] as String? ?? '').replaceFirst(RegExp(r'^v'), '');
+        final body = _stripLeadingHeadings(r['body'] as String? ?? '');
+        return '### v$v\n$body';
+      }).join('\n\n');
+    }
+
     return UpdateInfo(
       version: latestVersion,
-      releaseNotes: json['body'] as String? ?? '',
+      releaseNotes: notes,
       assetUrl: assetUrl,
       assetName: asset['name'] as String? ?? 'mStorage_Setup.exe',
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.2.0+5
+version: 1.2.1+6
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
## Summary
- Language autocomplete (English/Hindi/Telugu hints) in Admin panel
- Startup page floats to top of sidebar automatically
- Drag-to-reorder sidebar pages in Settings with reset support
- Consolidated multi-version changelogs in update dialogs
- Release note standard added in `.github/RELEASE_TEMPLATE.md`; all existing releases updated

## Test plan
- [ ] Language field in Admin shows hints on focus, filters on type, accepts free text
- [ ] Changing startup page in Settings moves that page to top of sidebar
- [ ] Dragging pages in Settings reorders the sidebar live; Reset reverts to startup-first and sets startup to Encode
- [ ] Page Order list in Settings mirrors actual sidebar order at all times
- [ ] Update dialog shows stacked changelogs when multiple versions behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)