### PR TITLE
feat: v1.3.0 — Series catalog with episode management

### DIFF
--- a/docs/feature-series-catalog.md
+++ b/docs/feature-series-catalog.md
@@ -1,0 +1,245 @@
+# v1.3.0 — Series Catalog Feature Plan
+
+## Overview
+
+Extend the Catalog tab to support TV series alongside movies. Series have a hierarchy
+(series → seasons → episodes), which is fundamentally different from movies (1 entry = 1 video).
+The approach: keep the existing Movies grid untouched and add a **Series sub-tab** within the
+Catalog screen, backed by a second sheet tab named **Series** in the same Google Spreadsheet.
+
+---
+
+## 1. Google Sheet Changes
+
+The user renames their existing Sheet1 to **Movies** and adds a new sheet tab named **Series**.
+
+### Series sheet: one row per episode
+
+Each row represents one episode. Series-level metadata (poster, IMDB ID, genres, tags, plot)
+is entered on the first row for each series and may be left blank on subsequent rows — the
+parser groups rows by `series_title` and inherits series-level fields from the first
+non-empty occurrence per series.
+
+#### Columns
+
+| Column | Required | Description |
+|---|---|---|
+| `series_title` | yes | Show name — the grouping key |
+| `series_imdb_id` | no | IMDB ID of the **series** (e.g. `tt0903747`) |
+| `season` | yes | Season number (integer) |
+| `episode` | yes | Episode number within the season (integer) |
+| `episode_title` | no | Episode title (blank → use "Episode N") |
+| `air_date` | no | ISO date or year |
+| `video_url` | yes | Google Photos album / direct link for this episode |
+| `poster_url` | no | Series poster — only needed on one row per series |
+| `size_mb` | no | File size in MB |
+| `language` | no | Language label |
+| `encoded` | no | `true` if video is encoded/hidden (default `false`) |
+| `show` | no | `false` to hide from catalog |
+| `tags` | no | Franchise tags, comma-separated |
+| `genres` | no | Genre tags, comma-separated |
+| `plot` | no | Series synopsis (blank → IMDB) |
+
+Flexible alias-matching applies (same strategy as movies): e.g. `series_title`, `show_title`,
+`title` all resolve to the series title column.
+
+### Single URL, two named sheet tabs
+
+No new URL setting. The app derives both CSV endpoints from the **existing** sheet URL:
+
+| Tab | Fetch URL |
+|---|---|
+| Movies | `…/export?format=csv&gid=0` (unchanged) |
+| Series | `…/gviz/tq?tqx=out:csv&sheet=Series` (by name) |
+
+The Google Visualization endpoint (`gviz/tq`) resolves tabs by name, works publicly without
+auth, and returns the same CSV format. If the **Series** tab doesn't exist yet, the request
+returns an error which the app treats as "no series data" (empty state, not an error banner).
+
+No changes to `sheetUrlProvider` or how the user configures the URL.
+
+---
+
+## 2. Data Model
+
+### New file: `lib/features/catalog/models/series_entry.dart`
+
+```
+SeriesEntry
+  String title
+  String imdbId             // series-level IMDB ID
+  String posterUrl
+  String plot
+  List<String> genres
+  List<String> tags
+  String? language
+  double? imdbRating        // series-level rating from IMDB
+  List<SeasonEntry> seasons
+
+SeasonEntry
+  int number
+  List<EpisodeEntry> episodes
+
+EpisodeEntry
+  int episodeNumber
+  String title              // from sheet, or "Episode N" fallback
+  DateTime? airDate
+  String videoUrl
+  int? sizeMb
+  bool encoded
+```
+
+### New file: `lib/features/catalog/models/series_sheet_schema.dart`
+
+Same pattern as `SheetSchema` — column names, indices, `headerTsv`, `parseTsv` / `buildTsv`.
+Useful when the Admin tool adds series support in a future release.
+
+### IMDB enrichment
+
+`ImdbService.resolve()` already handles series IMDB IDs (same API fields: title, poster, plot,
+genres, rating). No changes to `ImdbService` needed. Episode-level enrichment is deferred.
+
+---
+
+## 3. State Management
+
+### New file: `lib/features/catalog/series_notifier.dart`
+
+```
+seriesProvider  — StateNotifierProvider<SeriesNotifier, SeriesCatalogState>
+```
+
+No new URL provider — `SeriesNotifier` reads `sheetUrlProvider` directly and constructs the
+`gviz/tq` URL from the same sheet ID.
+
+`SeriesCatalogState` sealed class:
+- `SeriesCatalogIdle`
+- `SeriesCatalogLoading`
+- `SeriesCatalogLoaded(List<SeriesEntry> series)`
+- `SeriesCatalogError(String message)`
+
+`SeriesNotifier.load(sheetUrl)` pipeline:
+1. Extract sheet ID from URL (same `_extractSheetId` regex as movies)
+2. Build `gviz/tq` URL: `https://docs.google.com/spreadsheets/d/$id/gviz/tq?tqx=out:csv&sheet=Series`
+3. Check disk cache (TTL: 1 hour) → `catalog_csv_series_$id.json`
+4. Fetch CSV if stale or missing; treat HTTP error / HTML response as empty (Series tab not yet created)
+5. Parse flat rows → group by `series_title` → build `SeriesEntry` tree
+6. Enrich via `ImdbService.resolve()` on series-level IMDB IDs
+7. Emit `SeriesCatalogLoaded`
+
+Cache key uses `series_` prefix to avoid collision with the movies cache.
+
+---
+
+## 4. UI Architecture
+
+### 4a. Inner tab bar in CatalogScreen
+
+`CatalogScreen` gains a `TabController` with two tabs: **Movies** and **Series**.
+
+The tab switcher is a compact pill toggle placed between the `_TopBar` and the content area
+(where the sort/filter bar currently lives). The top bar (URL input / search) is **shared** —
+the same URL and search state applies regardless of which sub-tab is active.
+
+When the catalog sub-tab switches:
+- The active palette changes (amber for Movies, orange for Series)
+- The sort/filter bar only appears under Movies (Series has its own simpler controls)
+- The content area swaps between `_MoviesSubtab` and `_SeriesSubtab`
+
+Tab bar visual design:
+- Two pill buttons: `Movies` and `Series`
+- Active pill uses the sub-tab's accent color with 10% fill and full border
+- Inactive pill is muted text, no fill
+
+### 4b. Movies sub-tab (`_MoviesSubtab`)
+
+Zero changes to existing logic. `_Body`, `_Grid`, `_SortFilterBar`, `_CardDetail`,
+`_DownloadsListView`, `_DownloadPanel` are wrapped as-is inside the Movies tab view.
+
+### 4c. Series sub-tab (`_SeriesSubtab`)
+
+Mirrors `_Body` structure for its four states (idle / loading / loaded / error).
+
+**Idle state**: same prompt style as movies — "Paste a Google Sheets URL above…" — but noting
+that a **Series** tab must exist in the spreadsheet.
+
+**Loaded state** — `_SeriesGrid`:
+Masonry grid of `SeriesCard` widgets (one card per show, not per episode).
+
+**`SeriesCard`** (compact):
+- Poster thumbnail
+- Title
+- Sub-line: `3 seasons · 24 episodes`
+- Downloaded dot indicator if any episode from this series is in download history
+- Orange accent on hover/selected state
+
+**`SeriesCardExpanded`** (full overlay, same mechanism as movies):
+- Large poster left, metadata right
+- Title, IMDB rating, genres, language
+- Plot paragraph
+- Season accordion below: each season is a collapsible section header
+  - Episode rows inside: `E01 · Episode Title · air_date · [▶ Open] [↓ Download]`
+  - "Open" → launches `WebViewOverlay` with the episode's video URL
+  - "Download" → `downloadProvider.notifier.enqueue(...)` — same as movies
+- Keyboard: Left/Right navigates between series in the grid; Escape closes
+
+### 4d. Series sort + filter bar
+
+Simpler than movies:
+- Sort: **A–Z** | **Seasons** | **Episodes**
+- Filter: **Language** | **Genre**
+- No Rating sort (series-level IMDB rating is available, could add in future)
+
+---
+
+## 5. Theme
+
+New constant in `lib/core/theme/tab_colors.dart` (not a new `AppTab`):
+
+```dart
+const kSeriesPalette = TabPalette(
+  primary:   Color(0xFFEA580C),  // orange-600
+  secondary: Color(0xFFF97316),  // orange-500
+  glow:      Color(0x66EA580C),
+  surface:   Color(0xFF1A0A02),
+);
+```
+
+`CatalogScreen` passes either `AppTab.catalog.palette` or `kSeriesPalette` to child widgets
+based on the active sub-tab index.
+
+---
+
+## 6. Files to Create / Modify
+
+### New files
+| File | Purpose |
+|---|---|
+| `lib/features/catalog/models/series_entry.dart` | SeriesEntry / SeasonEntry / EpisodeEntry |
+| `lib/features/catalog/models/series_sheet_schema.dart` | Series column schema |
+| `lib/features/catalog/series_notifier.dart` | SeriesNotifier + SeriesCatalogState |
+| `lib/features/catalog/widgets/series_card.dart` | SeriesCard + SeriesCardExpanded |
+
+### Modified files
+| File | Change |
+|---|---|
+| `lib/core/theme/tab_colors.dart` | Add `kSeriesPalette` constant |
+| `lib/features/catalog/catalog_screen.dart` | Add TabController, pill tab bar, `_SeriesSubtab` integration, palette switching |
+
+### Untouched
+| File | Why |
+|---|---|
+| `lib/features/catalog/catalog_notifier.dart` | Movies unchanged |
+| `lib/features/catalog/models/catalog_entry.dart` | Movies model unchanged |
+| `lib/features/catalog/models/sheet_schema.dart` | Movies schema unchanged |
+| `lib/features/admin/admin_screen.dart` | Admin movies-only for now |
+| `lib/features/shell/app_shell.dart` | No new sidebar tab |
+| `lib/core/services/settings_service.dart` | No new settings key |
+
+---
+
+## 7. Deferred / Out of Scope
+
+- Episode-level IMDB enrichment (titles, air dates per episode from IMDB)
+- Admin tool for series
+- Series in the download history view (download records already work by title; no structural change needed)

--- a/docs/series_row_sample.txt
+++ b/docs/series_row_sample.txt
@@ -1,0 +1,3 @@
+episode_imdb_id	series_title	series_imdb_id	season	episode	episode_title	air_date	video_url	poster_url	size_mb	language	encoded	show	tags	genres	plot
+tt3330796	Breaking Bad	tt0903747	2	1	Seven Thirty-Seven	2009-03-08	https://photos.google.com/album/example	https://drive.google.com/thumbnail?id=exampleId&sz=w400	850	English	TRUE	TRUE	AMC,Crime	Drama,Thriller	Walt and Jesse must deal with the aftermath of the cartel confrontation.
+tt3330796		tt0903747					https://photos.app.goo.gl/8sxp4sGjy3PkKoRW9	https://drive.google.com/thumbnail?id=exampleId&sz=w400	850	English	TRUE	TRUE													

--- a/docs/sheet_schema.txt
+++ b/docs/sheet_schema.txt
@@ -1,0 +1,8 @@
+Movies
+title	imdb_id	date	video_url	poster_url	size_mb	language	plot	genres	tags	encoded	show	slide_images
+
+Series
+series_imdb_id	title	start_year	end_year	poster_url	plot	rating	genres	tags	show
+
+Episodes
+episode_imdb_id	series_imdb_id	season	episode	title	air_date	thumbnail_url	plot	rating	video_url	size_mb	language	encoded	show

--- a/installer.iss
+++ b/installer.iss
@@ -7,7 +7,7 @@
 ; Output: installer\mStorage_Setup.exe
 
 #define AppName        "mStorage"
-#define AppVersion     "1.2.3"
+#define AppVersion     "1.3.0"
 #define AppPublisher   "Seshu Tarapatla"
 #define AppURL         "https://github.com/SeshuTarapatla/mStorage"
 #define AppExeName     "m_storage.exe"

--- a/lib/core/theme/tab_colors.dart
+++ b/lib/core/theme/tab_colors.dart
@@ -58,3 +58,10 @@ const tabPalettes = {
 extension TabPaletteX on AppTab {
   TabPalette get palette => tabPalettes[this]!;
 }
+
+const kSeriesPalette = TabPalette(
+  primary:   Color(0xFFEA580C),
+  secondary: Color(0xFFF97316),
+  glow:      Color(0x66EA580C),
+  surface:   Color(0xFF1A0A02),
+);

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -4,28 +4,33 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/services/catalog_cache_manager.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
 import '../catalog/imdb_service.dart';
 import '../catalog/models/imdb_data.dart';
+import '../catalog/models/episode_sheet_schema.dart';
+import '../catalog/models/series_entry.dart';
+import '../catalog/models/series_sheet_schema.dart';
 import '../catalog/models/sheet_schema.dart';
+import '../catalog/series_notifier.dart';
 
 final _adminPalette = AppTab.admin.palette;
 
 // Amber badge for top-4 slide picks.
 const _kTop4Color = Color(0xFFF59E0B);
 
+enum _AdminMode { movie, series, episode }
 
-
-class AdminScreen extends StatefulWidget {
+class AdminScreen extends ConsumerStatefulWidget {
   const AdminScreen({super.key});
 
   @override
-  State<AdminScreen> createState() => _AdminScreenState();
+  ConsumerState<AdminScreen> createState() => _AdminScreenState();
 }
 
-class _AdminScreenState extends State<AdminScreen> {
+class _AdminScreenState extends ConsumerState<AdminScreen> {
   final _imdbIdCtrl = TextEditingController();
 
   bool _fetching = false;
@@ -46,6 +51,14 @@ class _AdminScreenState extends State<AdminScreen> {
   final _sizeMbCtrl      = TextEditingController();
   bool _encoded = true;
   bool _show    = true;
+
+  // ── Series mode ──────────────────────────────────────────────────────────
+  _AdminMode _mode = _AdminMode.movie;
+  final _seriesImdbCtrl     = TextEditingController();
+  final _seriesImdbFocusNode = FocusNode();
+  final _seasonCtrl     = TextEditingController(text: '1');
+  final _episodeCtrl    = TextEditingController(text: '1');
+  ImdbData? _episodeData; // episode IMDB data (fetched from _imdbIdCtrl in series mode)
 
   // All images fetched from API (up to 100).
   List<String> _allImages = [];
@@ -71,9 +84,19 @@ class _AdminScreenState extends State<AdminScreen> {
   int  _selectedMonth = 1;
   int  _selectedDay   = 1;
 
+  void _onFieldChanged() {
+    if (mounted && _data != null) setState(() {});
+  }
+
   @override
   void initState() {
     super.initState();
+    for (final c in [
+      _videoUrlCtrl, _languageCtrl, _sizeMbCtrl,
+      _seasonCtrl, _episodeCtrl,
+    ]) {
+      c.addListener(_onFieldChanged);
+    }
   }
 
   @override
@@ -87,6 +110,10 @@ class _AdminScreenState extends State<AdminScreen> {
     _languageCtrl.dispose();
     _languageFocusNode.dispose();
     _sizeMbCtrl.dispose();
+    _seriesImdbCtrl.dispose();
+    _seriesImdbFocusNode.dispose();
+    _seasonCtrl.dispose();
+    _episodeCtrl.dispose();
     _pasteErrorTimer?.cancel();
     _flashTimer?.cancel();
     super.dispose();
@@ -133,49 +160,129 @@ class _AdminScreenState extends State<AdminScreen> {
 
   // ── Data fetching ─────────────────────────────────────────────────────────
 
-  Future<void> _fetch() async {
-    final id = _imdbIdCtrl.text.trim();
-    if (id.isEmpty) return;
+  void _setMode(_AdminMode mode) {
+    if (mode == _mode) return;
     setState(() {
-      _fetching = true;
-      _error = null;
-      _data = null;
-      _genres = [];
-      _tags = [];
-      _allImages = [];
-      _selected = [];
+      _mode             = mode;
+      _data             = null;
+      _episodeData      = null;
+      _error            = null;
+      _genres           = [];
+      _tags             = [];
+      _allImages        = [];
+      _selected         = [];
       _videoUrlCtrl.clear();
       _languageCtrl.clear();
       _sizeMbCtrl.clear();
-      _encoded = true;
-      _show = true;
+      _seriesImdbCtrl.clear();
+      _encoded          = true;
+      _show             = true;
+      _selectedYear     = null;
+      _selectedMonth    = 1;
+      _selectedDay      = 1;
+      _seasonCtrl.text  = '1';
+      _episodeCtrl.text = '1';
     });
+  }
 
+  Future<void> _fetch() async {
+    final id = _imdbIdCtrl.text.trim();
+    if (id.isEmpty) return;
+    switch (_mode) {
+      case _AdminMode.movie:   await _fetchMovie(id);
+      case _AdminMode.series:  await _fetchSeries(id);
+      case _AdminMode.episode: await _fetchEpisode(id, _seriesImdbCtrl.text.trim());
+    }
+  }
+
+  Future<void> _fetchMovie(String id) async {
+    setState(() {
+      _fetching  = true; _error = null; _data = null; _episodeData = null;
+      _genres = []; _tags = []; _allImages = []; _selected = [];
+      _videoUrlCtrl.clear(); _languageCtrl.clear(); _sizeMbCtrl.clear();
+      _encoded = true; _show = true;
+    });
     try {
       final results = await ImdbService().resolve([id]);
       final data = results[id];
       if (!mounted) return;
       if (data == null) {
-        setState(() {
-          _error = 'No data found for "$id". Check the IMDB ID.';
-          _fetching = false;
-        });
+        setState(() { _error = 'No data found for "$id".'; _fetching = false; });
         return;
       }
-
       final page1 = await ImdbService().fetchImagesUncached(id);
       if (!mounted) return;
-
       setState(() {
         _data = data;
         _genres = List<String>.from(data.genres);
         _allImages = page1.images;
         _selected = page1.images.take(4).toList();
         _nextPageToken = page1.nextPageToken;
-        _fetching = false;
         _selectedYear  = data.releaseDate?.year;
         _selectedMonth = data.releaseDate?.month ?? 1;
-        _selectedDay   = data.releaseDate?.day ?? 1;
+        _selectedDay   = data.releaseDate?.day   ?? 1;
+        _fetching = false;
+      });
+    } catch (e) {
+      if (mounted) setState(() { _error = e.toString(); _fetching = false; });
+    }
+  }
+
+  Future<void> _fetchSeries(String id) async {
+    setState(() {
+      _fetching = true; _error = null; _data = null;
+      _genres = []; _tags = [];
+    });
+    try {
+      final results = await ImdbService().resolve([id]);
+      if (!mounted) return;
+      final data = results[id];
+      if (data == null) {
+        setState(() { _error = 'No data found for "$id".'; _fetching = false; });
+        return;
+      }
+      setState(() {
+        _data   = data;
+        _genres = List<String>.from(data.genres);
+        _fetching = false;
+      });
+    } catch (e) {
+      if (mounted) setState(() { _error = e.toString(); _fetching = false; });
+    }
+  }
+
+  Future<void> _fetchEpisode(String episodeId, String seriesId) async {
+    if (seriesId.isEmpty) {
+      setState(() => _error = 'Series IMDB ID is required.');
+      return;
+    }
+    setState(() {
+      _fetching = true; _error = null; _data = null; _episodeData = null;
+      _videoUrlCtrl.clear(); _languageCtrl.clear(); _sizeMbCtrl.clear();
+      _encoded = true; _show = true;
+    });
+    try {
+      final ids = <String>[seriesId];
+      if (episodeId.isNotEmpty) ids.add(episodeId);
+      final results = await ImdbService().resolve(ids);
+      if (!mounted) return;
+      final seriesData = results[seriesId];
+      if (seriesData == null) {
+        setState(() { _error = 'No series data for "$seriesId".'; _fetching = false; });
+        return;
+      }
+      final epData = episodeId.isNotEmpty ? results[episodeId] : null;
+      if (episodeId.isNotEmpty && epData == null) {
+        setState(() { _error = 'No episode data for "$episodeId".'; _fetching = false; });
+        return;
+      }
+      setState(() {
+        _data        = seriesData;
+        _episodeData = epData;
+        _selectedYear  = epData?.releaseDate?.year;
+        _selectedMonth = 1;
+        _selectedDay   = 1;
+        _fetching = false;
       });
     } catch (e) {
       if (mounted) setState(() { _error = e.toString(); _fetching = false; });
@@ -225,7 +332,127 @@ class _AdminScreenState extends State<AdminScreen> {
       return;
     }
 
-    // Case 2: tab-separated sheet row → proceed with full paste.
+    final tabCols = text.split('\t');
+
+    // Case 2a: Series TSV (10 cols) in series mode.
+    if (_mode == _AdminMode.series && tabCols.length >= SeriesSheetSchema.columnCount) {
+      final sc = SeriesSheetSchema.parseTsv(text);
+      final genresRaw = sc[SeriesSheetSchema.iGenres];
+      final tagsRaw   = sc[SeriesSheetSchema.iTags];
+      final genres = genresRaw.isEmpty ? <String>[] : genresRaw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+      final tags   = tagsRaw.isEmpty   ? <String>[] : tagsRaw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+      final startYear = int.tryParse(sc[SeriesSheetSchema.iStartYear]);
+      final seriesId  = sc[SeriesSheetSchema.iSeriesImdbId];
+
+      setState(() {
+        _imdbIdCtrl.text = seriesId;
+        _genres  = genres;
+        _tags    = tags;
+        _show    = sc[SeriesSheetSchema.iShow].toLowerCase() != 'false';
+        _data    = ImdbData(
+          id: seriesId,
+          title: sc[SeriesSheetSchema.iTitle],
+          plot: sc[SeriesSheetSchema.iPlot],
+          genres: genres,
+          releaseDate: startYear != null ? DateTime(startYear) : null,
+          posterUrl: sc[SeriesSheetSchema.iPosterUrl],
+          rating: double.tryParse(sc[SeriesSheetSchema.iRating]),
+          voteCount: null, runtimeSeconds: null, stars: const [], certificate: null,
+          endYear: int.tryParse(sc[SeriesSheetSchema.iEndYear]),
+        );
+        _loadingMore = seriesId.isNotEmpty;
+        _fetching    = false;
+        _error       = null;
+      });
+
+      // Enrich from API in background
+      if (seriesId.isEmpty) return;
+      try {
+        final results = await ImdbService().resolve([seriesId]);
+        if (!mounted) return;
+        final meta = results[seriesId];
+        if (meta == null) { setState(() => _loadingMore = false); return; }
+        final pasted = _data!;
+        setState(() {
+          _data = ImdbData(
+            id: seriesId,
+            title: pasted.title.isNotEmpty ? pasted.title : meta.title,
+            plot: pasted.plot.isNotEmpty ? pasted.plot : meta.plot,
+            genres: pasted.genres.isNotEmpty ? pasted.genres : List<String>.from(meta.genres),
+            releaseDate: meta.releaseDate ?? pasted.releaseDate,
+            posterUrl: pasted.posterUrl.isNotEmpty ? pasted.posterUrl : meta.posterUrl,
+            rating: meta.rating, voteCount: meta.voteCount,
+            runtimeSeconds: meta.runtimeSeconds,
+            stars: meta.stars, certificate: meta.certificate,
+            endYear: meta.endYear ?? pasted.endYear,
+          );
+          _genres      = _data!.genres;
+          _loadingMore = false;
+        });
+      } catch (_) {
+        if (mounted) setState(() => _loadingMore = false);
+      }
+      return;
+    }
+
+    // Case 2b: Episode TSV (14 cols) in episode mode.
+    if (_mode == _AdminMode.episode && tabCols.length >= EpisodeSheetSchema.columnCount) {
+      final ec     = EpisodeSheetSchema.parseTsv(text);
+      final epDate = DateTime.tryParse(ec[EpisodeSheetSchema.iAirDate]);
+      final seriesId = ec[EpisodeSheetSchema.iSeriesImdbId];
+
+      setState(() {
+        _imdbIdCtrl.text     = ec[EpisodeSheetSchema.iEpisodeImdbId];
+        _seriesImdbCtrl.text = seriesId;
+        _seasonCtrl.text     = ec[EpisodeSheetSchema.iSeason].isNotEmpty ? ec[EpisodeSheetSchema.iSeason] : '1';
+        _episodeCtrl.text    = ec[EpisodeSheetSchema.iEpisode].isNotEmpty ? ec[EpisodeSheetSchema.iEpisode] : '1';
+        _videoUrlCtrl.text   = ec[EpisodeSheetSchema.iVideoUrl];
+        _languageCtrl.text   = ec[EpisodeSheetSchema.iLanguage];
+        _sizeMbCtrl.text     = ec[EpisodeSheetSchema.iSizeMb];
+        _encoded       = ec[EpisodeSheetSchema.iEncoded].toLowerCase() == 'true';
+        _show          = ec[EpisodeSheetSchema.iShow].toLowerCase() != 'false';
+        _selectedYear  = epDate?.year;
+        _selectedMonth = epDate?.month ?? 1;
+        _selectedDay   = epDate?.day   ?? 1;
+        _episodeData   = ec[EpisodeSheetSchema.iTitle].isNotEmpty
+            ? ImdbData(
+                id: ec[EpisodeSheetSchema.iEpisodeImdbId],
+                title: ec[EpisodeSheetSchema.iTitle],
+                plot: ec[EpisodeSheetSchema.iPlot],
+                genres: const [],
+                releaseDate: epDate,
+                posterUrl: ec[EpisodeSheetSchema.iThumbnailUrl],
+                rating: double.tryParse(ec[EpisodeSheetSchema.iRating]),
+                voteCount: null, runtimeSeconds: null, stars: const [], certificate: null,
+              )
+            : null;
+        // Minimal series placeholder so form renders; enriched below.
+        _data = ImdbData(
+          id: seriesId, title: '', plot: '', genres: const [],
+          releaseDate: null, posterUrl: '', rating: null,
+          voteCount: null, runtimeSeconds: null, stars: const [], certificate: null,
+        );
+        _allImages = []; _selected = []; _nextPageToken = null;
+        _loadingMore = seriesId.isNotEmpty;
+        _fetching    = false;
+        _error       = null;
+      });
+
+      // Enrich series context from API in background
+      if (seriesId.isEmpty) return;
+      try {
+        final results = await ImdbService().resolve([seriesId]);
+        if (!mounted) return;
+        final meta = results[seriesId];
+        if (meta == null) { setState(() => _loadingMore = false); return; }
+        setState(() { _data = meta; _loadingMore = false; });
+      } catch (_) {
+        if (mounted) setState(() => _loadingMore = false);
+      }
+      return;
+    }
+
+    // Case 2b: tab-separated movies sheet row → proceed with full paste.
     final cols = SheetSchema.parseTsv(text);
 
     final title      = cols[SheetSchema.iTitle];
@@ -459,16 +686,40 @@ class _AdminScreenState extends State<AdminScreen> {
                   children: [
                     _buildPreview(),
                     const SizedBox(height: 24),
-                    _buildDateEditor(),
-                    const SizedBox(height: 24),
-                    _buildGenreEditor(),
-                    const SizedBox(height: 24),
-                    _buildTagsEditor(),
-                    const SizedBox(height: 24),
-                    _buildRowExtras(),
-                    const SizedBox(height: 24),
-                    _buildImagePicker(),
-                    const SizedBox(height: 24),
+                    if (_mode != _AdminMode.series) ...[
+                      _buildDateEditor(
+                        label: _mode == _AdminMode.episode ? 'Air Date' : 'Date',
+                      ),
+                      const SizedBox(height: 24),
+                    ],
+                    if (_mode != _AdminMode.episode) ...[
+                      _buildGenreEditor(),
+                      const SizedBox(height: 24),
+                      _buildTagsEditor(),
+                      const SizedBox(height: 24),
+                    ],
+                    if (_mode == _AdminMode.episode) ...[
+                      _buildEpisodeSection(),
+                      const SizedBox(height: 24),
+                    ],
+                    if (_mode != _AdminMode.series) ...[
+                      _buildRowExtras(),
+                      const SizedBox(height: 24),
+                    ] else ...[
+                      Row(children: [
+                        _ToggleChip(
+                          label: 'Show',
+                          value: _show,
+                          onChanged: (v) => setState(() => _show = v),
+                          palette: _adminPalette,
+                        ),
+                      ]),
+                      const SizedBox(height: 24),
+                    ],
+                    if (_mode == _AdminMode.movie) ...[
+                      _buildImagePicker(),
+                      const SizedBox(height: 24),
+                    ],
                     _buildResults(),
                     const SizedBox(height: 32),
                   ],
@@ -483,6 +734,7 @@ class _AdminScreenState extends State<AdminScreen> {
   // ── Header ────────────────────────────────────────────────────────────────
 
   Widget _buildHeader() {
+    final isEpisode = _mode == _AdminMode.episode;
     return Row(
       children: [
         Icon(Icons.admin_panel_settings_rounded,
@@ -493,16 +745,43 @@ class _AdminScreenState extends State<AdminScreen> {
                 fontSize: 18,
                 fontWeight: FontWeight.w700,
                 color: _adminPalette.primary)),
-        const SizedBox(width: 6),
-        Text('— Catalog entry editor',
-            style: TextStyle(fontSize: 14, color: kTextMuted)),
-        const SizedBox(width: 24),
+        const SizedBox(width: 12),
+        // Mode dropdown
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+          decoration: BoxDecoration(
+            color: kSurfaceColor,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: kBorderColor),
+          ),
+          child: DropdownButtonHideUnderline(
+            child: DropdownButton<_AdminMode>(
+              value: _mode,
+              isDense: true,
+              dropdownColor: kSurfaceColor,
+              style: TextStyle(fontSize: 13, color: kTextPrimary),
+              icon: Icon(Icons.expand_more_rounded, size: 16, color: kTextMuted),
+              items: const [
+                DropdownMenuItem(value: _AdminMode.movie,   child: Text('Movie')),
+                DropdownMenuItem(value: _AdminMode.series,  child: Text('Series')),
+                DropdownMenuItem(value: _AdminMode.episode, child: Text('Episode')),
+              ],
+              onChanged: (v) { if (v != null) _setMode(v); },
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        // Primary IMDB ID field
         Expanded(
           child: TextField(
             controller: _imdbIdCtrl,
             style: TextStyle(fontSize: 13, color: kTextPrimary),
             decoration: InputDecoration(
-              hintText: 'IMDB ID  (e.g. tt30825738)',
+              hintText: switch (_mode) {
+                _AdminMode.movie    => 'IMDB ID  (e.g. tt30825738)',
+                _AdminMode.series   => 'Series IMDB ID  (tt…)',
+                _AdminMode.episode  => 'Episode IMDB ID  (tt…)',
+              },
               hintStyle: TextStyle(fontSize: 13, color: kTextMuted),
               filled: true,
               fillColor: kSurfaceColor,
@@ -521,6 +800,11 @@ class _AdminScreenState extends State<AdminScreen> {
             onSubmitted: (_) => _fetch(),
           ),
         ),
+        // Series IMDB ID — Episode mode only
+        if (isEpisode) ...[
+          const SizedBox(width: 8),
+          Expanded(child: _buildSeriesIdField()),
+        ],
         const SizedBox(width: 8),
         Tooltip(
           message: 'Paste row from clipboard',
@@ -551,6 +835,120 @@ class _AdminScreenState extends State<AdminScreen> {
           ),
         ),
       ],
+    );
+  }
+
+  // ── Series ID autocomplete (Episode mode header) ──────────────────────────
+
+  Widget _buildSeriesIdField() {
+    final seriesState = ref.watch(seriesProvider);
+    final series = seriesState is SeriesCatalogLoaded
+        ? seriesState.series
+        : <SeriesEntry>[];
+
+    if (series.isEmpty) {
+      return TextField(
+        controller: _seriesImdbCtrl,
+        focusNode: _seriesImdbFocusNode,
+        style: TextStyle(fontSize: 13, color: kTextPrimary),
+        decoration: InputDecoration(
+          hintText: 'Series IMDB ID  (tt…)  — required',
+          hintStyle: TextStyle(fontSize: 13, color: kTextMuted),
+          filled: true,
+          fillColor: kSurfaceColor,
+          border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: kBorderColor)),
+          enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: kBorderColor)),
+          focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: kSeriesPalette.primary)),
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        ),
+        onSubmitted: (_) => _fetch(),
+      );
+    }
+
+    return RawAutocomplete<SeriesEntry>(
+      textEditingController: _seriesImdbCtrl,
+      focusNode: _seriesImdbFocusNode,
+      displayStringForOption: (e) => e.imdbId,
+      optionsBuilder: (v) {
+        if (v.text.isEmpty) return series;
+        final q = v.text.toLowerCase();
+        return series.where(
+          (e) => e.title.toLowerCase().contains(q) || e.imdbId.toLowerCase().contains(q),
+        );
+      },
+      onSelected: (e) {
+        _seriesImdbCtrl.text = e.imdbId;
+      },
+      optionsViewBuilder: (context, onSelected, options) => Align(
+        alignment: Alignment.topLeft,
+        child: Material(
+          color: kSurfaceColor,
+          elevation: 4,
+          borderRadius: BorderRadius.circular(8),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 180),
+            child: ListView.builder(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              shrinkWrap: true,
+              itemCount: options.length,
+              itemBuilder: (context, index) {
+                final entry = options.elementAt(index);
+                return InkWell(
+                  onTap: () => onSelected(entry),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            entry.title,
+                            style: TextStyle(fontSize: 12, color: kTextPrimary),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(entry.imdbId,
+                            style: TextStyle(fontSize: 11, color: kTextMuted)),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+      fieldViewBuilder: (context, controller, focusNode, onSubmitted) => TextField(
+        controller: controller,
+        focusNode: focusNode,
+        onSubmitted: (_) { onSubmitted(); _fetch(); },
+        style: TextStyle(fontSize: 13, color: kTextPrimary),
+        decoration: InputDecoration(
+          hintText: 'Series  (search title or paste tt…)',
+          hintStyle: TextStyle(fontSize: 13, color: kTextMuted),
+          filled: true,
+          fillColor: kSurfaceColor,
+          border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: kBorderColor)),
+          enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: kBorderColor)),
+          focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: kSeriesPalette.primary)),
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        ),
+      ),
     );
   }
 
@@ -635,7 +1033,7 @@ class _AdminScreenState extends State<AdminScreen> {
     return List.generate(count, (i) => i + 1);
   }
 
-  Widget _buildDateEditor() {
+  Widget _buildDateEditor({String label = 'Date'}) {
     final currentYear = DateTime.now().year;
     final years = List.generate(currentYear - 1899, (i) => currentYear - i);
     final days = _daysInMonth(_selectedYear ?? currentYear, _selectedMonth);
@@ -646,7 +1044,7 @@ class _AdminScreenState extends State<AdminScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _SectionHeader(
-          label: 'Date',
+          label: label,
           subtitle: 'API provides year only — fill in month and day if known',
         ),
         const SizedBox(height: 8),
@@ -1122,6 +1520,140 @@ class _AdminScreenState extends State<AdminScreen> {
     );
   }
 
+  // ── Episode section (series mode only) ───────────────────────────────────
+
+  Widget _buildEpisodeSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _SectionHeader(
+          label: 'Episode',
+          subtitle: 'Auto-filled from IMDB — edit if needed',
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            SizedBox(
+              width: 90,
+              child: _extrasField(controller: _seasonCtrl, hint: 'season #'),
+            ),
+            const SizedBox(width: 8),
+            SizedBox(
+              width: 90,
+              child: _extrasField(controller: _episodeCtrl, hint: 'episode #'),
+            ),
+          ],
+        ),
+        if (_episodeData != null) ...[
+          const SizedBox(height: 10),
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: kSurfaceColor,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                  color: kSeriesPalette.primary.withValues(alpha: 0.3)),
+            ),
+            child: Row(
+              children: [
+                if (_episodeData!.posterUrl.isNotEmpty) ...[
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(6),
+                    child: SizedBox(
+                      width: 80,
+                      height: 45,
+                      child: CachedNetworkImage(
+                        imageUrl: _episodeData!.posterUrl,
+                        fit: BoxFit.cover,
+                        cacheManager: CatalogCacheManager.instance,
+                        errorWidget: (_, _, _) =>
+                            Container(color: kSurface2Color),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                ],
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        _episodeData!.title,
+                        style: const TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: kTextPrimary),
+                      ),
+                      if (_episodeData!.releaseDate != null) ...[
+                        const SizedBox(height: 3),
+                        Text(
+                          _fmtDate(_episodeData!.releaseDate!),
+                          style: const TextStyle(
+                              fontSize: 11, color: kTextSecondary),
+                        ),
+                      ],
+                      if (_episodeData!.rating != null) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          '★ ${_episodeData!.rating!.toStringAsFixed(1)}',
+                          style: const TextStyle(
+                              fontSize: 11, color: Color(0xFFF5C518)),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  static String _fmtDate(DateTime d) {
+    final m = d.month.toString().padLeft(2, '0');
+    final day = d.day.toString().padLeft(2, '0');
+    return '${d.year}-$m-$day';
+  }
+
+  List<String> get _seriesRowValues {
+    final d = _data!;
+    return [
+      _imdbIdCtrl.text.trim(),                    // series_imdb_id
+      d.title,                                    // title
+      d.releaseDate?.year.toString() ?? '',       // start_year
+      d.endYear?.toString() ?? '',                // end_year
+      d.posterUrl,                                // poster_url
+      d.plot,                                     // plot
+      d.rating?.toStringAsFixed(1) ?? '',         // rating
+      _genres.join(', '),                         // genres
+      _tags.join(', '),                           // tags
+      _show ? 'TRUE' : 'FALSE',                   // show
+    ];
+  }
+
+  List<String> get _episodeRowValues {
+    final ep = _episodeData!;
+    return [
+      _imdbIdCtrl.text.trim(),                    // episode_imdb_id
+      _seriesImdbCtrl.text.trim(),                // series_imdb_id
+      _seasonCtrl.text.trim(),                    // season
+      _episodeCtrl.text.trim(),                   // episode
+      ep.title,                                   // title
+      _dateResult,                                // air_date
+      ep.posterUrl,                               // thumbnail_url
+      ep.plot,                                    // plot
+      ep.rating?.toStringAsFixed(1) ?? '',        // rating
+      _videoUrlCtrl.text.trim(),                  // video_url
+      _sizeMbCtrl.text.trim(),                    // size_mb
+      _languageCtrl.text.trim(),                  // language
+      _encoded ? 'TRUE' : 'FALSE',                // encoded
+      _show    ? 'TRUE' : 'FALSE',                // show
+    ];
+  }
+
   // ── Row extras ────────────────────────────────────────────────────────────
 
   Widget _buildRowExtras() {
@@ -1284,7 +1816,25 @@ class _AdminScreenState extends State<AdminScreen> {
   }
 
   Widget _buildResults() {
-    final values = _rowValues;
+    final List<String> values;
+    final List<String> columns;
+    final String tsvRow;
+    switch (_mode) {
+      case _AdminMode.movie:
+        values  = _rowValues;
+        columns = SheetSchema.columns;
+        tsvRow  = SheetSchema.buildTsv(values);
+      case _AdminMode.series:
+        values  = _seriesRowValues;
+        columns = SeriesSheetSchema.columns;
+        tsvRow  = SeriesSheetSchema.buildTsv(values);
+      case _AdminMode.episode:
+        values  = _episodeData != null
+            ? _episodeRowValues
+            : List.filled(EpisodeSheetSchema.columnCount, '');
+        columns = EpisodeSheetSchema.columns;
+        tsvRow  = EpisodeSheetSchema.buildTsv(values);
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1298,7 +1848,7 @@ class _AdminScreenState extends State<AdminScreen> {
               ),
             ),
             FilledButton.icon(
-              onPressed: () => _copy(SheetSchema.buildTsv(values)),
+              onPressed: () => _copy(tsvRow),
               icon: const Icon(Icons.table_rows_rounded, size: 14),
               label: const Text('Copy row'),
               style: FilledButton.styleFrom(
@@ -1322,10 +1872,10 @@ class _AdminScreenState extends State<AdminScreen> {
           ),
           child: Column(
             children: [
-              for (var i = 0; i < SheetSchema.columns.length; i++) ...[
+              for (var i = 0; i < columns.length; i++) ...[
                 if (i > 0) Divider(height: 1, color: kBorderColor),
                 _ResultRow(
-                  label: SheetSchema.columns[i],
+                  label: columns[i],
                   value: values[i],
                   onCopy: values[i].isNotEmpty ? () => _copy(values[i]) : null,
                 ),
@@ -1871,6 +2421,7 @@ class _TagEditorChip extends StatelessWidget {
     );
   }
 }
+
 
 class _ResultRow extends StatefulWidget {
   final String label;

--- a/lib/features/catalog/catalog_notifier.dart
+++ b/lib/features/catalog/catalog_notifier.dart
@@ -273,12 +273,14 @@ class _DownloadJob {
   final String url;
   final String suggestedFilename;
   final String title;
+  final String? subtitle;
   final String thumbnailUrl;
 
   const _DownloadJob({
     required this.url,
     required this.suggestedFilename,
     required this.title,
+    this.subtitle,
     required this.thumbnailUrl,
   });
 }
@@ -289,6 +291,7 @@ class _DownloadJob {
 
 class DownloadRecord {
   final String title;
+  final String? subtitle;
   final String filename;
   final String filePath;
   final String thumbnailUrl;
@@ -297,6 +300,7 @@ class DownloadRecord {
 
   const DownloadRecord({
     required this.title,
+    this.subtitle,
     required this.filename,
     required this.filePath,
     required this.thumbnailUrl,
@@ -306,6 +310,7 @@ class DownloadRecord {
 
   factory DownloadRecord.fromJson(Map<String, dynamic> j) => DownloadRecord(
         title: j['title'] as String? ?? '',
+        subtitle: j['subtitle'] as String?,
         filename: j['filename'] as String? ?? '',
         filePath: j['filePath'] as String? ?? '',
         thumbnailUrl: j['thumbnailUrl'] as String? ?? '',
@@ -315,6 +320,7 @@ class DownloadRecord {
 
   Map<String, dynamic> toJson() => {
         'title': title,
+        if (subtitle != null) 'subtitle': subtitle,
         'filename': filename,
         'filePath': filePath,
         'thumbnailUrl': thumbnailUrl,
@@ -395,6 +401,7 @@ sealed class DownloadState {}
 class DownloadIdle extends DownloadState {}
 
 class DownloadActive extends DownloadState {
+  final String title;
   final String filename;
   final int receivedBytes;
   final int totalBytes;
@@ -402,6 +409,7 @@ class DownloadActive extends DownloadState {
   final int queueRemaining;
 
   DownloadActive({
+    required this.title,
     required this.filename,
     required this.receivedBytes,
     required this.totalBytes,
@@ -447,12 +455,13 @@ class DownloadNotifier extends Notifier<DownloadState> {
 
   /// Adds a job to the queue and starts processing if not already running.
   void enqueue(String url, String suggestedFilename, String title,
-      String thumbnailUrl) {
+      String thumbnailUrl, {String? subtitle}) {
     if (!_running) _cancelled = false;
     _queue.add(_DownloadJob(
       url: url,
       suggestedFilename: suggestedFilename,
       title: title,
+      subtitle: subtitle,
       thumbnailUrl: thumbnailUrl,
     ));
     if (!_running) _processQueue();
@@ -489,6 +498,7 @@ class DownloadNotifier extends Notifier<DownloadState> {
 
     if (!_disposed) {
       state = DownloadActive(
+        title: job.title,
         filename: filename.isNotEmpty ? filename : 'Connecting…',
         receivedBytes: 0,
         totalBytes: 0,
@@ -518,6 +528,7 @@ class DownloadNotifier extends Notifier<DownloadState> {
 
     if (!_cancelled && !_disposed) {
       state = DownloadActive(
+        title: job.title,
         filename: filename,
         receivedBytes: 0,
         totalBytes: total,
@@ -541,6 +552,7 @@ class DownloadNotifier extends Notifier<DownloadState> {
         final elapsed = now.difference(lastTick).inMilliseconds;
         if (elapsed >= 300 && !_cancelled && !_disposed) {
           state = DownloadActive(
+            title: job.title,
             filename: filename,
             receivedBytes: received,
             totalBytes: total,
@@ -565,6 +577,7 @@ class DownloadNotifier extends Notifier<DownloadState> {
     // Record in history.
     await ref.read(downloadHistoryProvider.notifier).add(DownloadRecord(
           title: job.title,
+          subtitle: job.subtitle,
           filename: filename,
           filePath: file.path,
           thumbnailUrl: job.thumbnailUrl,

--- a/lib/features/catalog/catalog_screen.dart
+++ b/lib/features/catalog/catalog_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:math' show min;
+import 'dart:ui' show ImageFilter;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -17,10 +18,16 @@ import '../../core/theme/tab_colors.dart';
 import '../shell/app_shell.dart';
 import 'catalog_notifier.dart';
 import 'models/catalog_entry.dart';
+import 'models/series_entry.dart';
+import 'screens/series_detail_screen.dart';
+import 'series_notifier.dart';
 import 'widgets/catalog_card.dart';
+import 'widgets/series_card.dart';
 import 'widgets/webview_overlay.dart';
 
 enum _SortMode { alpha, date, rating }
+
+const _kBarHeight = 64.0;
 
 class CatalogScreen extends ConsumerStatefulWidget {
   const CatalogScreen({super.key});
@@ -43,7 +50,13 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
   Set<int> _filterYears = {};
   bool _filterDownloaded = false;
 
-  // Expanded card overlay state
+  // Sub-tab (Movies / Series) — plain int, no TabController, no animation delay
+  int _subTabIndex = 0;
+
+  // Open series detail (null = show grid)
+  SeriesEntry? _openedSeries;
+
+  // Movies expanded card overlay state
   CatalogEntry? _expandedEntry;
   Rect _expandedLocalRect = Rect.zero;
   Rect _bodyLocalRect = Rect.zero;
@@ -52,10 +65,13 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
     vsync: this,
     duration: const Duration(milliseconds: 320),
   );
+
+
   final _bodyKey = GlobalKey();
 
   static const _kSortMode = 'catalog_sort_mode';
   static const _kSortAsc  = 'catalog_sort_asc';
+  static const _kSubTab   = 'catalog_sub_tab';
 
   @override
   void initState() {
@@ -64,10 +80,10 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _focusNode.requestFocus();
     });
-    _loadSort();
+    _loadPrefs();
   }
 
-  Future<void> _loadSort() async {
+  Future<void> _loadPrefs() async {
     final prefs = await SharedPreferences.getInstance();
     if (!mounted) return;
     final modeStr = prefs.getString(_kSortMode);
@@ -77,7 +93,11 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
       'rating' => _SortMode.rating,
       _        => _SortMode.alpha,
     };
-    setState(() { _sortMode = mode; _sortAsc = asc; });
+    final subTab = prefs.getInt(_kSubTab) ?? 0;
+    setState(() { _sortMode = mode; _sortAsc = asc; _subTabIndex = subTab; });
+    if (subTab == 1) {
+      ref.read(catalogSubPaletteProvider.notifier).state = kSeriesPalette;
+    }
   }
 
   Future<void> _saveSort(_SortMode mode, bool asc) async {
@@ -92,6 +112,7 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
     _urlController.dispose();
     _searchController.dispose();
     _focusNode.dispose();
+    ref.read(catalogSubPaletteProvider.notifier).state = null;
     _expandAnim.dispose();
     super.dispose();
   }
@@ -109,6 +130,18 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
       // Shift+D is Google Photos' in-WebView download shortcut — ignore it here.
       if (HardwareKeyboard.instance.isShiftPressed) return false;
       setState(() => _showDownloads = !_showDownloads);
+      return true;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.escape && _openedSeries != null) {
+      setState(() => _openedSeries = null);
+      return true;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.f5) {
+      final url = ref.read(sheetUrlProvider);
+      if (url != null) {
+        ref.read(catalogProvider.notifier).load(url, forceRefresh: true);
+        ref.read(seriesProvider.notifier).load(url, forceRefresh: true);
+      }
       return true;
     }
     return false;
@@ -140,11 +173,27 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
     });
   }
 
+  void _switchSubTab(int index) {
+    setState(() {
+      _subTabIndex = index;
+      if (index != 1) _openedSeries = null;
+    });
+    ref.read(catalogSubPaletteProvider.notifier).state =
+        index == 1 ? kSeriesPalette : null;
+    SharedPreferences.getInstance().then((p) => p.setInt(_kSubTab, index));
+  }
+
+  void _onSeriesCardExpand(SeriesEntry entry) {
+    setState(() => _openedSeries = entry);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final palette = AppTab.catalog.palette;
+    final isSeriesTab = _subTabIndex == 1;
+    final palette = isSeriesTab ? kSeriesPalette : AppTab.catalog.palette;
     final sheetUrl = ref.watch(sheetUrlProvider);
     final catalogState = ref.watch(catalogProvider);
+    final seriesState = ref.watch(seriesProvider);
     final downloadState = ref.watch(downloadProvider);
     final downloadHistory = ref.watch(downloadHistoryProvider);
     final historyCount = downloadHistory.length;
@@ -153,6 +202,11 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
     if (sheetUrl != null && catalogState is CatalogIdle) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ref.read(catalogProvider.notifier).load(sheetUrl);
+      });
+    }
+    if (sheetUrl != null && seriesState is SeriesCatalogIdle) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(seriesProvider.notifier).load(sheetUrl);
       });
     }
 
@@ -192,7 +246,7 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
         return KeyEventResult.ignored;
       },
       child: Padding(
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, _kBarHeight),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -207,24 +261,29 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
               onSubmitUrl: (url) async {
                 await ref.read(sheetUrlProvider.notifier).save(url);
                 ref.read(catalogProvider.notifier).load(url);
+                ref.read(seriesProvider.notifier).load(url, forceRefresh: true);
               },
               onRefresh: _showDownloads
                   ? () =>
                       ref.read(downloadHistoryProvider.notifier).pruneDeleted()
                   : sheetUrl != null
-                      ? () => ref.read(catalogProvider.notifier).load(sheetUrl, forceRefresh: true)
+                      ? () {
+                          ref.read(catalogProvider.notifier).load(sheetUrl, forceRefresh: true);
+                          ref.read(seriesProvider.notifier).load(sheetUrl, forceRefresh: true);
+                        }
                       : null,
               onClearUrl: () {
                 ref.read(sheetUrlProvider.notifier).clear();
                 ref.read(catalogProvider.notifier).reset();
+                ref.read(seriesProvider.notifier).reset();
               },
               onToggleDownloads: () =>
                   setState(() => _showDownloads = !_showDownloads),
             ),
             const SizedBox(height: 12),
-            if (!_showDownloads && catalogState is CatalogLoaded) ...[
+            if (!isSeriesTab && !_showDownloads && catalogState is CatalogLoaded) ...[
               _SortFilterBar(
-                entries: (catalogState).entries,
+                entries: catalogState.entries,
                 sortMode: _sortMode,
                 sortAsc: _sortAsc,
                 filterLanguages: _filterLanguages,
@@ -277,6 +336,13 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
                                 ref.read(activeTabProvider.notifier).state =
                                     AppTab.player;
                               },
+                            )
+                          : isSeriesTab
+                          ? _SeriesBody(
+                              state: seriesState,
+                              search: _search,
+                              downloadedTitles: downloadedTitles,
+                              onCardExpand: _onSeriesCardExpand,
                             )
                           : _Body(
                               state: catalogState,
@@ -335,9 +401,33 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
 
     // Outer Stack: backdrop covers the full catalog area (TopBar included);
     // card is clamped to the body area below the TopBar.
-    return Stack(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      color: isSeriesTab
+          ? kSeriesPalette.surface
+          : AppTab.catalog.palette.surface,
+      child: _openedSeries != null
+          ? SeriesDetailScreen(
+              key: ValueKey(_openedSeries!.title),
+              entry: _openedSeries!,
+              onBack: () => setState(() => _openedSeries = null),
+            )
+          : Stack(
       children: [
         catalogUi,
+        if (!_showDownloads)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: _SubTabBar(
+              activeIndex: _subTabIndex,
+              surfaceColor: isSeriesTab
+                  ? kSeriesPalette.surface
+                  : AppTab.catalog.palette.surface,
+              onChanged: _switchSubTab,
+            ),
+          ),
         if (_expandedEntry != null) ...[
           FadeTransition(
             opacity: fadeAnim,
@@ -363,6 +453,7 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
           ),
         ],
       ],
+    ),
     );
   }
 
@@ -1235,7 +1326,7 @@ class _EmptyState extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.photo_library_outlined, size: 48, color: kTextMuted)
+          Icon(Icons.video_library_outlined, size: 48, color: kTextMuted)
               .animate(onPlay: (c) => c.repeat(reverse: true))
               .scaleXY(begin: 0.92, end: 1.0, duration: 1800.ms, curve: Curves.easeInOut),
           const SizedBox(height: 16),
@@ -1365,12 +1456,27 @@ class _DownloadsListView extends ConsumerWidget {
           record: rec,
           palette: palette,
           decodedVideoPath: decodedPath,
-          onOpenFolder: () =>
-              Process.run('explorer.exe', [p.dirname(rec.filePath)]),
+          onOpenFolder: () {
+            final folder = decodedPath != null
+                ? p.dirname(decodedPath)
+                : p.dirname(rec.filePath);
+            Process.run('explorer.exe', [folder]);
+          },
           onDecode: () => onDecodeFile(rec.filePath),
           onPlay: decodedPath != null ? () => onPlayFile(decodedPath) : null,
-          onDelete: () =>
-              ref.read(downloadHistoryProvider.notifier).remove(rec.filePath),
+          onDelete: () {
+            try {
+              final f = File(rec.filePath);
+              if (f.existsSync()) f.deleteSync();
+            } catch (_) {}
+            if (decodedPath != null) {
+              try {
+                final dir = Directory(p.dirname(decodedPath));
+                if (dir.existsSync()) dir.deleteSync(recursive: true);
+              } catch (_) {}
+            }
+            ref.read(downloadHistoryProvider.notifier).remove(rec.filePath);
+          },
         );
       },
     );
@@ -1451,6 +1557,16 @@ class _DownloadRecordRow extends StatelessWidget {
                           fontSize: titleSize,
                           fontWeight: FontWeight.w500,
                           color: fileExists ? kTextPrimary : kTextMuted)),
+                  if (record.subtitle != null) ...[
+                    const SizedBox(height: 1),
+                    Text(record.subtitle!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                            fontSize: metaSize,
+                            color: kSeriesPalette.primary.withValues(alpha: 0.8),
+                            fontWeight: FontWeight.w500)),
+                  ],
                   const SizedBox(height: 2),
                   Text(record.filename,
                       maxLines: 1,
@@ -1463,7 +1579,7 @@ class _DownloadRecordRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 8),
-            if (!fileExists)
+            if (!fileExists && decodedVideoPath == null)
               Tooltip(
                 message: 'File no longer exists on disk',
                 child: Icon(Icons.warning_amber_rounded,
@@ -1501,8 +1617,44 @@ class _DownloadRecordRow extends StatelessWidget {
             IconButton(
               icon: const Icon(Icons.delete_outline_rounded, color: kTextMuted),
               iconSize: iconSize,
-              tooltip: 'Remove from history',
-              onPressed: onDelete,
+              tooltip: 'Delete file',
+              onPressed: () => showDialog(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  backgroundColor: kSurfaceColor,
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12)),
+                  title: const Text('Delete download?',
+                      style: TextStyle(
+                          color: kTextPrimary,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600)),
+                  content: Text(
+                    decodedVideoPath != null
+                        ? 'This will permanently delete the decoded video folder and remove this entry from your download history.'
+                        : 'This will permanently delete the file from disk and remove it from your download history.',
+                    style: const TextStyle(
+                        color: kTextSecondary, fontSize: 13),
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx),
+                      child: const Text('Cancel',
+                          style: TextStyle(color: kTextMuted)),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        Navigator.pop(ctx);
+                        onDelete();
+                      },
+                      child: const Text('Delete',
+                          style: TextStyle(
+                              color: Colors.redAccent,
+                              fontWeight: FontWeight.w600)),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ],
         ),
@@ -1905,6 +2057,319 @@ class _ClearBtn extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-tab bottom bar — Movies / Series
+// ---------------------------------------------------------------------------
+
+class _SubTabBar extends StatelessWidget {
+  final int activeIndex;
+  final Color surfaceColor;
+  final ValueChanged<int> onChanged;
+
+  const _SubTabBar({
+    required this.activeIndex,
+    required this.surfaceColor,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                surfaceColor.withValues(alpha: 0.0),
+                surfaceColor.withValues(alpha: 0.92),
+              ],
+              stops: const [0.0, 0.38],
+            ),
+          ),
+          alignment: Alignment.bottomCenter,
+          padding: const EdgeInsets.only(bottom: 6),
+          child: Stack(
+            children: [
+              Row(
+                children: [
+                  _SubTabItem(
+                    icon: Icons.movie_rounded,
+                    label: 'Movies',
+                    active: activeIndex == 0,
+                    palette: AppTab.catalog.palette,
+                    onTap: () => onChanged(0),
+                  ),
+                  _SubTabItem(
+                    icon: Icons.live_tv_rounded,
+                    label: 'Series',
+                    active: activeIndex == 1,
+                    palette: kSeriesPalette,
+                    onTap: () => onChanged(1),
+                  ),
+                ],
+              ),
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                height: 2,
+                child: AnimatedAlign(
+                  duration: const Duration(milliseconds: 260),
+                  curve: Curves.easeInOut,
+                  alignment: activeIndex == 0
+                      ? Alignment.centerLeft
+                      : Alignment.centerRight,
+                  child: FractionallySizedBox(
+                    widthFactor: 0.5,
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 260),
+                      color: activeIndex == 0
+                          ? AppTab.catalog.palette.primary
+                          : kSeriesPalette.primary,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SubTabItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool active;
+  final TabPalette palette;
+  final VoidCallback onTap;
+
+  const _SubTabItem({
+    required this.icon,
+    required this.label,
+    required this.active,
+    required this.palette,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = active ? palette.primary : kTextMuted;
+    return Expanded(
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 18, color: color),
+              const SizedBox(height: 3),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: active ? FontWeight.w600 : FontWeight.normal,
+                  color: color,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Series body — handles the four catalog states
+// ---------------------------------------------------------------------------
+
+class _SeriesBody extends StatelessWidget {
+  final SeriesCatalogState state;
+  final String search;
+  final Set<String> downloadedTitles;
+  final void Function(SeriesEntry) onCardExpand;
+
+  const _SeriesBody({
+    required this.state,
+    required this.search,
+    required this.downloadedTitles,
+    required this.onCardExpand,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state) {
+      SeriesCatalogIdle()    => _SeriesEmptyState(),
+      SeriesCatalogLoading() => Center(
+          child: CircularProgressIndicator(color: kSeriesPalette.primary)),
+      SeriesCatalogError(:final message) => _ErrorState(message: message),
+      SeriesCatalogLoaded(:final series) => series.isEmpty
+          ? _SeriesEmptyState()
+          : _SeriesGrid(
+              all: series,
+              filtered: _filter(series),
+              downloadedTitles: downloadedTitles,
+              onCardExpand: onCardExpand,
+            ),
+    };
+  }
+
+  List<SeriesEntry> _filter(List<SeriesEntry> all) {
+    if (search.isEmpty) return all;
+    final q = search.toLowerCase();
+    return all.where((e) {
+      return e.title.toLowerCase().contains(q) ||
+          e.plot.toLowerCase().contains(q) ||
+          e.genres.any((g) => g.toLowerCase().contains(q)) ||
+          e.tags.any((t) => t.toLowerCase().contains(q));
+    }).toList();
+  }
+}
+
+class _SeriesEmptyState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.live_tv_outlined, size: 48, color: kTextMuted)
+              .animate(onPlay: (c) => c.repeat(reverse: true))
+              .scaleXY(
+                  begin: 0.92,
+                  end: 1.0,
+                  duration: 1800.ms,
+                  curve: Curves.easeInOut),
+          const SizedBox(height: 16),
+          const Text(
+            'No series yet',
+            style: TextStyle(
+                fontSize: 16, fontWeight: FontWeight.w600, color: kTextPrimary),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Add a "Series" tab to your spreadsheet to get started.',
+            style: TextStyle(fontSize: 13, color: kTextMuted),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SeriesGrid extends StatefulWidget {
+  final List<SeriesEntry> all;
+  final List<SeriesEntry> filtered;
+  final Set<String> downloadedTitles;
+  final void Function(SeriesEntry) onCardExpand;
+
+  const _SeriesGrid({
+    required this.all,
+    required this.filtered,
+    required this.downloadedTitles,
+    required this.onCardExpand,
+  });
+
+  @override
+  State<_SeriesGrid> createState() => _SeriesGridState();
+}
+
+class _SeriesGridState extends State<_SeriesGrid> {
+  double _aspectRatio = 2 / 3;
+  final _ratios = <double>[];
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveRatios(widget.all);
+  }
+
+  @override
+  void didUpdateWidget(_SeriesGrid old) {
+    super.didUpdateWidget(old);
+    if (old.all != widget.all) {
+      final oldUrls = old.all.map((e) => e.posterUrl).toSet();
+      final newEntries = widget.all
+          .where((e) =>
+              e.posterUrl.isNotEmpty && !oldUrls.contains(e.posterUrl))
+          .toList();
+      if (newEntries.isNotEmpty) _resolveRatios(newEntries);
+    }
+  }
+
+  void _resolveRatios(List<SeriesEntry> entries) {
+    final urls =
+        entries.map((e) => e.posterUrl).where((u) => u.isNotEmpty).toSet();
+    for (final url in urls) {
+      final provider = CachedNetworkImageProvider(url,
+          cacheManager: CatalogCacheManager.instance);
+      final stream = provider.resolve(const ImageConfiguration());
+      late ImageStreamListener listener;
+      listener = ImageStreamListener(
+        (ImageInfo info, _) {
+          stream.removeListener(listener);
+          final w = info.image.width;
+          final h = info.image.height;
+          if (h > 0) _onRatio(w / h);
+        },
+        onError: (_, _) => stream.removeListener(listener),
+      );
+      stream.addListener(listener);
+    }
+  }
+
+  void _onRatio(double ratio) {
+    _ratios.add(ratio);
+    final portraits = _ratios.where((r) => r < 1.0).toList();
+    if (portraits.isEmpty) return;
+    final sorted = List<double>.from(portraits)..sort();
+    final median = sorted[sorted.length ~/ 2];
+    if ((median - _aspectRatio).abs() > 0.02 && mounted) {
+      setState(() => _aspectRatio = median);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.filtered.isEmpty) {
+      return Center(
+        child: Text('No results.',
+            style: TextStyle(color: kTextMuted, fontSize: 14)),
+      );
+    }
+    return MasonryGridView.builder(
+      gridDelegate: const SliverSimpleGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 200,
+      ),
+      mainAxisSpacing: 12,
+      crossAxisSpacing: 12,
+      itemCount: widget.filtered.length,
+      itemBuilder: (_, i) {
+        final entry = widget.filtered[i];
+        return SeriesCard(
+          key: ValueKey(entry.title),
+          entry: entry,
+          aspectRatio: _aspectRatio,
+          isDownloaded:
+              widget.downloadedTitles.any((t) => t.startsWith(entry.title)),
+          onExpand: () => widget.onCardExpand(entry),
+        )
+            .animate()
+            .fadeIn(
+                duration: 280.ms,
+                delay: Duration(milliseconds: min(i, 9) * 35))
+            .slideY(begin: 0.06, duration: 280.ms, curve: Curves.easeOut);
+      },
     );
   }
 }

--- a/lib/features/catalog/models/episode_sheet_schema.dart
+++ b/lib/features/catalog/models/episode_sheet_schema.dart
@@ -1,0 +1,50 @@
+/// Canonical column order for the Episodes tab in the Google Sheet.
+/// One row per episode; episode_imdb_id is the primary key,
+/// series_imdb_id is the foreign key → Series tab.
+class EpisodeSheetSchema {
+  EpisodeSheetSchema._();
+
+  static const List<String> columns = [
+    'episode_imdb_id',  // 0 — primary key
+    'series_imdb_id',   // 1 — FK → Series.series_imdb_id
+    'season',           // 2
+    'episode',          // 3
+    'title',            // 4
+    'air_date',         // 5 — YYYY-MM-DD
+    'thumbnail_url',    // 6 — wide episode still
+    'plot',             // 7 — episode-specific plot
+    'rating',           // 8
+    'video_url',        // 9
+    'size_mb',          // 10
+    'language',         // 11
+    'encoded',          // 12 — TRUE / FALSE
+    'show',             // 13 — TRUE / FALSE
+  ];
+
+  static const int iEpisodeImdbId = 0;
+  static const int iSeriesImdbId  = 1;
+  static const int iSeason        = 2;
+  static const int iEpisode       = 3;
+  static const int iTitle         = 4;
+  static const int iAirDate       = 5;
+  static const int iThumbnailUrl  = 6;
+  static const int iPlot          = 7;
+  static const int iRating        = 8;
+  static const int iVideoUrl      = 9;
+  static const int iSizeMb        = 10;
+  static const int iLanguage      = 11;
+  static const int iEncoded       = 12;
+  static const int iShow          = 13;
+
+  static const int columnCount = 14;
+
+  static String get headerTsv => columns.join('\t');
+
+  static List<String> parseTsv(String tsv) {
+    final parts = tsv.split('\t').map((s) => s.trim()).toList();
+    while (parts.length < columnCount) { parts.add(''); }
+    return parts;
+  }
+
+  static String buildTsv(List<String> values) => values.join('\t');
+}

--- a/lib/features/catalog/models/imdb_data.dart
+++ b/lib/features/catalog/models/imdb_data.dart
@@ -10,6 +10,12 @@ class ImdbData {
   final int? runtimeSeconds;
   final List<String> stars;
   final String? certificate;
+  // TV series fields — null for movies / episodes
+  final int? endYear; // end year for tvSeries (null if ongoing or not a series)
+  // TV episode fields — null for movies / series
+  final int? seasonNumber;
+  final int? episodeNumber;
+  final String? parentId; // parent series IMDB ID
 
   const ImdbData({
     required this.id,
@@ -23,6 +29,10 @@ class ImdbData {
     required this.runtimeSeconds,
     required this.stars,
     required this.certificate,
+    this.endYear,
+    this.seasonNumber,
+    this.episodeNumber,
+    this.parentId,
   });
 
   /// Parse from the live API response.
@@ -70,6 +80,21 @@ class ImdbData {
         ? (certs.first as Map<String, dynamic>)['rating']?.toString()
         : null;
 
+    final endYear = json['endYear'] as int?;
+
+    // TV episode: season / episode number and parent series ID.
+    // API may return these flat or nested under an "episode" object.
+    final epObj = json['episode'] as Map<String, dynamic>?;
+    final seasonNumber = (json['seasonNumber'] as num?)?.toInt()
+        ?? (epObj?['seasonNumber'] as num?)?.toInt();
+    final episodeNumber = (json['episodeNumber'] as num?)?.toInt()
+        ?? (epObj?['episodeNumber'] as num?)?.toInt();
+    // Parent series ID: try several common field names.
+    final seriesObj = json['series'] as Map<String, dynamic>?;
+    final parentId = json['seriesId'] as String?
+        ?? json['parentId'] as String?
+        ?? seriesObj?['id'] as String?;
+
     return ImdbData(
       id: json['id'] as String? ?? '',
       // API field is primaryTitle, not title
@@ -83,6 +108,10 @@ class ImdbData {
       runtimeSeconds: json['runtimeSeconds'] as int?,
       stars: stars,
       certificate: certificate,
+      endYear: endYear,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+      parentId: parentId?.isNotEmpty == true ? parentId : null,
     );
   }
 
@@ -101,6 +130,10 @@ class ImdbData {
         runtimeSeconds: j['runtimeSeconds'] as int?,
         stars: (j['stars'] as List<dynamic>? ?? []).map((s) => '$s').toList(),
         certificate: j['certificate'] as String?,
+        endYear: j['endYear'] as int?,
+        seasonNumber: j['seasonNumber'] as int?,
+        episodeNumber: j['episodeNumber'] as int?,
+        parentId: j['parentId'] as String?,
       );
 
   Map<String, dynamic> toJson() => {
@@ -115,5 +148,9 @@ class ImdbData {
         'runtimeSeconds': runtimeSeconds,
         'stars': stars,
         'certificate': certificate,
+        if (endYear != null) 'endYear': endYear,
+        if (seasonNumber != null) 'seasonNumber': seasonNumber,
+        if (episodeNumber != null) 'episodeNumber': episodeNumber,
+        if (parentId != null) 'parentId': parentId,
       };
 }

--- a/lib/features/catalog/models/series_entry.dart
+++ b/lib/features/catalog/models/series_entry.dart
@@ -1,0 +1,108 @@
+class SeriesEntry {
+  final String title;
+  final String imdbId;
+  final String posterUrl;
+  final String plot;
+  final List<String> genres;
+  final List<String> tags;
+  final String? language;
+  final double? imdbRating;
+  final List<SeasonEntry> seasons;
+
+  const SeriesEntry({
+    required this.title,
+    required this.imdbId,
+    required this.posterUrl,
+    required this.plot,
+    required this.genres,
+    required this.tags,
+    this.language,
+    this.imdbRating,
+    required this.seasons,
+  });
+
+  int get totalEpisodes => seasons.fold(0, (s, e) => s + e.episodes.length);
+
+  SeriesEntry withImdb({
+    required String posterUrl,
+    required String plot,
+    required List<String> genres,
+    required double? rating,
+  }) =>
+      SeriesEntry(
+        title: title,
+        imdbId: imdbId,
+        posterUrl: this.posterUrl.isNotEmpty ? this.posterUrl : posterUrl,
+        plot: this.plot.isNotEmpty ? this.plot : plot,
+        genres: this.genres.isNotEmpty ? this.genres : genres,
+        tags: tags,
+        language: language,
+        imdbRating: rating,
+        seasons: seasons,
+      );
+}
+
+class SeasonEntry {
+  final int number;
+  final List<EpisodeEntry> episodes;
+
+  const SeasonEntry({required this.number, required this.episodes});
+}
+
+class EpisodeEntry {
+  final int episodeNumber;
+  final String title;
+  final String imdbId;
+  final DateTime? airDate;
+  final String videoUrl;
+  final int? sizeMb;
+  final bool encoded;
+  final double? imdbRating;
+  final String plot;
+  final String posterUrl;
+  final int? runtimeSeconds;
+
+  const EpisodeEntry({
+    required this.episodeNumber,
+    required this.title,
+    this.imdbId = '',
+    this.airDate,
+    required this.videoUrl,
+    this.sizeMb,
+    required this.encoded,
+    this.imdbRating,
+    this.plot = '',
+    this.posterUrl = '',
+    this.runtimeSeconds,
+  });
+
+  String get displayTitle =>
+      title.isNotEmpty ? title : 'Episode $episodeNumber';
+
+  String get runtimeLabel {
+    if (runtimeSeconds == null) return '';
+    final m = runtimeSeconds! ~/ 60;
+    return m >= 60 ? '${m ~/ 60}h ${m % 60}m' : '${m}m';
+  }
+
+  EpisodeEntry withImdb(
+      {required String title,
+      required DateTime? airDate,
+      required double? rating,
+      required String plot,
+      required String posterUrl,
+      required int? runtimeSeconds}) =>
+      EpisodeEntry(
+        episodeNumber: episodeNumber,
+        title: this.title.isNotEmpty ? this.title : title,
+        imdbId: imdbId,
+        airDate: this.airDate ?? airDate,
+        videoUrl: videoUrl,
+        sizeMb: sizeMb,
+        encoded: encoded,
+        imdbRating: rating,
+        plot: plot,
+        posterUrl: posterUrl,
+        runtimeSeconds: runtimeSeconds,
+      );
+}

--- a/lib/features/catalog/models/series_sheet_schema.dart
+++ b/lib/features/catalog/models/series_sheet_schema.dart
@@ -1,0 +1,41 @@
+/// Canonical column order for the Series tab in the Google Sheet.
+/// One row per TV show; series_imdb_id is the primary key.
+class SeriesSheetSchema {
+  SeriesSheetSchema._();
+
+  static const List<String> columns = [
+    'series_imdb_id',  // 0 — primary key
+    'title',           // 1
+    'start_year',      // 2
+    'end_year',        // 3
+    'poster_url',      // 4
+    'plot',            // 5
+    'rating',          // 6
+    'genres',          // 7 — comma-separated
+    'tags',            // 8 — comma-separated
+    'show',            // 9 — TRUE / FALSE
+  ];
+
+  static const int iSeriesImdbId = 0;
+  static const int iTitle        = 1;
+  static const int iStartYear    = 2;
+  static const int iEndYear      = 3;
+  static const int iPosterUrl    = 4;
+  static const int iPlot         = 5;
+  static const int iRating       = 6;
+  static const int iGenres       = 7;
+  static const int iTags         = 8;
+  static const int iShow         = 9;
+
+  static const int columnCount = 10;
+
+  static String get headerTsv => columns.join('\t');
+
+  static List<String> parseTsv(String tsv) {
+    final parts = tsv.split('\t').map((s) => s.trim()).toList();
+    while (parts.length < columnCount) { parts.add(''); }
+    return parts;
+  }
+
+  static String buildTsv(List<String> values) => values.join('\t');
+}

--- a/lib/features/catalog/screens/series_detail_screen.dart
+++ b/lib/features/catalog/screens/series_detail_screen.dart
@@ -1,0 +1,892 @@
+import 'dart:io';
+import 'dart:ui' show ImageFilter;
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+import '../../../core/providers/decode_request_provider.dart';
+import '../../../core/providers/player_request_provider.dart';
+import '../../../core/services/catalog_cache_manager.dart';
+import '../../../core/services/settings_service.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/theme/tab_colors.dart';
+import '../catalog_notifier.dart'
+    show DownloadActive, DownloadRecord, downloadHistoryProvider, downloadProvider;
+import '../models/series_entry.dart';
+import '../widgets/webview_overlay.dart';
+import '../../shell/app_shell.dart' show activeTabProvider;
+
+class SeriesDetailScreen extends ConsumerStatefulWidget {
+  final SeriesEntry entry;
+  final VoidCallback onBack;
+
+  const SeriesDetailScreen({super.key, required this.entry, required this.onBack});
+
+  @override
+  ConsumerState<SeriesDetailScreen> createState() =>
+      _SeriesDetailScreenState();
+}
+
+class _SeriesDetailScreenState extends ConsumerState<SeriesDetailScreen> {
+  int _seasonIndex = 0;
+
+
+  @override
+  Widget build(BuildContext context) {
+    final e = widget.entry;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _TopBar(title: e.title, onBack: widget.onBack),
+        Divider(height: 1, thickness: 1, color: kBorderColor),
+        Expanded(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: 288,
+                child: _LeftPanel(entry: e),
+              ),
+              VerticalDivider(width: 1, thickness: 1, color: kBorderColor),
+              Expanded(
+                child: _RightPanel(
+                  entry: e,
+                  seasonIndex: _seasonIndex,
+                  onSeasonChanged: (i) => setState(() => _seasonIndex = i),
+                  onEpisodeDownload: _onEpisodeDownload,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _onEpisodeDownload(int seasonNumber, EpisodeEntry ep) {
+    final e = widget.entry;
+    final epCode =
+        'S${seasonNumber.toString().padLeft(2, '0')}E${ep.episodeNumber.toString().padLeft(2, '0')}';
+    showDialog(
+      context: context,
+      barrierColor: Colors.black54,
+      builder: (_) => WebViewOverlay(
+        url: ep.videoUrl,
+        title: ep.displayTitle,
+        onDownloadRequested: (dlUrl, filename) {
+          ref.read(downloadProvider.notifier).enqueue(
+                dlUrl, filename ?? '', ep.displayTitle, e.posterUrl,
+                subtitle: '$epCode — ${e.title}');
+        },
+      ),
+    );
+  }
+
+}
+
+// ---------------------------------------------------------------------------
+// Top bar
+// ---------------------------------------------------------------------------
+
+class _TopBar extends StatelessWidget {
+  final String title;
+  final VoidCallback onBack;
+
+  const _TopBar({required this.title, required this.onBack});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 52,
+      child: Row(
+        children: [
+          InkWell(
+            onTap: onBack,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.arrow_back_rounded,
+                      size: 16, color: kSeriesPalette.primary),
+                  const SizedBox(width: 6),
+                  Text(
+                    'Back',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: kSeriesPalette.primary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w700,
+                color: kTextPrimary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Left panel — poster + meta
+// ---------------------------------------------------------------------------
+
+class _LeftPanel extends StatelessWidget {
+  final SeriesEntry entry;
+
+  const _LeftPanel({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final e = entry;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Poster
+          if (e.posterUrl.isNotEmpty)
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: AspectRatio(
+                aspectRatio: 2 / 3,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    CachedNetworkImage(
+                      imageUrl: e.posterUrl,
+                      cacheManager: CatalogCacheManager.instance,
+                      fit: BoxFit.cover,
+                      placeholder: (_, _) => Container(color: kSurface2Color),
+                      errorWidget: (_, _, _) => Container(color: kSurface2Color),
+                      imageBuilder: (_, ip) => ImageFiltered(
+                        imageFilter:
+                            ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+                        child: Image(image: ip, fit: BoxFit.cover),
+                      ),
+                    ),
+                    Container(color: Colors.black.withValues(alpha: 0.15)),
+                    CachedNetworkImage(
+                      imageUrl: e.posterUrl,
+                      cacheManager: CatalogCacheManager.instance,
+                      fit: BoxFit.cover,
+                      placeholder: (_, _) => const SizedBox.shrink(),
+                      errorWidget: (_, _, _) => const SizedBox.shrink(),
+                    ),
+                    if (e.imdbRating != null)
+                      Positioned(
+                        bottom: 8,
+                        right: 8,
+                        child: _RatingBadge(rating: e.imdbRating!),
+                      ),
+                  ],
+                ),
+              ),
+            )
+          else
+            AspectRatio(
+              aspectRatio: 2 / 3,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: kSurface2Color,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child:
+                    const Icon(Icons.live_tv_rounded, color: kTextMuted, size: 48),
+              ),
+            ),
+
+          const SizedBox(height: 16),
+
+          // Meta pills
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _Pill(
+                icon: Icons.live_tv_rounded,
+                label: e.seasons.length == 1
+                    ? '1 Season'
+                    : '${e.seasons.length} Seasons',
+              ),
+              _Pill(
+                icon: Icons.video_library_rounded,
+                label: '${e.totalEpisodes} Episodes',
+              ),
+              if (e.language != null)
+                _Pill(icon: Icons.translate_rounded, label: e.language!),
+            ],
+          ),
+
+          // Genres
+          if (e.genres.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: e.genres.map((g) => _Tag(tag: g)).toList(),
+            ),
+          ],
+
+          // Tags
+          if (e.tags.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: e.tags.map((t) => _Tag(tag: t, muted: true)).toList(),
+            ),
+          ],
+
+          // Plot
+          if (e.plot.isNotEmpty) ...[
+            const SizedBox(height: 14),
+            Divider(color: kBorderColor),
+            const SizedBox(height: 10),
+            Text(
+              e.plot,
+              style: const TextStyle(
+                fontSize: 12,
+                color: kTextSecondary,
+                height: 1.65,
+              ),
+            ),
+          ],
+
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Right panel — season selector + episode list
+// ---------------------------------------------------------------------------
+
+class _RightPanel extends StatelessWidget {
+  final SeriesEntry entry;
+  final int seasonIndex;
+  final ValueChanged<int> onSeasonChanged;
+  final void Function(int seasonNumber, EpisodeEntry) onEpisodeDownload;
+
+  const _RightPanel({
+    required this.entry,
+    required this.seasonIndex,
+    required this.onSeasonChanged,
+    required this.onEpisodeDownload,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final e = entry;
+
+    if (e.seasons.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.video_library_outlined, size: 48, color: kTextMuted),
+            const SizedBox(height: 16),
+            const Text(
+              'No episodes yet',
+              style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: kTextPrimary),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Add rows to the Episodes sheet to get started.',
+              style: TextStyle(fontSize: 13, color: kTextMuted),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final season = e.seasons[seasonIndex.clamp(0, e.seasons.length - 1)];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Season selector
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 14, 20, 14),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: List.generate(e.seasons.length, (i) {
+                final s = e.seasons[i];
+                final active = i == seasonIndex;
+                return _SeasonPill(
+                  label: 'Season ${s.number}',
+                  count: s.episodes.length,
+                  active: active,
+                  onTap: () => onSeasonChanged(i),
+                );
+              }),
+            ),
+          ),
+        ),
+        Divider(height: 1, thickness: 1, color: kBorderColor),
+        // Episode list
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+            itemCount: season.episodes.length,
+            itemBuilder: (context, i) {
+              final ep = season.episodes[i];
+              return _EpisodeDetailRow(
+                episode: ep,
+                onDownload: () => onEpisodeDownload(season.number, ep),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Season pill selector
+// ---------------------------------------------------------------------------
+
+class _SeasonPill extends StatelessWidget {
+  final String label;
+  final int count;
+  final bool active;
+  final VoidCallback onTap;
+
+  const _SeasonPill({
+    required this.label,
+    required this.count,
+    required this.active,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const palette = kSeriesPalette;
+    final color = active ? palette.primary : kTextMuted;
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
+          decoration: BoxDecoration(
+            color: active
+                ? palette.primary.withValues(alpha: 0.12)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: active
+                  ? palette.primary.withValues(alpha: 0.6)
+                  : kBorderColor,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight:
+                      active ? FontWeight.w600 : FontWeight.w400,
+                  color: color,
+                ),
+              ),
+              const SizedBox(width: 6),
+              Text(
+                '$count ep',
+                style: TextStyle(
+                  fontSize: 10,
+                  color: active ? palette.secondary : kTextMuted,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Episode detail row
+// ---------------------------------------------------------------------------
+
+class _EpisodeDetailRow extends ConsumerStatefulWidget {
+  final EpisodeEntry episode;
+  final VoidCallback onDownload;
+
+  const _EpisodeDetailRow({
+    required this.episode,
+    required this.onDownload,
+  });
+
+  @override
+  ConsumerState<_EpisodeDetailRow> createState() => _EpisodeDetailRowState();
+}
+
+class _EpisodeDetailRowState extends ConsumerState<_EpisodeDetailRow> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    const palette = kSeriesPalette;
+    final ep = widget.episode;
+    final dlState = ref.watch(downloadProvider);
+    final activeDl = dlState is DownloadActive && dlState.title == ep.displayTitle
+        ? dlState
+        : null;
+    final history = ref.watch(downloadHistoryProvider);
+    final downloadRecord = history.cast<DownloadRecord?>().firstWhere(
+      (r) => r!.title == ep.displayTitle && File(r.filePath).existsSync(),
+      orElse: () => null,
+    );
+    final settings = ref.watch(settingsProvider);
+    final decodeDir = settings.decodeOutputDirectory.isEmpty
+        ? AppDirectories.decoded
+        : settings.decodeOutputDirectory;
+    final decodedPath = _decodedVideoPath(decodeDir, ep.displayTitle);
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        margin: const EdgeInsets.only(bottom: 8),
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          color: _hovered ? kSurface2Color : kSurfaceColor,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: _hovered
+                ? palette.primary.withValues(alpha: 0.35)
+                : kBorderColor,
+          ),
+          boxShadow: _hovered
+              ? [BoxShadow(color: palette.glow.withValues(alpha: 0.25), blurRadius: 8)]
+              : [],
+        ),
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Thumbnail — flush left, full card height
+              SizedBox(
+                width: 120,
+                child: ep.posterUrl.isNotEmpty
+                    ? CachedNetworkImage(
+                        imageUrl: ep.posterUrl,
+                        cacheManager: CatalogCacheManager.instance,
+                        fit: BoxFit.cover,
+                        placeholder: (_, _) => Container(color: kSurface2Color),
+                        errorWidget: (_, _, _) =>
+                            Container(color: kSurface2Color),
+                      )
+                    : Container(
+                        color: kSurface2Color,
+                        child: const Icon(Icons.movie_rounded,
+                            size: 22, color: kTextMuted),
+                      ),
+              ),
+              // Content
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 10, 0, 10),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Title row + plot + meta
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            // Episode number + title + rating on one line
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Text(
+                                  'E${ep.episodeNumber.toString().padLeft(2, '0')}',
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w700,
+                                    color: palette.primary,
+                                    fontFamily: 'monospace',
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    ep.displayTitle,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: const TextStyle(
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w600,
+                                      color: kTextPrimary,
+                                    ),
+                                  ),
+                                ),
+                                if (ep.imdbRating != null) ...[
+                                  const SizedBox(width: 8),
+                                  Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      const Icon(Icons.star_rounded,
+                                          size: 11, color: Color(0xFFF5C518)),
+                                      const SizedBox(width: 3),
+                                      Text(
+                                        ep.imdbRating!.toStringAsFixed(1),
+                                        style: const TextStyle(
+                                          fontSize: 11,
+                                          fontWeight: FontWeight.w600,
+                                          color: Color(0xFFF5C518),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ],
+                            ),
+                            if (ep.plot.isNotEmpty) ...[
+                              const SizedBox(height: 5),
+                              Text(
+                                ep.plot,
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  fontSize: 11,
+                                  color: kTextSecondary,
+                                  height: 1.5,
+                                ),
+                              ),
+                            ],
+                            const SizedBox(height: 6),
+                            Row(
+                              children: [
+                                if (ep.airDate != null)
+                                  _MetaChip(label: _fmtDate(ep.airDate!)),
+                                if (ep.runtimeLabel.isNotEmpty) ...[
+                                  const SizedBox(width: 6),
+                                  _MetaChip(label: ep.runtimeLabel),
+                                ],
+                                if (ep.sizeMb != null) ...[
+                                  const SizedBox(width: 6),
+                                  _MetaChip(label: '${ep.sizeMb} MB'),
+                                ],
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                      // Action button: progress → play → decode → download
+                      if (ep.videoUrl.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(left: 10, right: 12),
+                          child: Center(
+                            child: activeDl != null
+                                ? _EpisodeProgressBtn(
+                                    received: activeDl.receivedBytes,
+                                    total: activeDl.totalBytes,
+                                    color: palette.primary,
+                                  )
+                                : decodedPath != null
+                                    ? _ActionBtn(
+                                        icon: Icons.play_circle_rounded,
+                                        label: 'Play',
+                                        color: palette.primary,
+                                        onTap: () {
+                                          ref.read(playerOpenRequestProvider.notifier).state =
+                                              decodedPath;
+                                          ref.read(activeTabProvider.notifier).state =
+                                              AppTab.player;
+                                        },
+                                      )
+                                    : downloadRecord != null
+                                        ? _ActionBtn(
+                                            icon: Icons.lock_open_rounded,
+                                            label: 'Decode',
+                                            color: palette.primary,
+                                            onTap: () {
+                                              ref.read(decodeOpenRequestProvider.notifier).state =
+                                                  downloadRecord.filePath;
+                                              ref.read(activeTabProvider.notifier).state =
+                                                  AppTab.decode;
+                                            },
+                                          )
+                                        : _ActionBtn(
+                                            icon: Icons.download_rounded,
+                                            label: 'Download',
+                                            color: palette.primary,
+                                            onTap: widget.onDownload,
+                                          ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _fmtDate(DateTime d) =>
+      '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+  static const _kVideoExts = {'mp4', 'mkv', 'avi', 'mov', 'webm'};
+
+  static String? _decodedVideoPath(String decodeDir, String title) {
+    final folder = Directory(p.join(decodeDir, title));
+    if (!folder.existsSync()) return null;
+    try {
+      for (final entry in folder.listSync()) {
+        if (entry is File) {
+          final ext = p.extension(entry.path).replaceFirst('.', '').toLowerCase();
+          if (_kVideoExts.contains(ext)) return entry.path;
+        }
+      }
+    } catch (_) {}
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Action button
+// ---------------------------------------------------------------------------
+
+class _ActionBtn extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback onTap;
+
+  const _ActionBtn({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: color.withValues(alpha: 0.25)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 12, color: color),
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Episode download progress button
+// ---------------------------------------------------------------------------
+
+class _EpisodeProgressBtn extends StatelessWidget {
+  final int received;
+  final int total;
+  final Color color;
+
+  const _EpisodeProgressBtn({
+    required this.received,
+    required this.total,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = total > 0 ? received / total : null;
+    final label = progress != null
+        ? '${(progress * 100).toStringAsFixed(0)}%'
+        : 'Loading…';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 12,
+            height: 12,
+            child: CircularProgressIndicator(
+              value: progress,
+              strokeWidth: 2,
+              color: color,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w500,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Meta chip
+// ---------------------------------------------------------------------------
+
+class _MetaChip extends StatelessWidget {
+  final String label;
+  const _MetaChip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: kSurface2Color,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(fontSize: 10, color: kTextMuted),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers (mirrored from series_card.dart)
+// ---------------------------------------------------------------------------
+
+class _RatingBadge extends StatelessWidget {
+  final double rating;
+  const _RatingBadge({required this.rating});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.72),
+        borderRadius: BorderRadius.circular(5),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.star_rounded, size: 10, color: Color(0xFFF5C518)),
+          const SizedBox(width: 3),
+          Text(
+            rating.toStringAsFixed(1),
+            style: const TextStyle(
+              fontSize: 11,
+              color: Colors.white,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Pill extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _Pill({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    const c = kTextSecondary;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: c.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: c.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 11, color: c),
+          const SizedBox(width: 4),
+          Text(label, style: TextStyle(fontSize: 11, color: c)),
+        ],
+      ),
+    );
+  }
+}
+
+class _Tag extends StatelessWidget {
+  final String tag;
+  final bool muted;
+  const _Tag({required this.tag, this.muted = false});
+
+  @override
+  Widget build(BuildContext context) {
+    const palette = kSeriesPalette;
+    final color = muted ? kTextMuted : palette.primary;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(tag, style: TextStyle(fontSize: 11, color: color)),
+    );
+  }
+}

--- a/lib/features/catalog/series_notifier.dart
+++ b/lib/features/catalog/series_notifier.dart
@@ -1,0 +1,442 @@
+import 'dart:async' show unawaited;
+import 'dart:convert';
+import 'dart:io';
+import 'package:csv/csv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import '../../core/theme/tab_colors.dart';
+import 'imdb_service.dart';
+import 'models/imdb_data.dart';
+import 'models/series_entry.dart';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+sealed class SeriesCatalogState {}
+
+class SeriesCatalogIdle extends SeriesCatalogState {}
+
+class SeriesCatalogLoading extends SeriesCatalogState {}
+
+class SeriesCatalogLoaded extends SeriesCatalogState {
+  final List<SeriesEntry> series;
+  SeriesCatalogLoaded(this.series);
+}
+
+class SeriesCatalogError extends SeriesCatalogState {
+  final String message;
+  SeriesCatalogError(this.message);
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+final seriesProvider =
+    StateNotifierProvider<SeriesNotifier, SeriesCatalogState>(
+        (_) => SeriesNotifier());
+
+/// Overrides the catalog tab palette when the Series sub-tab is active.
+/// Null = use the default catalog (amber) palette.
+final catalogSubPaletteProvider = StateProvider<TabPalette?>((ref) => null);
+
+// ---------------------------------------------------------------------------
+// Notifier
+// ---------------------------------------------------------------------------
+
+class SeriesNotifier extends StateNotifier<SeriesCatalogState> {
+  SeriesNotifier() : super(SeriesCatalogIdle());
+
+  static const _kCsvCacheTtl = Duration(hours: 1);
+  String? _cacheDir;
+
+  static String? _extractSheetId(String url) {
+    final match = RegExp(r'/spreadsheets/d/([a-zA-Z0-9_-]+)').firstMatch(url);
+    return match?.group(1);
+  }
+
+  static String _seriesCsvUrl(String sheetId) =>
+      'https://docs.google.com/spreadsheets/d/$sheetId'
+      '/gviz/tq?tqx=out:csv&sheet=Series';
+
+  static String _episodesCsvUrl(String sheetId) =>
+      'https://docs.google.com/spreadsheets/d/$sheetId'
+      '/gviz/tq?tqx=out:csv&sheet=Episodes';
+
+  static String _validBody(http.Response resp) {
+    if (resp.statusCode != 200 || resp.body.trimLeft().startsWith('<')) return '';
+    return resp.body;
+  }
+
+  // ── Cache helpers ──────────────────────────────────────────────────────────
+
+  Future<String> _ensureCacheDir() async {
+    _cacheDir ??= (await getApplicationSupportDirectory()).path;
+    return _cacheDir!;
+  }
+
+  Future<({String series, String episodes, DateTime fetchedAt})?> _loadCache(
+      String sheetId) async {
+    try {
+      final dir  = await _ensureCacheDir();
+      final file = File(p.join(dir, 'catalog_csv_series_$sheetId.json'));
+      if (!file.existsSync()) return null;
+      final map  = jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+      final at   = DateTime.tryParse(map['fetchedAt'] as String? ?? '');
+      if (at == null) return null;
+      return (
+        series:   map['series']   as String? ?? '',
+        episodes: map['episodes'] as String? ?? '',
+        fetchedAt: at,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _saveCache(
+      String sheetId, String seriesBody, String episodesBody) async {
+    try {
+      final dir = await _ensureCacheDir();
+      await File(p.join(dir, 'catalog_csv_series_$sheetId.json'))
+          .writeAsString(jsonEncode({
+        'fetchedAt': DateTime.now().toIso8601String(),
+        'series':   seriesBody,
+        'episodes': episodesBody,
+      }));
+    } catch (_) {}
+  }
+
+  Future<void> _clearCache(String sheetId) async {
+    try {
+      final dir  = await _ensureCacheDir();
+      final file = File(p.join(dir, 'catalog_csv_series_$sheetId.json'));
+      if (file.existsSync()) await file.delete();
+    } catch (_) {}
+  }
+
+  // ── Parsing ────────────────────────────────────────────────────────────────
+
+  static String _norm(String s) =>
+      s.trim().toLowerCase().replaceAll(RegExp(r'[\s_\-]+'), '');
+
+  Future<List<SeriesEntry>> _buildEntries(
+      String seriesCsv, String episodesCsv) async {
+
+    // ── Parse Series tab ────────────────────────────────────────────────────
+    final Map<String, _SeriesFields> seriesById = {};
+    final List<String> seriesOrder = [];
+
+    if (seriesCsv.isNotEmpty) {
+      final norm = seriesCsv.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+      final rows = const CsvToListConverter(eol: '\n').convert(norm);
+
+      if (rows.length >= 2) {
+        final sh = {
+          for (var i = 0; i < rows[0].length; i++)
+            _norm(rows[0][i].toString()): i,
+        };
+
+        String sc(List<dynamic> row, List<String> aliases) {
+          for (final a in aliases) {
+            final idx = sh[a];
+            if (idx != null && idx < row.length) {
+              final v = row[idx].toString().trim();
+              if (v.isNotEmpty) return v;
+            }
+          }
+          return '';
+        }
+
+        final visIdx = sh['show'] ?? sh['enabled'] ?? sh['visible'];
+
+        for (final row in rows.skip(1)) {
+          if (row.isEmpty) continue;
+          if (visIdx != null && visIdx < row.length) {
+            if (row[visIdx].toString().trim().toLowerCase() == 'false') continue;
+          }
+
+          final imdbId = sc(row, ['seriesimdbid', 'imdbid', 'imdb']);
+          if (imdbId.isEmpty) continue;
+
+          if (!seriesById.containsKey(imdbId)) {
+            seriesById[imdbId] = _SeriesFields();
+            seriesOrder.add(imdbId);
+          }
+
+          final meta = seriesById[imdbId]!;
+          if (meta.title.isEmpty) {
+            meta.title = sc(row, ['title', 'seriestitle', 'showtitle', 'name']);
+          }
+          if (meta.posterUrl.isEmpty) {
+            meta.posterUrl = _toPosterUrl(
+                sc(row, ['posterurl', 'poster', 'image', 'imageurl', 'cover']));
+          }
+          if (meta.plot.isEmpty) {
+            meta.plot = sc(row, ['plot', 'description', 'desc', 'synopsis', 'summary']);
+          }
+          if (meta.genres.isEmpty) {
+            final g = sc(row, ['genres', 'genre', 'category']);
+            if (g.isNotEmpty) {
+              meta.genres = g.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+            }
+          }
+          if (meta.tags.isEmpty) {
+            final t = sc(row, ['tags', 'tag']);
+            if (t.isNotEmpty) {
+              meta.tags = t.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+            }
+          }
+        }
+      }
+    }
+
+    // ── Parse Episodes tab ──────────────────────────────────────────────────
+    // Map: series_imdb_id → Map<season → List<EpisodeEntry>>
+    final Map<String, Map<int, List<EpisodeEntry>>> episodeTree = {};
+
+    if (episodesCsv.isNotEmpty) {
+      final norm = episodesCsv.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+      final rows = const CsvToListConverter(eol: '\n').convert(norm);
+
+      if (rows.length >= 2) {
+        final eh = {
+          for (var i = 0; i < rows[0].length; i++)
+            _norm(rows[0][i].toString()): i,
+        };
+
+        String ec(List<dynamic> row, List<String> aliases) {
+          for (final a in aliases) {
+            final idx = eh[a];
+            if (idx != null && idx < row.length) {
+              final v = row[idx].toString().trim();
+              if (v.isNotEmpty) return v;
+            }
+          }
+          return '';
+        }
+
+        final visIdx = eh['show'] ?? eh['enabled'] ?? eh['visible'];
+
+        for (final row in rows.skip(1)) {
+          if (row.isEmpty) continue;
+          if (visIdx != null && visIdx < row.length) {
+            if (row[visIdx].toString().trim().toLowerCase() == 'false') continue;
+          }
+
+          final seriesId = ec(row, ['seriesimdbid', 'seriesid']);
+          if (seriesId.isEmpty) continue;
+
+          final episodeImdbId = ec(row, ['episodeimdbid', 'episodeid', 'imdbid']);
+          final season  = int.tryParse(ec(row, ['season', 's'])) ?? 1;
+          final epNum   = int.tryParse(ec(row, ['episode', 'ep', 'e'])) ?? 1;
+          final title   = ec(row, ['title', 'episodetitle', 'eptitle']);
+          final airDate = DateTime.tryParse(ec(row, ['airdate', 'air_date', 'date', 'aired']));
+          final thumb   = ec(row, ['thumbnailurl', 'thumbnail', 'posterurl', 'image']);
+          final plot    = ec(row, ['plot', 'description']);
+          final rating  = double.tryParse(ec(row, ['rating']));
+          final videoUrl = ec(row, ['videourl', 'url', 'googlephotosurl', 'albumurl', 'link']);
+          final sizeMb  = int.tryParse(ec(row, ['sizemb', 'size', 'filesize']));
+          final encoded = ec(row, ['encoded']).toLowerCase() == 'true';
+
+          final ep = EpisodeEntry(
+            episodeNumber: epNum,
+            title: title,
+            imdbId: episodeImdbId,
+            airDate: airDate,
+            videoUrl: videoUrl,
+            sizeMb: sizeMb,
+            encoded: encoded,
+            plot: plot,
+            posterUrl: thumb,
+            imdbRating: rating,
+          );
+
+          episodeTree
+              .putIfAbsent(seriesId, () => {})
+              .putIfAbsent(season, () => [])
+              .add(ep);
+        }
+      }
+    }
+
+    // ── Assemble SeriesEntry list ────────────────────────────────────────────
+    final rawEntries = seriesOrder.map((imdbId) {
+      final meta     = seriesById[imdbId]!;
+      final seasonMap = episodeTree[imdbId] ?? {};
+      final seasons  = (seasonMap.keys.toList()..sort())
+          .map((n) {
+            final eps = seasonMap[n]!
+              ..sort((a, b) => a.episodeNumber.compareTo(b.episodeNumber));
+            return SeasonEntry(number: n, episodes: eps);
+          })
+          .toList();
+
+      return SeriesEntry(
+        title: meta.title,
+        imdbId: imdbId,
+        posterUrl: meta.posterUrl,
+        plot: meta.plot,
+        genres: meta.genres,
+        tags: meta.tags,
+        seasons: seasons,
+      );
+    }).toList();
+
+    // ── Series-level IMDB enrichment ─────────────────────────────────────────
+    final seriesImdbIds = rawEntries
+        .where((e) => e.imdbId.isNotEmpty)
+        .map((e) => e.imdbId)
+        .toList();
+
+    final seriesImdbMap = seriesImdbIds.isNotEmpty
+        ? await ImdbService().resolve(seriesImdbIds)
+        : <String, ImdbData>{};
+
+    final seriesEnriched = rawEntries.map((e) {
+      final data = seriesImdbMap[e.imdbId];
+      if (data == null) return e;
+      return e.withImdb(
+        posterUrl: data.posterUrl,
+        plot: data.plot,
+        genres: data.genres,
+        rating: data.rating,
+      );
+    }).toList();
+
+    // ── Episode-level IMDB enrichment ─────────────────────────────────────────
+    final episodeImdbIds = seriesEnriched
+        .expand((s) => s.seasons)
+        .expand((season) => season.episodes)
+        .where((ep) => ep.imdbId.isNotEmpty)
+        .map((ep) => ep.imdbId)
+        .toSet()
+        .toList();
+
+    if (episodeImdbIds.isEmpty) return seriesEnriched;
+
+    final epImdbMap = await ImdbService().resolve(episodeImdbIds);
+
+    return seriesEnriched.map((series) {
+      final enrichedSeasons = series.seasons.map((season) {
+        final enrichedEps = season.episodes.map((ep) {
+          final data = epImdbMap[ep.imdbId];
+          if (data == null) return ep;
+          return ep.withImdb(
+            title: data.title,
+            airDate: data.releaseDate,
+            rating: data.rating,
+            plot: data.plot,
+            posterUrl: data.posterUrl,
+            runtimeSeconds: data.runtimeSeconds,
+          );
+        }).toList();
+        return SeasonEntry(number: season.number, episodes: enrichedEps);
+      }).toList();
+      return SeriesEntry(
+        title: series.title,
+        imdbId: series.imdbId,
+        posterUrl: series.posterUrl,
+        plot: series.plot,
+        genres: series.genres,
+        tags: series.tags,
+        language: series.language,
+        imdbRating: series.imdbRating,
+        seasons: enrichedSeasons,
+      );
+    }).toList();
+  }
+
+  static String _toPosterUrl(String url) {
+    final match = RegExp(r'/file/d/([a-zA-Z0-9_-]+)').firstMatch(url);
+    if (match != null) {
+      return 'https://drive.google.com/thumbnail?id=${match.group(1)}&sz=w400';
+    }
+    return url;
+  }
+
+  // ── Load ──────────────────────────────────────────────────────────────────
+
+  Future<void> load(String sheetUrl, {bool forceRefresh = false}) async {
+    state = SeriesCatalogLoading();
+
+    final sheetId = _extractSheetId(sheetUrl);
+    if (sheetId == null) {
+      state = SeriesCatalogError('Invalid Google Sheets URL.');
+      return;
+    }
+
+    if (forceRefresh) {
+      unawaited(_clearCache(sheetId));
+    } else {
+      final cached = await _loadCache(sheetId);
+      if (cached != null) {
+        final entries = await _buildEntries(cached.series, cached.episodes);
+        if (mounted) state = SeriesCatalogLoaded(entries);
+
+        final age = DateTime.now().difference(cached.fetchedAt);
+        if (age < _kCsvCacheTtl) return;
+
+        _silentRefresh(sheetId, cached.series, cached.episodes);
+        return;
+      }
+    }
+
+    try {
+      final results = await Future.wait([
+        http.get(Uri.parse(_seriesCsvUrl(sheetId))),
+        http.get(Uri.parse(_episodesCsvUrl(sheetId))),
+      ]);
+
+      final seriesBody   = _validBody(results[0]);
+      final episodesBody = _validBody(results[1]);
+
+      unawaited(_saveCache(sheetId, seriesBody, episodesBody));
+      final entries = await _buildEntries(seriesBody, episodesBody);
+      if (mounted) state = SeriesCatalogLoaded(entries);
+    } catch (e) {
+      if (mounted) state = SeriesCatalogError('Failed to fetch series: $e');
+    }
+  }
+
+  Future<void> _silentRefresh(
+      String sheetId, String cachedSeries, String cachedEpisodes) async {
+    try {
+      final results = await Future.wait([
+        http.get(Uri.parse(_seriesCsvUrl(sheetId))),
+        http.get(Uri.parse(_episodesCsvUrl(sheetId))),
+      ]);
+
+      final seriesBody   = _validBody(results[0]);
+      final episodesBody = _validBody(results[1]);
+
+      if (seriesBody == cachedSeries && episodesBody == cachedEpisodes) {
+        unawaited(_saveCache(sheetId, cachedSeries, cachedEpisodes));
+        return;
+      }
+
+      unawaited(_saveCache(sheetId, seriesBody, episodesBody));
+      final entries = await _buildEntries(seriesBody, episodesBody);
+      if (mounted) state = SeriesCatalogLoaded(entries);
+    } catch (_) {}
+  }
+
+  void reset() => state = SeriesCatalogIdle();
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+class _SeriesFields {
+  String title    = '';
+  String imdbId   = '';
+  String posterUrl = '';
+  String plot     = '';
+  List<String> genres = [];
+  List<String> tags   = [];
+  String? language;
+}

--- a/lib/features/catalog/widgets/catalog_card.dart
+++ b/lib/features/catalog/widgets/catalog_card.dart
@@ -1,12 +1,20 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math' show max;
 import 'dart:ui' show ImageFilter;
 import 'dart:ui' as ui;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+import '../../../core/providers/decode_request_provider.dart';
+import '../../../core/providers/player_request_provider.dart';
 import '../../../core/services/catalog_cache_manager.dart';
+import '../../../core/services/settings_service.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/theme/tab_colors.dart';
+import '../../shell/app_shell.dart';
+import '../catalog_notifier.dart';
 import '../imdb_service.dart';
 import '../models/catalog_entry.dart';
 
@@ -140,7 +148,7 @@ class _CatalogCardState extends State<CatalogCard> {
 // Expanded card — used by the catalog screen's local overlay stack
 // ---------------------------------------------------------------------------
 
-class CatalogCardExpanded extends StatefulWidget {
+class CatalogCardExpanded extends ConsumerStatefulWidget {
   final CatalogEntry entry;
   final TabPalette palette;
   final bool isDownloaded;
@@ -159,10 +167,10 @@ class CatalogCardExpanded extends StatefulWidget {
   });
 
   @override
-  State<CatalogCardExpanded> createState() => CatalogCardExpandedState();
+  ConsumerState<CatalogCardExpanded> createState() => CatalogCardExpandedState();
 }
 
-class CatalogCardExpandedState extends State<CatalogCardExpanded> {
+class CatalogCardExpandedState extends ConsumerState<CatalogCardExpanded> {
   final _pageController = PageController();
   int _currentPage = 0;
   List<String> _images = [];
@@ -438,36 +446,7 @@ class CatalogCardExpandedState extends State<CatalogCardExpanded> {
                     ),
                   ),
                   const SizedBox(height: 16),
-                  if (widget.isDownloaded) ...[
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: const [
-                        Icon(Icons.download_done_rounded, size: 13, color: Color(0xFF69F0AE)),
-                        SizedBox(width: 5),
-                        Text('Already downloaded',
-                            style: TextStyle(fontSize: 11, color: Color(0xFF69F0AE))),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                  ],
-                  // Button — always visible at the bottom
-                  SizedBox(
-                    width: double.infinity,
-                    child: FilledButton.icon(
-                      onPressed: entry.videoUrl.isNotEmpty
-                          ? widget.onOpenInBrowser
-                          : null,
-                      icon: const Icon(Icons.open_in_new_rounded, size: 16),
-                      label: const Text('View & Download'),
-                      style: FilledButton.styleFrom(
-                        backgroundColor: palette.primary,
-                        foregroundColor: Colors.black,
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10)),
-                      ),
-                    ),
-                  ),
+                  _EntryActionButton(entry: entry, palette: palette, onOpenInBrowser: widget.onOpenInBrowser, onClose: widget.onClose),
                 ],
               ),
             ),
@@ -479,6 +458,117 @@ class CatalogCardExpandedState extends State<CatalogCardExpanded> {
 
   String _fmtDate(DateTime d) =>
       '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}
+
+// ---------------------------------------------------------------------------
+// 4-state action button for the expanded movie card
+// ---------------------------------------------------------------------------
+
+class _EntryActionButton extends ConsumerWidget {
+  final CatalogEntry entry;
+  final TabPalette palette;
+  final VoidCallback onOpenInBrowser;
+  final VoidCallback onClose;
+
+  const _EntryActionButton({
+    required this.entry,
+    required this.palette,
+    required this.onOpenInBrowser,
+    required this.onClose,
+  });
+
+  static const _kVideoExts = {'mp4', 'mkv', 'avi', 'mov', 'webm'};
+
+  static String? _decodedVideoPath(String decodeDir, String title) {
+    final folder = Directory(p.join(decodeDir, title));
+    if (!folder.existsSync()) return null;
+    try {
+      for (final e in folder.listSync()) {
+        if (e is File) {
+          final ext = p.extension(e.path).replaceFirst('.', '').toLowerCase();
+          if (_kVideoExts.contains(ext)) return e.path;
+        }
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final history   = ref.watch(downloadHistoryProvider);
+    final dlState   = ref.watch(downloadProvider);
+    final settings  = ref.watch(settingsProvider);
+    final decodeDir = settings.decodeOutputDirectory.isEmpty
+        ? AppDirectories.decoded
+        : settings.decodeOutputDirectory;
+
+    final record = history.cast<DownloadRecord?>().firstWhere(
+      (r) => r!.title == entry.title && File(r.filePath).existsSync(),
+      orElse: () => null,
+    );
+
+    final isActive    = dlState is DownloadActive && dlState.title == entry.title;
+    final decodedPath = _decodedVideoPath(decodeDir, entry.title);
+
+    final style = FilledButton.styleFrom(
+      backgroundColor: palette.primary,
+      foregroundColor: Colors.black,
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+    );
+
+    final Widget btn;
+    if (isActive) {
+      btn = FilledButton.icon(
+        onPressed: null,
+        icon: SizedBox(
+          width: 14, height: 14,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: kTextMuted,
+          ),
+        ),
+        label: const Text('Downloading…'),
+        style: FilledButton.styleFrom(
+          backgroundColor: kSurface2Color,
+          foregroundColor: kTextMuted,
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        ),
+      );
+    } else if (decodedPath != null) {
+      btn = FilledButton.icon(
+        onPressed: () {
+          onClose();
+          ref.read(playerOpenRequestProvider.notifier).state = decodedPath;
+          ref.read(activeTabProvider.notifier).state = AppTab.player;
+        },
+        icon: const Icon(Icons.play_circle_rounded, size: 16),
+        label: const Text('Play'),
+        style: style,
+      );
+    } else if (record != null) {
+      btn = FilledButton.icon(
+        onPressed: () {
+          onClose();
+          ref.read(decodeOpenRequestProvider.notifier).state = record.filePath;
+          ref.read(activeTabProvider.notifier).state = AppTab.decode;
+        },
+        icon: const Icon(Icons.lock_open_rounded, size: 16),
+        label: const Text('Decode'),
+        style: style,
+      );
+    } else {
+      btn = FilledButton.icon(
+        onPressed: entry.videoUrl.isNotEmpty ? onOpenInBrowser : null,
+        icon: const Icon(Icons.open_in_new_rounded, size: 16),
+        label: const Text('View & Download'),
+        style: style,
+      );
+    }
+
+    return SizedBox(width: double.infinity, child: btn);
+  }
 }
 
 // Per-session cache: URL → normalized crop rect (0–1 coordinates).

--- a/lib/features/catalog/widgets/series_card.dart
+++ b/lib/features/catalog/widgets/series_card.dart
@@ -1,0 +1,760 @@
+import 'dart:ui' show ImageFilter;
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import '../../../core/services/catalog_cache_manager.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/theme/tab_colors.dart';
+import '../models/series_entry.dart';
+
+// ---------------------------------------------------------------------------
+// Compact grid card — one per series
+// ---------------------------------------------------------------------------
+
+class SeriesCard extends StatefulWidget {
+  final SeriesEntry entry;
+  final double aspectRatio;
+  final bool isDownloaded;
+  final VoidCallback onExpand;
+
+  const SeriesCard({
+    super.key,
+    required this.entry,
+    required this.aspectRatio,
+    this.isDownloaded = false,
+    required this.onExpand,
+  });
+
+  @override
+  State<SeriesCard> createState() => _SeriesCardState();
+}
+
+class _SeriesCardState extends State<SeriesCard> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    const palette = kSeriesPalette;
+    final e = widget.entry;
+    final seasonCount  = e.seasons.length;
+    final episodeCount = e.totalEpisodes;
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit:  (_) => setState(() => _hovered = false),
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: widget.onExpand,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          decoration: BoxDecoration(
+            color: _hovered ? kSurface2Color : kSurfaceColor,
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: _hovered
+                  ? palette.primary.withValues(alpha: 0.5)
+                  : kBorderColor,
+            ),
+            boxShadow: _hovered
+                ? [BoxShadow(color: palette.glow, blurRadius: 12)]
+                : [],
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Stack(
+                children: [
+                  _SeriesThumbnail(
+                    url: e.posterUrl,
+                    aspectRatio: widget.aspectRatio,
+                    rating: e.imdbRating,
+                  ),
+                  if (widget.isDownloaded)
+                    Positioned(
+                      top: 6,
+                      right: 6,
+                      child: const Icon(Icons.download_done_rounded,
+                          size: 16, color: Color(0xFFEA580C)),
+                    ),
+                ],
+              ),
+              Padding(
+                padding: const EdgeInsets.all(10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      e.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: kTextPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      _countLabel(seasonCount, episodeCount),
+                      style: const TextStyle(fontSize: 11, color: kTextMuted),
+                    ),
+                    if (e.genres.isNotEmpty) ...[
+                      const SizedBox(height: 6),
+                      SizedBox(
+                        height: 20,
+                        child: ClipRect(
+                          child: Wrap(
+                            spacing: 4,
+                            runSpacing: 4,
+                            children: e.genres
+                                .take(3)
+                                .map((t) => _Tag(tag: t))
+                                .toList(),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _countLabel(int seasons, int episodes) {
+    final s = seasons == 1 ? '1 season' : '$seasons seasons';
+    final e = episodes == 1 ? '1 episode' : '$episodes episodes';
+    return '$s · $e';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Expanded overlay card
+// ---------------------------------------------------------------------------
+
+class SeriesCardExpanded extends StatefulWidget {
+  final SeriesEntry entry;
+  final VoidCallback onClose;
+  final void Function(SeriesEntry entry, String videoUrl) onOpenEpisode;
+  final void Function(String videoUrl, String title, String thumbnailUrl)
+      onDownloadEpisode;
+  final double maxHeight;
+
+  const SeriesCardExpanded({
+    super.key,
+    required this.entry,
+    required this.onClose,
+    required this.onOpenEpisode,
+    required this.onDownloadEpisode,
+    this.maxHeight = 640,
+  });
+
+  @override
+  State<SeriesCardExpanded> createState() => SeriesCardExpandedState();
+}
+
+class SeriesCardExpandedState extends State<SeriesCardExpanded> {
+  // Track which seasons are expanded; default first season open
+  late Set<int> _expandedSeasons;
+
+  @override
+  void initState() {
+    super.initState();
+    _expandedSeasons = widget.entry.seasons.isNotEmpty
+        ? {widget.entry.seasons.first.number}
+        : {};
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const palette = kSeriesPalette;
+    final e = widget.entry;
+
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      constraints: BoxConstraints(maxHeight: widget.maxHeight),
+      decoration: BoxDecoration(
+        color: kSurfaceColor,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: palette.primary.withValues(alpha: 0.45),
+          width: 1.5,
+        ),
+        boxShadow: [
+          BoxShadow(color: palette.glow, blurRadius: 48, spreadRadius: 4),
+          BoxShadow(
+              color: Colors.black.withValues(alpha: 0.6), blurRadius: 24),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Poster banner
+          if (e.posterUrl.isNotEmpty)
+            ClipRRect(
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(15)),
+              child: SizedBox(
+                height: 200,
+                width: double.infinity,
+                child: _PosterBanner(url: e.posterUrl),
+              ),
+            ),
+          // Content
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Title row
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          e.title,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w700,
+                            color: kTextPrimary,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      InkWell(
+                        onTap: widget.onClose,
+                        borderRadius: BorderRadius.circular(6),
+                        child: Padding(
+                          padding: const EdgeInsets.all(4),
+                          child: Icon(Icons.close_rounded,
+                              size: 18, color: kTextMuted),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  // Scrollable body
+                  Flexible(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // Meta pills
+                          Wrap(
+                            spacing: 6,
+                            runSpacing: 6,
+                            children: [
+                              if (e.imdbRating != null)
+                                _Pill(
+                                  icon: Icons.star_rounded,
+                                  label: e.imdbRating!.toStringAsFixed(1),
+                                  color: const Color(0xFFF5C518),
+                                ),
+                              _Pill(
+                                icon: Icons.live_tv_rounded,
+                                label: e.seasons.length == 1
+                                    ? '1 Season'
+                                    : '${e.seasons.length} Seasons',
+                              ),
+                              _Pill(
+                                icon: Icons.video_library_rounded,
+                                label: '${e.totalEpisodes} Episodes',
+                              ),
+                              if (e.language != null)
+                                _Pill(
+                                  icon: Icons.translate_rounded,
+                                  label: e.language!,
+                                ),
+                            ],
+                          ),
+                          // Genres
+                          if (e.genres.isNotEmpty) ...[
+                            const SizedBox(height: 10),
+                            Wrap(
+                              spacing: 6,
+                              runSpacing: 6,
+                              children: e.genres
+                                  .map((t) => _Tag(tag: t))
+                                  .toList(),
+                            ),
+                          ],
+                          // Tags
+                          if (e.tags.isNotEmpty) ...[
+                            const SizedBox(height: 6),
+                            Wrap(
+                              spacing: 6,
+                              runSpacing: 6,
+                              children: e.tags
+                                  .map((t) => _Tag(tag: t, muted: true))
+                                  .toList(),
+                            ),
+                          ],
+                          // Plot
+                          if (e.plot.isNotEmpty) ...[
+                            const SizedBox(height: 12),
+                            Text(
+                              e.plot,
+                              style: const TextStyle(
+                                fontSize: 12,
+                                color: kTextSecondary,
+                                height: 1.55,
+                              ),
+                            ),
+                          ],
+                          // Season accordion
+                          if (e.seasons.isNotEmpty) ...[
+                            const SizedBox(height: 14),
+                            ...e.seasons.map(
+                              (season) => _SeasonSection(
+                                season: season,
+                                expanded:
+                                    _expandedSeasons.contains(season.number),
+                                onToggle: () => setState(() {
+                                  if (_expandedSeasons
+                                      .contains(season.number)) {
+                                    _expandedSeasons.remove(season.number);
+                                  } else {
+                                    _expandedSeasons.add(season.number);
+                                  }
+                                }),
+                                onOpen: (ep) => widget.onOpenEpisode(
+                                    widget.entry, ep.videoUrl),
+                                onDownload: (ep) {
+                                  final label = ep.displayTitle.isNotEmpty
+                                      ? ep.displayTitle
+                                      : 'Episode ${ep.episodeNumber}';
+                                  widget.onDownloadEpisode(
+                                    ep.videoUrl,
+                                    '${e.title} S${_pad(season.number)}E${_pad(ep.episodeNumber)} — $label',
+                                    e.posterUrl,
+                                  );
+                                },
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _pad(int n) => n.toString().padLeft(2, '0');
+}
+
+// ---------------------------------------------------------------------------
+// Season section — collapsible
+// ---------------------------------------------------------------------------
+
+class _SeasonSection extends StatelessWidget {
+  final SeasonEntry season;
+  final bool expanded;
+  final VoidCallback onToggle;
+  final void Function(EpisodeEntry) onOpen;
+  final void Function(EpisodeEntry) onDownload;
+
+  const _SeasonSection({
+    required this.season,
+    required this.expanded,
+    required this.onToggle,
+    required this.onOpen,
+    required this.onDownload,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const palette = kSeriesPalette;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Season header
+        InkWell(
+          onTap: onToggle,
+          borderRadius: BorderRadius.circular(6),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Row(
+              children: [
+                AnimatedRotation(
+                  turns: expanded ? 0.25 : 0,
+                  duration: const Duration(milliseconds: 180),
+                  child: Icon(Icons.chevron_right_rounded,
+                      size: 16, color: palette.primary),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  'Season ${season.number}',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: palette.primary,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '${season.episodes.length} episodes',
+                  style: const TextStyle(fontSize: 11, color: kTextMuted),
+                ),
+              ],
+            ),
+          ),
+        ),
+        // Episodes
+        AnimatedCrossFade(
+          firstChild: const SizedBox.shrink(),
+          secondChild: Column(
+            children: season.episodes
+                .map((ep) => _EpisodeRow(
+                      episode: ep,
+                      onOpen: () => onOpen(ep),
+                      onDownload: () => onDownload(ep),
+                    ))
+                .toList(),
+          ),
+          crossFadeState: expanded
+              ? CrossFadeState.showSecond
+              : CrossFadeState.showFirst,
+          duration: const Duration(milliseconds: 200),
+          sizeCurve: Curves.easeOut,
+        ),
+        Divider(height: 1, color: kBorderColor),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Episode row
+// ---------------------------------------------------------------------------
+
+class _EpisodeRow extends StatelessWidget {
+  final EpisodeEntry episode;
+  final VoidCallback onOpen;
+  final VoidCallback onDownload;
+
+  const _EpisodeRow({
+    required this.episode,
+    required this.onOpen,
+    required this.onDownload,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const palette = kSeriesPalette;
+    final ep = episode;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(22, 5, 0, 5),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Episode number + optional rating
+          SizedBox(
+            width: 36,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'E${ep.episodeNumber.toString().padLeft(2, '0')}',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: kTextMuted,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+                if (ep.imdbRating != null)
+                  Text(
+                    '★ ${ep.imdbRating!.toStringAsFixed(1)}',
+                    style: const TextStyle(
+                      fontSize: 9,
+                      color: Color(0xFFF5C518),
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  ep.displayTitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontSize: 12, color: kTextPrimary),
+                ),
+                if (ep.plot.isNotEmpty)
+                  Text(
+                    ep.plot,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                        fontSize: 10, color: kTextMuted, height: 1.4),
+                  )
+                else if (ep.airDate != null)
+                  Text(
+                    _fmtDate(ep.airDate!),
+                    style: const TextStyle(fontSize: 10, color: kTextMuted),
+                  ),
+                if (ep.plot.isNotEmpty && ep.airDate != null)
+                  Text(
+                    _fmtDate(ep.airDate!),
+                    style: const TextStyle(fontSize: 10, color: kTextMuted),
+                  ),
+              ],
+            ),
+          ),
+          if (ep.videoUrl.isNotEmpty) ...[
+            _EpBtn(
+              icon: Icons.open_in_new_rounded,
+              tooltip: 'Open',
+              color: palette.primary,
+              onTap: onOpen,
+            ),
+            const SizedBox(width: 2),
+            _EpBtn(
+              icon: Icons.download_rounded,
+              tooltip: 'Download',
+              color: kTextSecondary,
+              onTap: onDownload,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  static String _fmtDate(DateTime d) =>
+      '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}
+
+class _EpBtn extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final Color color;
+  final VoidCallback onTap;
+
+  const _EpBtn({
+    required this.icon,
+    required this.tooltip,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(4),
+        child: Padding(
+          padding: const EdgeInsets.all(5),
+          child: Icon(icon, size: 14, color: color),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Poster banner (single image, no slideshow for series)
+// ---------------------------------------------------------------------------
+
+class _PosterBanner extends StatelessWidget {
+  final String url;
+  const _PosterBanner({required this.url});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        CachedNetworkImage(
+          imageUrl: url,
+          cacheManager: CatalogCacheManager.instance,
+          fit: BoxFit.cover,
+          placeholder: (_, _) => Container(color: kSurface2Color),
+          errorWidget: (_, _, _) => Container(color: kSurface2Color),
+          imageBuilder: (_, ip) => ImageFiltered(
+            imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+            child: Image(image: ip, fit: BoxFit.cover),
+          ),
+        ),
+        Container(color: Colors.black.withValues(alpha: 0.22)),
+        CachedNetworkImage(
+          imageUrl: url,
+          cacheManager: CatalogCacheManager.instance,
+          fit: BoxFit.contain,
+          placeholder: (_, _) => const SizedBox.shrink(),
+          errorWidget: (_, _, _) => const SizedBox.shrink(),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Thumbnail for the compact grid card
+// ---------------------------------------------------------------------------
+
+class _SeriesThumbnail extends StatelessWidget {
+  final String url;
+  final double aspectRatio;
+  final double? rating;
+
+  const _SeriesThumbnail({
+    required this.url,
+    required this.aspectRatio,
+    this.rating,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(10)),
+      child: AspectRatio(
+        aspectRatio: aspectRatio,
+        child: url.isNotEmpty
+            ? Stack(
+                fit: StackFit.expand,
+                children: [
+                  CachedNetworkImage(
+                    imageUrl: url,
+                    cacheManager: CatalogCacheManager.instance,
+                    fit: BoxFit.cover,
+                    placeholder: (_, _) => _placeholder(),
+                    errorWidget: (_, _, _) => _placeholder(),
+                    imageBuilder: (_, ip) => ImageFiltered(
+                      imageFilter:
+                          ImageFilter.blur(sigmaX: 28, sigmaY: 28),
+                      child: Image(image: ip, fit: BoxFit.cover),
+                    ),
+                  ),
+                  Container(
+                      color: Colors.black.withValues(alpha: 0.18)),
+                  CachedNetworkImage(
+                    imageUrl: url,
+                    cacheManager: CatalogCacheManager.instance,
+                    fit: BoxFit.cover,
+                    placeholder: (_, _) => const SizedBox.shrink(),
+                    errorWidget: (_, _, _) => const SizedBox.shrink(),
+                  ),
+                  if (rating != null)
+                    Positioned(
+                      bottom: 6,
+                      right: 6,
+                      child: _RatingBadge(rating: rating!),
+                    ),
+                ],
+              )
+            : _placeholder(),
+      ),
+    );
+  }
+
+  Widget _placeholder() => Container(
+        color: kSurface2Color,
+        child: const Icon(Icons.live_tv_rounded,
+            color: kTextMuted, size: 32),
+      );
+}
+
+class _RatingBadge extends StatelessWidget {
+  final double rating;
+  const _RatingBadge({required this.rating});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.72),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.star_rounded, size: 9, color: Color(0xFFF5C518)),
+          const SizedBox(width: 3),
+          Text(
+            rating.toStringAsFixed(1),
+            style: const TextStyle(
+              fontSize: 10,
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+class _Pill extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color? color;
+
+  const _Pill({required this.icon, required this.label, this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = color ?? kTextSecondary;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: c.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: c.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 11, color: c),
+          const SizedBox(width: 4),
+          Text(label, style: TextStyle(fontSize: 11, color: c)),
+        ],
+      ),
+    );
+  }
+}
+
+class _Tag extends StatelessWidget {
+  final String tag;
+  final bool muted;
+  const _Tag({required this.tag, this.muted = false});
+
+  @override
+  Widget build(BuildContext context) {
+    const palette = kSeriesPalette;
+    final color = muted ? kTextMuted : palette.primary;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(tag, style: TextStyle(fontSize: 10, color: color)),
+    );
+  }
+}

--- a/lib/features/decode/decode_screen.dart
+++ b/lib/features/decode/decode_screen.dart
@@ -94,6 +94,20 @@ class _DecodeScreenState extends ConsumerState<DecodeScreen> {
     final settings = ref.watch(settingsProvider);
     final accent = _palette.primary;
 
+    // Auto-delete the encoded source file when decode succeeds.
+    // Keep the history record so Downloads still shows the entry with a Play button.
+    ref.listen<DecodeState>(decodeProvider, (previous, next) {
+      if (previous?.step != DecodeStep.done && next.step == DecodeStep.done) {
+        final path = _videoPath;
+        if (path != null) {
+          try {
+            final file = File(path);
+            if (file.existsSync()) file.deleteSync();
+          } catch (_) {}
+        }
+      }
+    });
+
     // Consume any file path sent from the Catalog "Decode this" shortcut.
     ref.listen<String?>(decodeOpenRequestProvider, (_, path) {
       if (path != null && mounted) {

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -17,6 +17,7 @@ import '../decode/decode_screen.dart';
 import '../player/player_screen.dart';
 import '../catalog/catalog_screen.dart';
 import '../catalog/catalog_notifier.dart';
+import '../catalog/series_notifier.dart' show catalogSubPaletteProvider;
 import '../settings/settings_screen.dart';
 
 // Reads startupTab from already-loaded settings (main() loads before runApp).
@@ -186,7 +187,10 @@ class _AppShellState extends ConsumerState<AppShell>
   @override
   Widget build(BuildContext context) {
     final activeTab = ref.watch(activeTabProvider);
-    final palette = activeTab.palette;
+    final subPalette = ref.watch(catalogSubPaletteProvider);
+    final palette = (activeTab == AppTab.catalog && subPalette != null)
+        ? subPalette
+        : activeTab.palette;
 
     // Trigger animation whenever the active tab changes.
     ref.listen(activeTabProvider, (prev, next) {
@@ -504,7 +508,7 @@ class _SidebarState extends ConsumerState<_Sidebar> {
                   (updateStatus == UpdateStatus.available ||
                    updateStatus == UpdateStatus.downloading ||
                    updateStatus == UpdateStatus.readyToInstall),
-              palette: item.$1.palette,
+              palette: widget.activeTab == item.$1 ? widget.palette : item.$1.palette,
               onTap: () =>
                   ref.read(activeTabProvider.notifier).state = item.$1,
               onHover: (v) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.2.3+8
+version: 1.3.0+9
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
## What's New

### Features
- **Series Catalog** — New Series sub-tab in Catalog with a teal palette; browse series as poster cards, open a detail screen with season selector and per-episode list
- **Episode Actions** — Each episode row has a 4-state button: Download → Decode → Play, with a live progress indicator while downloading
- **Series Admin Mode** — Admin screen supports an Episode sheet mode; Series ID field autocompletes from loaded series data
- **Animated Sub-tab Indicator** — The Movies / Series indicator line slides smoothly between tabs instead of appearing/disappearing

### Fixes
- **Decoded file not shown as Play** — Catalog and series detail now check the decoded folder independently of the download record, so Play appears correctly after the encoded file is cleaned up
- **Downloads list emptied after decode** — History record is preserved after decode; only the encoded file is deleted from disk
- **Series with no episodes crashed** — Detail screen now shows a friendly empty state instead of throwing `Invalid argument(s): 0`
- **Folder icon opened wrong location** — In Downloads, the folder button now opens the decoded folder when a decoded video exists, not the (deleted) download folder

### Improvements
- **Auto-delete encoded file** — Decode screen deletes the source encoded file automatically on successful decode to reclaim disk space
- **Delete in Downloads** — Bin button now shows a confirmation dialog and deletes the actual file(s) from disk (encoded and/or decoded folder)
- **Episode row layout** — Episode number, title and rating are now on a single line for a cleaner, more readable layout
- **Keyboard shortcuts** — Escape exits the series detail screen; F5 force-refreshes the catalog
- **Sub-tab persistence** — Last selected sub-tab (Movies / Series) is remembered across tab switches and app restarts
- **Movie card 4-state button** — Expanded movie card shows Decode or Play instead of View & Download once a file has been downloaded or decoded

🤖 Generated with [Claude Code](https://claude.com/claude-code)