### PR TITLE
feat: v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,30 @@ The resulting file is a valid MP4: it plays as a short clip in any media player,
 - Stop Syncplay kills the entire process tree (including the VLC child process)
 - Collapsible Syncplay console log
 
+### Catalog
+- Paste a Google Sheets URL to load a browsable video catalog
+- Masonry grid of cards with poster thumbnails, IMDB ratings, genres, and release dates
+- Expand any card for a full detail view with a slideshow, plot, and tags
+- Sort by title, date, or rating; filter by language, genre, year, or downloaded status
+- Open any entry in an embedded WebView and download directly from the page
+- Re-download protection — prompts before overwriting an existing file
+- Downloaded indicator (green tick badge) on cards already in your download history
+- Download history panel with file size, open-in-Explorer, play, and decode shortcuts
+- Queue-based downloader with progress bar and speed readout
+
 ### Settings
 - Archive encryption password
 - Custom encode/decode output directories
 - Aspect ratio preservation toggle and mask duration
-- Startup page picker
+- Startup page picker with drag-to-reorder sidebar pages
 - Syncplay username, room, port
 - Danger Zone — reset all settings to defaults
 
 ### Shell
-- `Ctrl+1`–`4` keyboard shortcuts to switch tabs (Encode / Decode / Player / Settings)
 - Animated pulsing dot on sidebar while encode or decode is running
 - Per-tab accent colours with smooth transitions
 - Custom frameless title bar with drag region
+- Update notifier — prompts on every launch when a newer release is available
 
 ---
 

--- a/lib/features/catalog/catalog_screen.dart
+++ b/lib/features/catalog/catalog_screen.dart
@@ -41,6 +41,7 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
   Set<String> _filterLanguages = {};
   Set<String> _filterGenres = {};
   Set<int> _filterYears = {};
+  bool _filterDownloaded = false;
 
   // Expanded card overlay state
   CatalogEntry? _expandedEntry;
@@ -145,7 +146,9 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
     final sheetUrl = ref.watch(sheetUrlProvider);
     final catalogState = ref.watch(catalogProvider);
     final downloadState = ref.watch(downloadProvider);
-    final historyCount = ref.watch(downloadHistoryProvider).length;
+    final downloadHistory = ref.watch(downloadHistoryProvider);
+    final historyCount = downloadHistory.length;
+    final downloadedTitles = downloadHistory.map((r) => r.title).toSet();
 
     if (sheetUrl != null && catalogState is CatalogIdle) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -227,6 +230,7 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
                 filterLanguages: _filterLanguages,
                 filterGenres: _filterGenres,
                 filterYears: _filterYears,
+                filterDownloaded: _filterDownloaded,
                 palette: palette,
                 onSortChanged: (mode, asc) {
                   setState(() { _sortMode = mode; _sortAsc = asc; });
@@ -238,10 +242,13 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
                     setState(() => _filterGenres = v),
                 onYearsChanged: (v) =>
                     setState(() => _filterYears = v),
+                onToggleDownloaded: () =>
+                    setState(() => _filterDownloaded = !_filterDownloaded),
                 onClearFilters: () => setState(() {
                   _filterLanguages = {};
                   _filterGenres = {};
                   _filterYears = {};
+                  _filterDownloaded = false;
                 }),
               ),
               const SizedBox(height: 12),
@@ -279,6 +286,8 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
                               filterLanguages: _filterLanguages,
                               filterGenres: _filterGenres,
                               filterYears: _filterYears,
+                              filterDownloaded: _filterDownloaded,
+                              downloadedTitles: downloadedTitles,
                               palette: palette,
                               onOpenInBrowser: _openWebView,
                               onCardExpand: _onCardExpand,
@@ -345,6 +354,7 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
             animation: _expandAnim,
             palette: palette,
             cardKey: _expandedCardKey,
+            isDownloaded: downloadedTitles.contains(_expandedEntry!.title),
             onClose: _closeExpanded,
             onOpenInBrowser: () {
               _closeExpanded();
@@ -364,12 +374,51 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
         url: entry.videoUrl,
         title: entry.title,
         onDownloadRequested: (url, filename) {
-          ref.read(downloadProvider.notifier).enqueue(
-                url,
-                filename ?? '',
-                entry.title,
-                entry.thumbnailUrl,
+          final fname = filename ?? '';
+          final history = ref.read(downloadHistoryProvider);
+          final existing = history
+              .where((r) => r.filename == fname && File(r.filePath).existsSync())
+              .firstOrNull;
+          if (existing != null) {
+            // Defer the dialog to the next frame — onDownloadRequested fires
+            // synchronously inside _triggerDownload, which has already called
+            // Navigator.pop() to close the WebView. Pushing a new route in the
+            // same stack frame corrupts the Navigator before the pop completes.
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted) return;
+              showDialog(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  backgroundColor: kSurfaceColor,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  title: const Text('Already Downloaded',
+                      style: TextStyle(color: kTextPrimary, fontSize: 15, fontWeight: FontWeight.w600)),
+                  content: const Text(
+                    'This video is already in your downloads. Downloading again will overwrite the existing file.',
+                    style: TextStyle(color: kTextSecondary, fontSize: 13),
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx),
+                      child: const Text('Cancel', style: TextStyle(color: kTextMuted)),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        Navigator.pop(ctx);
+                        ref.read(downloadProvider.notifier).enqueue(
+                              url, fname, entry.title, entry.thumbnailUrl);
+                      },
+                      child: Text('Download Anyway',
+                          style: TextStyle(color: AppTab.catalog.palette.primary, fontWeight: FontWeight.w600)),
+                    ),
+                  ],
+                ),
               );
+            });
+          } else {
+            ref.read(downloadProvider.notifier).enqueue(
+                  url, fname, entry.title, entry.thumbnailUrl);
+          }
         },
       ),
     );
@@ -653,6 +702,8 @@ class _Body extends StatelessWidget {
   final Set<String> filterLanguages;
   final Set<String> filterGenres;
   final Set<int> filterYears;
+  final bool filterDownloaded;
+  final Set<String> downloadedTitles;
   final TabPalette palette;
   final ValueChanged<CatalogEntry> onOpenInBrowser;
   final void Function(CatalogEntry, Rect) onCardExpand;
@@ -665,6 +716,8 @@ class _Body extends StatelessWidget {
     required this.filterLanguages,
     required this.filterGenres,
     required this.filterYears,
+    this.filterDownloaded = false,
+    this.downloadedTitles = const {},
     required this.palette,
     required this.onOpenInBrowser,
     required this.onCardExpand,
@@ -679,6 +732,7 @@ class _Body extends StatelessWidget {
       CatalogLoaded(:final entries)  => _Grid(
           entries: _filterAndSort(entries),
           allEntries: entries,
+          downloadedTitles: downloadedTitles,
           palette: palette,
           onOpenInBrowser: onOpenInBrowser,
           onCardExpand: onCardExpand,
@@ -698,6 +752,7 @@ class _Body extends StatelessWidget {
       if (filterLanguages.isNotEmpty && !filterLanguages.contains(e.language)) return false;
       if (filterGenres.isNotEmpty && !e.genres.any(filterGenres.contains)) return false;
       if (filterYears.isNotEmpty && !filterYears.contains(e.date?.year)) return false;
+      if (filterDownloaded && !downloadedTitles.contains(e.title)) return false;
       return true;
     }).toList();
 
@@ -716,6 +771,7 @@ class _Body extends StatelessWidget {
 class _Grid extends StatefulWidget {
   final List<CatalogEntry> entries;
   final List<CatalogEntry> allEntries;
+  final Set<String> downloadedTitles;
   final TabPalette palette;
   final ValueChanged<CatalogEntry> onOpenInBrowser;
   final void Function(CatalogEntry, Rect) onCardExpand;
@@ -723,6 +779,7 @@ class _Grid extends StatefulWidget {
   const _Grid({
     required this.entries,
     required this.allEntries,
+    this.downloadedTitles = const {},
     required this.palette,
     required this.onOpenInBrowser,
     required this.onCardExpand,
@@ -814,6 +871,7 @@ class _GridState extends State<_Grid> {
           key: ValueKey(entry.imdbId.isNotEmpty ? entry.imdbId : entry.title),
           entry: entry,
           aspectRatio: _aspectRatio,
+          isDownloaded: widget.downloadedTitles.contains(entry.title),
           onOpenInBrowser: () => widget.onOpenInBrowser(entry),
           onExpand: (rect) => widget.onCardExpand(entry, rect),
         )
@@ -836,6 +894,7 @@ class _CardDetail extends StatelessWidget {
   final AnimationController animation;
   final TabPalette palette;
   final GlobalKey<CatalogCardExpandedState> cardKey;
+  final bool isDownloaded;
   final VoidCallback onClose;
   final VoidCallback onOpenInBrowser;
 
@@ -846,6 +905,7 @@ class _CardDetail extends StatelessWidget {
     required this.animation,
     required this.palette,
     required this.cardKey,
+    this.isDownloaded = false,
     required this.onClose,
     required this.onOpenInBrowser,
   });
@@ -884,6 +944,7 @@ class _CardDetail extends StatelessWidget {
               key: cardKey,
               entry: entry,
               palette: palette,
+              isDownloaded: isDownloaded,
               onClose: onClose,
               onOpenInBrowser: onOpenInBrowser,
               maxHeight: expandedMaxH,
@@ -1474,11 +1535,13 @@ class _SortFilterBar extends StatelessWidget {
   final Set<String> filterLanguages;
   final Set<String> filterGenres;
   final Set<int> filterYears;
+  final bool filterDownloaded;
   final TabPalette palette;
   final void Function(_SortMode, bool) onSortChanged;
   final void Function(Set<String>) onLanguagesChanged;
   final void Function(Set<String>) onGenresChanged;
   final void Function(Set<int>) onYearsChanged;
+  final VoidCallback onToggleDownloaded;
   final VoidCallback onClearFilters;
 
   const _SortFilterBar({
@@ -1488,11 +1551,13 @@ class _SortFilterBar extends StatelessWidget {
     required this.filterLanguages,
     required this.filterGenres,
     required this.filterYears,
+    this.filterDownloaded = false,
     required this.palette,
     required this.onSortChanged,
     required this.onLanguagesChanged,
     required this.onGenresChanged,
     required this.onYearsChanged,
+    required this.onToggleDownloaded,
     required this.onClearFilters,
   });
 
@@ -1507,7 +1572,7 @@ class _SortFilterBar extends StatelessWidget {
         ..sort((a, b) => b.compareTo(a));
 
     final hasFilters = filterLanguages.isNotEmpty ||
-        filterGenres.isNotEmpty || filterYears.isNotEmpty;
+        filterGenres.isNotEmpty || filterYears.isNotEmpty || filterDownloaded;
 
     return Row(
       children: [
@@ -1543,7 +1608,7 @@ class _SortFilterBar extends StatelessWidget {
           ),
           const SizedBox(width: 6),
         ],
-        if (years.isNotEmpty)
+        if (years.isNotEmpty) ...[
           _FilterBtn(
             label: 'Year',
             options: years.map((y) => '$y').toList(),
@@ -1551,6 +1616,14 @@ class _SortFilterBar extends StatelessWidget {
             palette: palette,
             onChanged: (s) => onYearsChanged(s.map(int.parse).toSet()),
           ),
+          const SizedBox(width: 6),
+        ],
+        _ToggleFilterBtn(
+          label: 'Downloaded',
+          active: filterDownloaded,
+          palette: palette,
+          onTap: onToggleDownloaded,
+        ),
       ],
     );
   }
@@ -1602,6 +1675,51 @@ class _SortBtn extends StatelessWidget {
                 size: 11, color: color,
               ),
             ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+class _ToggleFilterBtn extends StatelessWidget {
+  final String label;
+  final bool active;
+  final TabPalette palette;
+  final VoidCallback onTap;
+
+  const _ToggleFilterBtn({
+    required this.label,
+    required this.active,
+    required this.palette,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = active ? palette.primary : kTextSecondary;
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 120),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: active ? palette.primary.withValues(alpha: 0.1) : kSurfaceColor,
+          borderRadius: BorderRadius.circular(7),
+          border: Border.all(
+            color: active ? palette.primary.withValues(alpha: 0.45) : kBorderColor,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (active) ...[
+              Icon(Icons.download_done_rounded, size: 11, color: color),
+              const SizedBox(width: 4),
+            ],
+            Text(label, style: TextStyle(fontSize: 12, color: color)),
           ],
         ),
       ),

--- a/lib/features/catalog/widgets/catalog_card.dart
+++ b/lib/features/catalog/widgets/catalog_card.dart
@@ -13,6 +13,7 @@ import '../models/catalog_entry.dart';
 class CatalogCard extends StatefulWidget {
   final CatalogEntry entry;
   final double aspectRatio;
+  final bool isDownloaded;
   final VoidCallback onOpenInBrowser;
   final void Function(Rect globalRect) onExpand;
 
@@ -20,6 +21,7 @@ class CatalogCard extends StatefulWidget {
     super.key,
     required this.entry,
     required this.aspectRatio,
+    this.isDownloaded = false,
     required this.onOpenInBrowser,
     required this.onExpand,
   });
@@ -62,10 +64,24 @@ class _CatalogCardState extends State<CatalogCard> {
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
-              _Thumbnail(
-                url: widget.entry.thumbnailUrl,
-                aspectRatio: widget.aspectRatio,
-                rating: widget.entry.imdbRating,
+              Stack(
+                children: [
+                  _Thumbnail(
+                    url: widget.entry.thumbnailUrl,
+                    aspectRatio: widget.aspectRatio,
+                    rating: widget.entry.imdbRating,
+                  ),
+                  if (widget.isDownloaded)
+                    Positioned(
+                      top: 6,
+                      right: 6,
+                      child: Icon(
+                        Icons.download_done_rounded,
+                        size: 16,
+                        color: palette.primary,
+                      ),
+                    ),
+                ],
               ),
               Padding(
                 padding: const EdgeInsets.all(10),
@@ -127,6 +143,7 @@ class _CatalogCardState extends State<CatalogCard> {
 class CatalogCardExpanded extends StatefulWidget {
   final CatalogEntry entry;
   final TabPalette palette;
+  final bool isDownloaded;
   final VoidCallback onClose;
   final VoidCallback onOpenInBrowser;
   final double maxHeight;
@@ -135,6 +152,7 @@ class CatalogCardExpanded extends StatefulWidget {
     super.key,
     required this.entry,
     required this.palette,
+    this.isDownloaded = false,
     required this.onClose,
     required this.onOpenInBrowser,
     this.maxHeight = 640,
@@ -420,6 +438,18 @@ class CatalogCardExpandedState extends State<CatalogCardExpanded> {
                     ),
                   ),
                   const SizedBox(height: 16),
+                  if (widget.isDownloaded) ...[
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: const [
+                        Icon(Icons.download_done_rounded, size: 13, color: Color(0xFF69F0AE)),
+                        SizedBox(width: 5),
+                        Text('Already downloaded',
+                            style: TextStyle(fontSize: 11, color: Color(0xFF69F0AE))),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                  ],
                   // Button — always visible at the bottom
                   SizedBox(
                     width: double.infinity,

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -130,7 +130,7 @@ class _AppShellState extends ConsumerState<AppShell>
           TextButton(
             onPressed: () {
               Navigator.pop(ctx);
-              ref.read(updateProvider.notifier).dismissForToday();
+              ref.read(updateProvider.notifier).dismiss();
             },
             child: const Text('Later', style: TextStyle(color: kTextMuted)),
           ),
@@ -192,11 +192,10 @@ class _AppShellState extends ConsumerState<AppShell>
       }
     });
 
-    // Show update dialog once on the day a new version is detected.
+    // Show update dialog every time a new version is detected on app start.
     ref.listen(updateProvider, (prev, next) {
       if (prev?.status != UpdateStatus.available &&
-          next.status == UpdateStatus.available &&
-          !next.dismissedToday) {
+          next.status == UpdateStatus.available) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) _showUpdateDialog(context, next.info!, palette);
         });

--- a/lib/features/updater/update_model.dart
+++ b/lib/features/updater/update_model.dart
@@ -37,14 +37,11 @@ class UpdateState {
   final UpdateInfo? info;
   final double downloadProgress;
   final String? errorMessage;
-  // True when the user already dismissed the popup today — show badge only.
-  final bool dismissedToday;
 
   const UpdateState({
     this.status = UpdateStatus.idle,
     this.info,
     this.downloadProgress = 0.0,
     this.errorMessage,
-    this.dismissedToday = false,
   });
 }

--- a/lib/features/updater/update_notifier.dart
+++ b/lib/features/updater/update_notifier.dart
@@ -1,12 +1,9 @@
 import 'dart:async' show unawaited;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:window_manager/window_manager.dart';
 import 'update_model.dart';
 import 'update_service.dart';
-
-const _kDismissedDateKey = 'update_dismissed_date';
 
 final updateProvider =
     NotifierProvider<UpdateNotifier, UpdateState>(UpdateNotifier.new);
@@ -16,23 +13,6 @@ class UpdateNotifier extends Notifier<UpdateState> {
 
   @override
   UpdateState build() => const UpdateState();
-
-  static String _today() => DateTime.now().toIso8601String().substring(0, 10);
-
-  Future<bool> _isDismissedToday() async {
-    final prefs = await SharedPreferences.getInstance();
-    return (prefs.getString(_kDismissedDateKey) ?? '') == _today();
-  }
-
-  Future<void> dismissForToday() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_kDismissedDateKey, _today());
-    state = UpdateState(
-      status: state.status,
-      info: state.info,
-      dismissedToday: true,
-    );
-  }
 
   Future<void> checkForUpdate() async {
     if (state.status == UpdateStatus.checking) return;
@@ -45,12 +25,7 @@ class UpdateNotifier extends Notifier<UpdateState> {
         state = const UpdateState(status: UpdateStatus.upToDate);
       } else if (UpdateService.isNewer(info.version, packageInfo.version)) {
         if (info.assetUrl.isEmpty) throw Exception('No .exe asset found in release');
-        final dismissed = await _isDismissedToday();
-        state = UpdateState(
-          status: UpdateStatus.available,
-          info: info,
-          dismissedToday: dismissed,
-        );
+        state = UpdateState(status: UpdateStatus.available, info: info);
       } else {
         // Same or older — store info so release notes are available in the UI.
         state = UpdateState(status: UpdateStatus.upToDate, info: info);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.2.1+6
+version: 1.2.2+7
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
## Summary
- Update popup shows on every app start (removed once-per-day suppression)
- Catalog card tick badge + expanded card text for already-downloaded videos
- Downloaded filter toggle in the sort/filter bar
- Re-download overwrite warning dialog (Navigator crash fixed via `addPostFrameCallback`)
- README updated with Catalog section and current feature set

## Test plan
- [ ] Launch app with an available update — popup appears every time
- [ ] Download a catalog video; confirm tick badge appears on card and "Already downloaded" in expanded view
- [ ] Click download on an already-downloaded video — overwrite warning appears, Cancel and Download Anyway both work
- [ ] Toggle Downloaded filter — grid shows only downloaded entries; Clear Filters resets it
- [ ] Downloaded filter with no downloads — shows empty "No results."

🤖 Generated with [Claude Code](https://claude.com/claude-code)