### PR TITLE
feat: v1.2.3 — URL-aware default navigation order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# mStorage — Claude Instructions
+
+## Release Workflow
+
+This is the **standard process for every release**. Follow it in full, in order.
+
+### 1. Read QUERY.md first
+When a new release is mentioned or triggered, read `QUERY.md` at the root. It contains the target version and the change expectations for that release. This file is updated by the user on the fly.
+
+### 2. Create a feature branch
+Never commit release work directly to `main`. Create a branch named exactly:
+```
+feat/vX.Y.Z
+```
+where X.Y.Z matches the version in QUERY.md.
+
+### 3. Plan before implementing
+Before touching any code, produce a written plan of the changes described in QUERY.md and wait for the user to review it. Only proceed to implementation after the user approves.
+
+### 4. Implement and iterate
+Apply the changes. The user will review and give feedback. Go back and forth until the user explicitly says they are satisfied and ready to release.
+
+### 5. Raise a PR
+When the user confirms readiness, open a GitHub PR from `feat/vX.Y.Z` → `main`.
+
+### 6. Merge
+
+### 7. Build the Inno Setup installer
+After merge, build the Windows installer using the Inno Setup script in the repo.
+
+### 8. Tag and release on GitHub
+Create a GitHub release using the tag `vX.Y.Z`. Write release notes following the rules in `.github/RELEASE_TEMPLATE.md`:
+- Open with `## What's New`
+- Use only `### Features`, `### Fixes`, `### Improvements` sections (omit empty ones)
+- Each bullet: `- **Label** — Description` (em dash, no trailing period)
+- No version number in body, no installation instructions
+
+---
+
+## Navigation
+- `QUERY.md` — per-release version + change expectations (updated by user before each release)
+- `.github/RELEASE_TEMPLATE.md` — release note format rules

--- a/installer.iss
+++ b/installer.iss
@@ -7,7 +7,7 @@
 ; Output: installer\mStorage_Setup.exe
 
 #define AppName        "mStorage"
-#define AppVersion     "1.2.2"
+#define AppVersion     "1.2.3"
 #define AppPublisher   "Seshu Tarapatla"
 #define AppURL         "https://github.com/SeshuTarapatla/mStorage"
 #define AppExeName     "m_storage.exe"

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -306,25 +306,41 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         AppTab.admin    => (Icons.admin_panel_settings_rounded, 'Admin'),
       };
 
-  static List<int> _effectiveOrder(AppSettings settings) {
+  static int _effectiveStartupTab(AppSettings settings, String? sheetUrl) {
+    if (settings.startupTab != 0) return settings.startupTab;
+    return sheetUrl != null ? AppTab.catalog.index : AppTab.encode.index;
+  }
+
+  static List<int> _effectiveOrder(AppSettings settings, String? sheetUrl) {
     if (settings.tabOrder != null) return settings.tabOrder!;
-    const base = [
+    const defaultOrder = [
       AppTab.encode,
       AppTab.decode,
       AppTab.player,
       AppTab.catalog,
       AppTab.settings,
     ];
-    final startupIdx =
-        settings.startupTab.clamp(0, AppTab.settings.index);
-    return [
-      startupIdx,
-      ...base.map((t) => t.index).where((i) => i != startupIdx),
-    ];
+    if (settings.startupTab != 0) {
+      final startupIdx = settings.startupTab.clamp(0, AppTab.settings.index);
+      return [
+        startupIdx,
+        ...defaultOrder.map((t) => t.index).where((i) => i != startupIdx),
+      ];
+    }
+    if (sheetUrl != null) {
+      return [
+        AppTab.catalog.index,
+        AppTab.player.index,
+        AppTab.encode.index,
+        AppTab.decode.index,
+        AppTab.settings.index,
+      ];
+    }
+    return defaultOrder.map((t) => t.index).toList();
   }
 
-  Widget _buildLayoutSection(AppSettings settings, Color accent) {
-    final order = _effectiveOrder(settings);
+  Widget _buildLayoutSection(AppSettings settings, Color accent, String? sheetUrl) {
+    final order = _effectiveOrder(settings, sheetUrl);
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
       child: Column(
@@ -455,6 +471,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final settings = ref.watch(settingsProvider);
+    final sheetUrl = ref.watch(sheetUrlProvider);
     final accent = _palette.primary;
     final updateState = ref.watch(updateProvider);
     final updatePending = updateState.status == UpdateStatus.available ||
@@ -512,7 +529,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                         padding: const EdgeInsets.only(left: 6),
                         child: _ChipButton(
                           label: tab.name[0].toUpperCase() + tab.name.substring(1),
-                          selected: settings.startupTab == tab.index,
+                          selected: _effectiveStartupTab(settings, sheetUrl) == tab.index,
                           accent: accent,
                           onTap: () => ref
                               .read(settingsProvider.notifier)
@@ -531,7 +548,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           _SettingsGroup(
             label: 'Layout',
             accent: accent,
-            children: [_buildLayoutSection(settings, accent)],
+            children: [_buildLayoutSection(settings, accent, sheetUrl)],
           ).animate().fadeIn(duration: 300.ms, delay: 60.ms),
 
           const SizedBox(height: 20),

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -16,14 +16,18 @@ import '../encode/encode_screen.dart';
 import '../decode/decode_screen.dart';
 import '../player/player_screen.dart';
 import '../catalog/catalog_screen.dart';
+import '../catalog/catalog_notifier.dart';
 import '../settings/settings_screen.dart';
 
 // Reads startupTab from already-loaded settings (main() loads before runApp).
 // ref.read (not watch) so user navigation doesn't get overridden on rebuilds.
 final activeTabProvider = StateProvider<AppTab>((ref) {
-  final idx = ref.read(settingsProvider).startupTab;
-  // Clamp to public tabs only — admin is the last enum value and not a startup option.
-  return AppTab.values[idx.clamp(0, AppTab.settings.index)];
+  final settings = ref.read(settingsProvider);
+  final idx = settings.startupTab;
+  if (idx != 0) return AppTab.values[idx.clamp(0, AppTab.settings.index)];
+  // At default (0): open Catalog if sheet URL is configured, otherwise Encode.
+  final sheetUrl = ref.read(sheetUrlProvider);
+  return sheetUrl != null ? AppTab.catalog : AppTab.encode;
 });
 
 final ghAuthProvider = FutureProvider<bool>(
@@ -451,13 +455,29 @@ class _SidebarState extends ConsumerState<_Sidebar> {
           .where((i) => i <= AppTab.settings.index)
           .map((i) => _baseItems.firstWhere((item) => item.$1.index == i))
           .toList();
-    } else {
+    } else if (settings.startupTab != 0) {
+      // User explicitly picked a startup tab — honor it.
       final startupTab =
           AppTab.values[settings.startupTab.clamp(0, AppTab.settings.index)];
       base = [
         ..._baseItems.where((i) => i.$1 == startupTab),
         ..._baseItems.where((i) => i.$1 != startupTab),
       ];
+    } else {
+      // Both tabOrder and startupTab are at defaults (reset state).
+      // Use URL-aware ordering: if sheet URL is configured, surface Catalog first.
+      final sheetUrl = ref.watch(sheetUrlProvider);
+      if (sheetUrl != null) {
+        base = [
+          _baseItems.firstWhere((i) => i.$1 == AppTab.catalog),
+          _baseItems.firstWhere((i) => i.$1 == AppTab.player),
+          _baseItems.firstWhere((i) => i.$1 == AppTab.encode),
+          _baseItems.firstWhere((i) => i.$1 == AppTab.decode),
+          _baseItems.firstWhere((i) => i.$1 == AppTab.settings),
+        ];
+      } else {
+        base = List.of(_baseItems);
+      }
     }
     final items = isAdmin ? [...base, _adminItem] : base;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.2.2+7
+version: 1.2.3+8
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
## Summary
- When a sheet URL is configured and the user hasn't customised tab order or startup page, the sidebar defaults to **Catalog → Player → Encode → Decode → Settings** instead of Encode-first
- Startup Page selector in Settings and the active tab on launch follow the same URL-aware logic
- Explicit user preferences (custom tab order, explicit startup page selection) always take precedence; Reset returns to the URL-aware default

## Test plan
- [ ] Fresh install (no URL set): sidebar order is Encode → Decode → Player → Catalog → Settings, Startup Page shows Encode
- [ ] Set a sheet URL: sidebar reorders to Catalog → Player → Encode → Decode → Settings, Startup Page selector shows Catalog, app opens to Catalog on next launch
- [ ] Drag to reorder pages: custom order persists, overrides URL-aware default
- [ ] Press Reset: reverts to URL-aware default (Catalog-first if URL set)
- [ ] Explicitly pick a Startup Page: that choice takes precedence over URL default
- [ ] Clear the sheet URL: sidebar reverts to Encode-first default order

🤖 Generated with [Claude Code](https://claude.com/claude-code)