### PR TITLE
feat: v1.4.0 — Performance & correctness release

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,339 @@
+# mStorage — Improvement Report
+
+A full-project audit focused on **performance, responsiveness, functionality, and UX depth**.
+This complements `docs/ux-improvements.md` (the v1.1 animation-polish pass, now largely
+implemented) — nothing here duplicates that document. Items reference actual code locations
+so they can be picked up directly into a release plan (`QUERY.md` → `feat/vX.Y.Z`).
+
+Priority: **P1** = correctness / clearly felt by the user · **P2** = solid improvement ·
+**P3** = nice-to-have.
+Effort: **S** (< ½ day) · **M** (½–1 day) · **L** (multi-day).
+
+---
+
+## 1. Performance & Responsiveness (highest impact)
+
+### 1.1 Decode blocks the UI thread with synchronous file I/O  `P1 / M`
+`FormatService.extractArchive` (`lib/core/services/format_service.dart`) scans the whole
+encoded file with `readSync` in a loop **on the main isolate**. For a 4–8 GB movie this
+freezes the entire window (no animations, no cancel button response) for the duration of
+the breakpoint search + payload copy. The decode "Splitting" spinner is frozen exactly
+when it matters most.
+
+**Fix:** Run the entire scan/copy inside `Isolate.run(...)` (it's already a static method
+with plain-path inputs — a 5-line change), or switch to async `openRead()` streaming.
+While there:
+- `Uint8List.fromList([...tail, ...chunk])` copies ~1 MB per iteration — search the chunk
+  directly and only stitch the boundary region (`tail + first 12 bytes of chunk`).
+- `_findSeparator` is a naive O(n·m) scan; fine once it's off the UI thread, but a
+  first-byte `indexOf` skip makes it ~10× faster for free.
+
+### 1.2 Encrypted encode can balloon memory to the size of the movie  `P1 / S`
+`ArchiveService._createEncryptedZip` (`archive_service.dart:209-219`) pumps file chunks
+into `process.stdin.add(chunk)` **without awaiting backpressure**. `IOSink.add` is
+fire-and-forget — if 7za consumes stdin slower than the disk reads (always true while it
+encrypts), the unwritten chunks accumulate in Dart heap. Encoding a 6 GB movie with a
+password can climb to gigabytes of RAM.
+
+**Fix:** `await process.stdin.flush()` periodically, or pipe via
+`addStream` with a progress-counting `StreamTransformer`. Also throttle `onProgress`
+here the same way the unencrypted path does (it currently fires per chunk → hundreds of
+state updates/sec → needless rebuilds).
+
+### 1.3 Pure-Dart CRC32 ZIP writer should run in an isolate  `P1 / S`
+The unencrypted path (`createZip`) computes CRC-32 byte-by-byte in Dart on the main
+isolate. It yields between chunks (so no hard freeze), but a multi-GB encode keeps the UI
+janky and is CPU-bound single-threaded. Wrap the whole STORE-writer body in
+`Isolate.run` and forward progress through a `ReceivePort` / `Stream`.
+
+### 1.4 Encode + decode share (and delete) the same temp directory — race  `P1 / S`
+Both `encode_notifier.dart` and `decode_notifier.dart` use
+`%TEMP%/mstorage_cache` and **delete it recursively** when they finish. Running a decode
+while an encode is in flight (both are allowed — separate tabs, both have running states)
+will destroy the other job's intermediate files mid-run.
+
+**Fix:** Create a unique subdirectory per job
+(`mstorage_cache/<uuid>`), delete only that. Also wrap cleanup in try/catch — today a
+locked file during `cacheDir.delete(recursive: true)` fails the whole encode *after* the
+output was already written successfully.
+
+### 1.5 Sync disk I/O inside `build()` — Downloads list & drop zones  `P1 / M`
+- `_DownloadsListView` (`catalog_screen.dart`) calls `Directory(...).listSync()` and
+  `File(...).existsSync()` **per row, per rebuild** — and it rebuilds every 300 ms while a
+  download is active (progress ticks). With 50+ history records on a HDD this stutters.
+- `FileDropZone._sizeLabel` calls `File(path).lengthSync()` on every rebuild of the
+  encode screen.
+
+**Fix:** Resolve file existence / decoded-path / size once when the data changes (a small
+`FutureProvider.family` or a cached map keyed by `filePath` invalidated on
+refresh/delete), not in `build`.
+
+### 1.6 Hidden tabs keep doing layout work and running animations  `P2 / S`
+`AppShell` keeps all six screens mounted via `Opacity(opacity: 0)`
+(`app_shell.dart:237-244`). `Opacity(0)` skips painting but **not layout**, and repeating
+`flutter_animate` loops (catalog empty-state pulse, sidebar running-dot) keep ticking in
+invisible tabs. The catalog grid (potentially hundreds of cards) re-layouts on every
+window resize even while you're on the Encode tab.
+
+**Fix:** Replace the invisible branch with `Offstage(offstage: true, child: TickerMode(enabled: false, ...))`.
+Same state-preservation guarantee, zero layout/ticker cost. (Note: if background video
+playback while on other tabs is *intended* for the Player tab, keep Player on the
+`Offstage`-only path — `TickerMode` off would freeze its controls but not the audio.)
+
+### 1.7 Catalog first load waits on IMDB before showing anything  `P1 / M`
+`CatalogNotifier._buildEntries` awaits `ImdbService().resolve(imdbIds)` **before**
+emitting `CatalogLoaded`. On a fresh install (cold IMDB cache) with a 100-row sheet
+that's 20 sequential batch requests (batches of 5, awaited in a serial loop) — easily
+10–20 s of spinner for data the user doesn't need to start browsing.
+
+**Fix (two parts):**
+1. Emit `CatalogLoaded(rawEntries)` immediately after CSV parse, then merge IMDB data
+   into state as batches resolve (the UI already handles missing ratings gracefully).
+2. Fetch batches concurrently with a small cap: `Future.wait` over 3–4 batches at a time
+   instead of strictly serial.
+
+### 1.8 Downscale decoded poster images for grid cards  `P2 / S`
+Catalog cards are ≤ 200 px wide but `CachedNetworkImage` decodes posters at full
+resolution (IMDB originals can be 2000+ px). Set `memCacheWidth: 400` (2× for DPR) on the
+grid/list thumbnails — typically cuts image memory by 10–20× and noticeably speeds up
+first-scroll of a large catalog.
+
+### 1.9 No timeout on catalog CSV fetch  `P2 / S`
+`http.get(csvUrl)` in `catalog_notifier.dart` has no `.timeout(...)`. A hung connection
+leaves the catalog on the loading spinner forever with no retry path. Add a 15 s timeout
++ map it to the friendly error state (the IMDB service already does this correctly).
+
+### 1.10 Debounce catalog search  `P3 / S`
+Every keystroke refilters + re-sorts the full list and rebuilds the masonry grid
+(`onSearch: (v) => setState(...)`). Fine at 100 entries; visible at 500+. A 150–200 ms
+debounce (or at least moving filter+sort out of `_Body.build` into a memoized provider
+keyed by query/filter inputs) keeps typing smooth and removes redundant work.
+
+---
+
+## 2. Functional gaps — Encode / Decode
+
+### 2.1 Encode cannot be cancelled  `P1 / M`
+Decode has a cancel button and kills the 7za process; **encode has nothing**. A wrong
+file selection at the start of a 10-minute encode means waiting it out or killing the
+app. Keep handles to the ffmpeg process and zip job, add a `cancel()` to
+`EncodeNotifier` mirroring `DecodeNotifier.cancel()`, and surface the same "Cancel"
+header button the Decode screen already has.
+
+### 2.2 Encode silently overwrites existing output  `P1 / S`
+`FormatService.combine` opens `<outputDir>/<title>.mp4` with `openWrite()` — an existing
+encode with the same title is destroyed without warning. Check existence in `_runEncode`
+and show the same "already exists — overwrite?" dialog pattern used by catalog downloads.
+
+### 2.3 Date/Time fields are unvalidated free text  `P2 / S`
+`_dateCtrl` / `_timeCtrl` feed straight into ffmpeg's `creation_time` metadata. A typo
+("2025-13-1") produces a malformed timestamp with zero feedback. Either add inline
+validation (regex + red border) or replace with `showDatePicker` / `showTimePicker`
+field taps — pickers are the better UX and remove the failure mode entirely.
+
+### 2.4 ffmpeg mask generation progress is indeterminate  `P2 / M`
+Step 1 of the pipeline shows only a spinner. ffmpeg supports `-progress pipe:1`
+(key=value lines incl. `out_time_ms`); with the known target duration you can show a
+real percentage like the other two steps. Use `Process.start` instead of `Process.run`
+in `FfmpegService.generateMaskVideo` — this is also a prerequisite for 2.1 (cancel).
+
+### 2.5 Decode extraction progress  `P2 / M`
+The "Unpacking" step is also indeterminate. 7za prints percentages with `-bsp1`
+(`x archive -bsp1 ...` → stdout lines like ` 23%`). The process handle already exists in
+`DecodeNotifier` — parse stdout and feed a progress value into the existing step UI.
+
+### 2.6 Auto-delete of the source file after decode should be opt-in  `P1 / S`
+`decode_screen.dart:97-109` permanently deletes the encoded source file the moment decode
+succeeds — hardcoded, no setting, no undo. If extraction produced garbage (wrong password
+edge cases, partial disk), the original is already gone. Add a Settings toggle
+("Delete encoded file after successful decode", default **off** — or on, but visible),
+and consider `Recycle Bin` semantics instead of hard delete.
+
+### 2.7 Wrong-password failures surface as raw 7za stderr  `P2 / S`
+Decoding with a wrong/missing password shows `Extraction failed: <7za dump>`. 7za's
+output contains recognizable markers ("Wrong password", "ERROR: CRC Failed ... Wrong
+password?"). Detect them and show a human message — "Incorrect password — check
+Settings → Password" — with a button that jumps to Settings (the pattern already exists
+in `PasswordWarningBanner`).
+
+### 2.8 Free-disk-space preflight  `P3 / S`
+Encode needs roughly 2× the movie size (zip in temp + final output); decode similar.
+Running out of space mid-job currently dies with a raw filesystem exception. A cheap
+preflight (`GetDiskFreeSpaceEx` via the already-imported `win32` package) with a clear
+warning is much friendlier.
+
+### 2.9 Batch encode queue  `P3 / L`
+Encoding a season of files is currently fully manual, one at a time. The download side
+already has a clean queue implementation (`DownloadNotifier`) — the same pattern applied
+to encode (drop N videos → queued with shared settings, sidebar badge shows count) is
+the single biggest workflow improvement for heavy users.
+
+---
+
+## 3. Player — biggest UX headroom in the app
+
+### 3.1 Fixed 320 px video area; no fullscreen  `P1 / M`
+For an app whose end goal is *watching movies*, the player renders in a fixed
+320-px-tall box (`_VideoArea`, `player_screen.dart:428`) inside a scroll view, with no
+way to enlarge it. media_kit ships fullscreen support
+(`MaterialDesktopVideoControlsTheme`, `toggleFullscreen`).
+
+**Fix:** Make the video area `Expanded` (fill available height, letterboxed), add a
+fullscreen toggle button + `F` key + double-click-to-fullscreen, `Esc` to exit.
+
+### 3.2 Resume playback position, not just last file  `P2 / M`
+`lastVideoPath` is persisted but always restarts at 0:00. Persist
+`player.state.position` (throttled, e.g. every 5 s + on close) keyed by file path, and
+make "Resume" actually resume — with a small "start over" alternative.
+
+### 3.3 Keyboard coverage  `P2 / S`
+Only Space is handled. Standard desktop-player keys are cheap to add to the existing
+`_handleKeyEvent`: `←/→` seek ±10 s, `↑/↓` volume, `M` mute, `F` fullscreen. Persist
+volume in settings (it currently resets every session).
+
+### 3.4 Auto-load sibling/extracted subtitles  `P2 / S`
+Decode extracts `<title>.srt` next to the movie, but opening the file in the player
+doesn't attach it (mpv only auto-loads exact-name matches in some configs). On
+`_openVideo`, scan the file's directory for `srt/ass/vtt` and add via
+`player.setSubtitleTrack(SubtitleTrack.uri(...))`, plus a small CC button to pick among
+multiple.
+
+### 3.5 Tab-switch playback is invisible  `P3 / S`
+Because all tabs stay mounted, video/audio keeps playing when you switch tabs with no
+indication or control. Either pause on tab-leave (setting), or reuse the sidebar
+"running" pulse dot on the Player tab while `player.state.playing` — one `ref.watch`
+in `_Sidebar`.
+
+---
+
+## 4. Catalog & Downloads
+
+### 4.1 Download queue robustness: one failure kills the whole queue  `P1 / M`
+In `DownloadNotifier._processQueue`, any job exception does `_queue.clear()` and stops.
+A transient network blip on file 1 of 5 cancels the other 4 silently. Per-job try/catch:
+record the failure (title + reason), continue the queue, and show a summary
+("3 done, 1 failed — Retry"). A retry button on `DownloadError` is the matching quick win.
+
+### 4.2 Partial files left on disk after failure  `P1 / S`
+Cancel deletes the partial file, but an *error* path does not — a failed 2 GB download
+leaves a corrupt `.mp4` in the download dir that then shows up as playable/decodable.
+Delete (or `.part`-suffix during transfer, rename on success — also fixes 4.3).
+
+### 4.3 Filename collisions overwrite silently  `P2 / S`
+The "already downloaded" check only consults *history*; a file present on disk but not
+in history (or two catalog entries sharing a filename) is clobbered. Check
+`File(...).existsSync()` at the sink-open site and de-dupe (`name (1).mp4`) or prompt.
+
+### 4.4 Keyboard shortcuts exist but are undiscoverable  `P2 / S`
+`D` toggles downloads, `F5` refreshes, `Esc`/`Backspace` navigate back, `←/→` browse the
+expanded card — none of this is shown anywhere. Add a small `?`-key overlay (or a hint
+row in the empty states / tooltip on the toggle buttons) listing them. Cheap, and these
+shortcuts are genuinely good once known.
+
+### 4.5 Sheet URL error feedback before the spinner  `P3 / S`
+Pasting a non-Sheets URL gives the generic error state only after a load attempt.
+Validate the `/spreadsheets/d/<id>` pattern in `onSubmitUrl` and shake/red-border the
+field immediately.
+
+### 4.6 Downloads view: sort + total size  `P3 / S`
+History is fixed newest-first with no total. A header line ("23 files · 41.2 GB") and a
+date/size/title sort toggle reuse the catalog's existing sort-bar patterns.
+
+### 4.7 Open Downloads folder shortcut  `P3 / S`
+A single "open downloads folder in Explorer" icon button next to the Downloads toggle
+saves the most common round trip. (`Process.run('explorer.exe', [dir])` is already used
+elsewhere.)
+
+---
+
+## 5. App shell & system integration
+
+### 5.1 Remember window bounds  `P2 / S`
+The app opens 1100×740 centered every launch. Persist size/position/maximized via
+`window_manager` (`onWindowResized`/`onWindowMoved` → settings) and restore in `main()`.
+Standard desktop expectation.
+
+### 5.2 Title bar: double-click to maximize + correct restore icon  `P2 / S`
+The custom title bar drags but doesn't toggle maximize on double-click (a hardwired
+Windows habit), and the maximize button always shows `crop_square` even when maximized
+(should swap to a "restore" glyph via `onWindowMaximize`/`onWindowUnmaximize` listeners).
+
+### 5.3 Cross-tab completion notifications  `P2 / M`
+Long operations finish invisibly if you're on another tab — encode done, download done,
+decode done all render banners only inside their own screens (the sidebar dot just stops
+pulsing). Add a lightweight in-app toast (top-right overlay, accent-colored per source
+tab, click → jump to tab). Optionally a Windows tray/toast notification when the window
+is minimized — `windows_notification` or `local_notifier` are small deps.
+
+### 5.4 Single-instance guard  `P3 / S`
+Two app instances can run simultaneously and fight over the temp cache dir, settings
+file, and download history. `windows_single_instance` (or a named mutex via `win32`)
+plus focusing the existing window is the standard fix.
+
+### 5.5 File associations / "Open with" entry  `P3 / M`
+Registering the app for `.mp4` "Open with" (via the Inno Setup script) and handling the
+file-path command-line arg (`main(List<String> args)` → route to Decode or Player) makes
+the encode/decode loop dramatically faster for daily use.
+
+---
+
+## 6. Security & robustness (worth knowing, even for a personal tool)
+
+### 6.1 Password is passed on the 7za command line  `P2 / S`
+`-p$password` (both in `ArchiveService` and `DecodeNotifier`) is visible to any process
+listing tools while 7za runs. 7-Zip has no stdin-password mode, but you can avoid the
+exposure for *decode* by extracting with `-p` via an environment-variable-free response…
+in practice the pragmatic options are: accept it (single-user machine), or document it.
+At minimum, stop **interpolating the password into the args list that gets logged in
+error messages** — `Extraction failed: ${stderr}` currently never echoes it, but
+`Exception('7za encryption failed ...')` paths should be audited to keep it that way.
+
+### 6.2 Password stored in plaintext SharedPreferences  `P3 / S`
+`shared_preferences` writes it to an unencrypted file under AppData. On Windows,
+`flutter_secure_storage` (DPAPI-backed) is a drop-in for just the password key.
+
+### 6.3 Updater: no integrity check on the downloaded installer  `P3 / S`
+`update_service.dart` downloads over HTTPS from GitHub releases (good) but doesn't
+verify size or hash before `Process.start`. Publishing a `.sha256` asset alongside the
+installer and checking it is cheap insurance against truncated downloads (the current
+failure mode would be a cryptic installer error).
+
+---
+
+## 7. Code health (keeps future releases fast)
+
+| Item | Where | Why |
+|---|---|---|
+| Split the two 2,300-line screens | `catalog_screen.dart` (2,376), `admin_screen.dart` (2,361) | Each holds 15+ private widget classes; extraction into `widgets/` files (pattern already exists for `catalog_card.dart`) makes every future change cheaper. `P2/M` |
+| Deduplicate the primary action button | `_EncodeButton`, `_DecodeButton`, `_VlcButton`, `_SyncplayButton` | Four near-identical hover/press/gradient implementations → one `PrimaryButton` in `shared_widgets.dart`. `P3/S` |
+| Deduplicate the done-banner | `_DoneBanner` (encode), `_DecodeDoneBanner`, `_DoneDownload` | Same layout, three copies. `P3/S` |
+| Duplicated `@override` | `decode_screen.dart:90-91` | Harmless but sloppy; lint should have caught it. `P3/S` |
+| Markdown stylesheet copies | `app_shell.dart:_mdStyle` vs `settings_screen.dart:_showChangelog` | Same stylesheet built twice — move to `app_theme.dart`. `P3/S` |
+| Raw `e.toString()` in user-facing errors | encode/decode notifiers | Map common cases (file gone, access denied, disk full) to friendly text; keep details behind a "copy details" action. `P2/S` |
+| Tests | `test/` has only the icon generator + template widget test | The pure logic is very testable: `FormatService` separator scan (incl. boundary-straddling separators), `ArchiveService` ZIP writer (validate with `archive` package read-back), `UpdateService.isNewer`, catalog CSV parsing/filtering. These guard the *format compatibility promise* that the whole app rests on. `P1/M` |
+
+---
+
+## 8. Suggested release grouping
+
+**v1.4 — "Fast & unbreakable" (perf + correctness core)**
+- 1.1 decode off the UI thread · 1.2 stdin backpressure · 1.3 zip isolate
+- 1.4 temp-dir race · 2.1 encode cancel · 2.2 overwrite guard · 2.6 auto-delete opt-in
+- 4.1/4.2 download queue resilience + partial-file cleanup
+- 7 tests for `FormatService`/`ArchiveService` (protects the legacy format promise)
+
+**v1.5 — "Player that feels like a player"**
+- 3.1 fullscreen + expanded video area · 3.2 resume position · 3.3 keyboard · 3.4 subtitles
+- 5.1 window bounds · 5.2 title-bar double-click
+
+**v1.6 — "Catalog at scale"**
+- 1.7 progressive IMDB merge · 1.8 memCacheWidth · 1.5 async downloads-list checks
+- 1.9 fetch timeout · 1.10 search debounce · 4.4 shortcut discoverability · 4.6 downloads sort
+
+**v1.7 — "Workflow & integration"**
+- 5.3 cross-tab toasts · 2.4/2.5 real progress for ffmpeg/7za · 2.3 date/time pickers
+- 2.9 batch encode · 5.4 single instance · 5.5 file associations
+
+---
+
+*Generated 2026-06-12 from a full read of `lib/` at v1.3.0 (`160a361`).*

--- a/lib/core/models/settings_model.dart
+++ b/lib/core/models/settings_model.dart
@@ -11,6 +11,7 @@ class AppSettings {
   final int startupTab;
   final String lastVideoPath;
   final List<int>? tabOrder;
+  final bool deleteAfterDecode;
 
   const AppSettings({
     this.password = '',
@@ -25,6 +26,7 @@ class AppSettings {
     this.startupTab = 0,
     this.lastVideoPath = '',
     this.tabOrder,
+    this.deleteAfterDecode = false,
   });
 
   AppSettings copyWith({
@@ -40,6 +42,7 @@ class AppSettings {
     int? startupTab,
     String? lastVideoPath,
     List<int>? tabOrder,
+    bool? deleteAfterDecode,
   }) {
     return AppSettings(
       password: password ?? this.password,
@@ -57,6 +60,7 @@ class AppSettings {
       startupTab: startupTab ?? this.startupTab,
       lastVideoPath: lastVideoPath ?? this.lastVideoPath,
       tabOrder: tabOrder ?? this.tabOrder,
+      deleteAfterDecode: deleteAfterDecode ?? this.deleteAfterDecode,
     );
   }
 }

--- a/lib/core/services/archive_service.dart
+++ b/lib/core/services/archive_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
@@ -46,9 +47,10 @@ class ArchiveService {
     return t;
   }
 
-  static int _crc32Update(int crc, List<int> data) {
+  static int _crc32Update(int crc, Uint8List data) {
+    final table = _crcTable;
     for (final b in data) {
-      crc = _crcTable[(crc ^ b) & 0xFF] ^ (crc >> 8);
+      crc = table[(crc ^ b) & 0xFF] ^ (crc >> 8);
     }
     return crc;
   }
@@ -69,33 +71,39 @@ class ArchiveService {
   /// When [password] is set, delegates to 7za for AES-256 encryption via stdin
   /// (avoids copying large video files). Falls back to the pure Dart STORE
   /// writer when no password is required.
+  ///
+  /// Unencrypted: runs in a background isolate; progress is polled externally
+  /// via the output file size. [onProgress] is only called with 1.0 on completion.
+  /// Encrypted: [onProgress] fires per 0.5 % of bytes piped to 7za.
   static Future<void> createZip({
     required List<(String, String)> fileEntries,
     required String outputPath,
     String password = '',
     void Function(double)? onProgress,
+    void Function(Process)? onProcessStarted,
   }) async {
     if (password.isNotEmpty) {
-      await _createEncryptedZip(fileEntries, outputPath, password, onProgress);
+      await _createEncryptedZip(
+        fileEntries, outputPath, password, onProgress,
+        onProcessStarted: onProcessStarted,
+      );
       return;
     }
-    // No password — use fast streaming Dart writer.
+    await Isolate.run(() => _doCreateZip(fileEntries, outputPath));
+    onProgress?.call(1.0);
+  }
 
-    int totalBytes = 0;
-    for (final (path, _) in fileEntries) {
-      try {
-        totalBytes += await File(path).length();
-      } catch (_) {}
-    }
-
-    final out = File(outputPath).openWrite();
+  /// Pure-sync ZIP STORE writer — runs inside a background isolate.
+  static void _doCreateZip(
+    List<(String, String)> fileEntries,
+    String outputPath,
+  ) {
+    final outFile = File(outputPath).openSync(mode: FileMode.write);
     int offset = 0;
-    int bytesWritten = 0;
-    double lastReported = -1.0;
     final cdRecords = <List<int>>[];
 
     void w(List<int> bytes) {
-      out.add(bytes);
+      outFile.writeFromSync(bytes);
       offset += bytes.length;
     }
 
@@ -105,63 +113,62 @@ class ArchiveService {
         final localOffset = offset;
 
         // Local file header (30 bytes + filename)
-        w([0x50, 0x4B, 0x03, 0x04]);   // LFH signature
-        w(_u16(20));                     // version needed: 2.0
-        w(_u16(0x0808));                 // flags: bit3=data-descriptor, bit11=UTF-8
-        w(_u16(0));                      // compression: STORE
-        w(_u16(0));                      // mod time
-        w(_u16(0));                      // mod date
-        w(_u32(0));                      // CRC-32 (deferred via data descriptor)
-        w(_u32(0));                      // compressed size (deferred)
-        w(_u32(0));                      // uncompressed size (deferred)
-        w(_u16(nameBytes.length));       // filename length
-        w(_u16(0));                      // extra field length
-        w(nameBytes);                    // filename
+        w([0x50, 0x4B, 0x03, 0x04]);
+        w(_u16(20));
+        w(_u16(0x0808));
+        w(_u16(0));
+        w(_u16(0));
+        w(_u16(0));
+        w(_u32(0));
+        w(_u32(0));
+        w(_u32(0));
+        w(_u16(nameBytes.length));
+        w(_u16(0));
+        w(nameBytes);
 
         // Stream file data, computing CRC-32 incrementally
+        final inFile = File(sourcePath).openSync();
         int crc = 0xFFFFFFFF;
         int fileSize = 0;
-        await for (final chunk in File(sourcePath).openRead()) {
-          w(chunk);
-          crc = _crc32Update(crc, chunk);
-          fileSize += chunk.length;
-          bytesWritten += chunk.length;
-          if (onProgress != null && totalBytes > 0) {
-            final frac = (bytesWritten / totalBytes).clamp(0.0, 0.99);
-            if (frac - lastReported >= 0.005) {
-              lastReported = frac;
-              onProgress(frac);
-            }
+        try {
+          while (true) {
+            final block = inFile.readSync(65536);
+            if (block.isEmpty) break;
+            w(block);
+            crc = _crc32Update(crc, block);
+            fileSize += block.length;
           }
+        } finally {
+          inFile.closeSync();
         }
         final finalCrc = (crc ^ 0xFFFFFFFF) & 0xFFFFFFFF;
 
-        // Data descriptor (sig + CRC + compressed size + uncompressed size)
-        w([0x50, 0x4B, 0x07, 0x08]);   // DD signature
+        // Data descriptor
+        w([0x50, 0x4B, 0x07, 0x08]);
         w(_u32(finalCrc));
         w(_u32(fileSize));
-        w(_u32(fileSize));              // compressed == uncompressed for STORE
+        w(_u32(fileSize));
 
-        // Central directory record for this file
+        // Central directory record
         final cd = <int>[];
         void cw(List<int> b) => cd.addAll(b);
-        cw([0x50, 0x4B, 0x01, 0x02]);  // CDR signature
-        cw(_u16(20));                    // version made by
-        cw(_u16(20));                    // version needed
-        cw(_u16(0x0808));                // flags (match LFH)
-        cw(_u16(0));                     // compression: STORE
-        cw(_u16(0));                     // mod time
-        cw(_u16(0));                     // mod date
+        cw([0x50, 0x4B, 0x01, 0x02]);
+        cw(_u16(20));
+        cw(_u16(20));
+        cw(_u16(0x0808));
+        cw(_u16(0));
+        cw(_u16(0));
+        cw(_u16(0));
         cw(_u32(finalCrc));
-        cw(_u32(fileSize));              // compressed size
-        cw(_u32(fileSize));              // uncompressed size
-        cw(_u16(nameBytes.length));      // filename length
-        cw(_u16(0));                     // extra field length
-        cw(_u16(0));                     // comment length
-        cw(_u16(0));                     // disk number start
-        cw(_u16(0));                     // internal file attributes
-        cw(_u32(0));                     // external file attributes
-        cw(_u32(localOffset));           // offset of local header
+        cw(_u32(fileSize));
+        cw(_u32(fileSize));
+        cw(_u16(nameBytes.length));
+        cw(_u16(0));
+        cw(_u16(0));
+        cw(_u16(0));
+        cw(_u16(0));
+        cw(_u32(0));
+        cw(_u32(localOffset));
         cw(nameBytes);
         cdRecords.add(cd);
       }
@@ -174,19 +181,16 @@ class ArchiveService {
       final cdSize = offset - cdOffset;
 
       // End of central directory record
-      w([0x50, 0x4B, 0x05, 0x06]);     // EOCD signature
-      w(_u16(0));                        // disk number
-      w(_u16(0));                        // disk with CD start
-      w(_u16(cdRecords.length));         // entries on this disk
-      w(_u16(cdRecords.length));         // total entries
-      w(_u32(cdSize));                   // CD size
-      w(_u32(cdOffset));                 // CD offset
-      w(_u16(0));                        // comment length
-
-      await out.flush();
-      onProgress?.call(1.0);
+      w([0x50, 0x4B, 0x05, 0x06]);
+      w(_u16(0));
+      w(_u16(0));
+      w(_u16(cdRecords.length));
+      w(_u16(cdRecords.length));
+      w(_u32(cdSize));
+      w(_u32(cdOffset));
+      w(_u16(0));
     } finally {
-      await out.close();
+      outFile.closeSync();
     }
   }
 
@@ -196,8 +200,9 @@ class ArchiveService {
     List<(String, String)> fileEntries,
     String outputPath,
     String password,
-    void Function(double)? onProgress,
-  ) async {
+    void Function(double)? onProgress, {
+    void Function(Process)? onProcessStarted,
+  }) async {
     final sevenZ = await sevenZipPath;
     int totalBytes = 0;
     for (final (path, _) in fileEntries) {
@@ -206,18 +211,29 @@ class ArchiveService {
       } catch (_) {}
     }
     int processed = 0;
+    double lastFrac = 0.0;
+
     for (final (sourcePath, archiveName) in fileEntries) {
       final process = await Process.start(sevenZ, [
         'a', '-tzip', '-p$password', '-mem=AES256', outputPath, '-si$archiveName',
       ]);
-      await for (final chunk in File(sourcePath).openRead()) {
-        process.stdin.add(chunk);
+      onProcessStarted?.call(process);
+
+      // addStream provides natural backpressure; map() throttles progress calls.
+      final countingStream = File(sourcePath).openRead().map((chunk) {
         processed += chunk.length;
         if (onProgress != null && totalBytes > 0) {
-          onProgress((processed / totalBytes).clamp(0.0, 0.99));
+          final frac = (processed / totalBytes).clamp(0.0, 0.99);
+          if (frac - lastFrac >= 0.005) {
+            lastFrac = frac;
+            onProgress(frac);
+          }
         }
-      }
+        return chunk;
+      });
+      await process.stdin.addStream(countingStream);
       await process.stdin.close();
+
       final exitCode = await process.exitCode;
       if (exitCode != 0) {
         final err = await process.stderr.transform(utf8.decoder).join();

--- a/lib/core/services/ffmpeg_service.dart
+++ b/lib/core/services/ffmpeg_service.dart
@@ -19,6 +19,39 @@ class FfmpegService {
     return dest;
   }
 
+  /// Starts mask video generation and returns the [Process] handle so the
+  /// caller can cancel it. Collect stderr and await [Process.exitCode] yourself.
+  static Future<Process> startMaskGeneration({
+    required String posterPath,
+    required String outputPath,
+    required String date,
+    required String time,
+    int durationSeconds = 5,
+    bool preserveAspectRatio = true,
+    int targetWidth = 1920,
+    int targetHeight = 1080,
+  }) async {
+    final ffmpeg = await binaryPath;
+    final creationTime = '${date}T$time';
+    final w = targetWidth;
+    final h = targetHeight;
+    final scaleFilter = preserveAspectRatio
+        ? 'scale=$w:$h:force_original_aspect_ratio=decrease,pad=$w:$h:(ow-iw)/2:(oh-ih)/2:color=black'
+        : 'scale=$w:$h';
+    final args = [
+      '-y',
+      '-loop', '1',
+      '-i', posterPath,
+      '-c:v', 'libx264',
+      '-t', '$durationSeconds',
+      '-pix_fmt', 'yuv420p',
+      '-vf', scaleFilter,
+      '-metadata', 'creation_time=$creationTime',
+      outputPath,
+    ];
+    return Process.start(ffmpeg, args);
+  }
+
   /// Builds a mask video from [posterPath].
   /// [targetWidth]x[targetHeight] is auto-detected from poster orientation by
   /// the caller. [preserveAspectRatio] letterboxes; false stretches to fill.

--- a/lib/core/services/format_service.dart
+++ b/lib/core/services/format_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:typed_data';
 
 const _separator = '\nbreakpoint\n';
@@ -22,20 +23,23 @@ class FormatService {
   }
 
   /// Extracts the archive payload from an encoded MP4 into [outputArchivePath].
-  /// Scans the entire file for the separator (fixes the legacy 1 MB bug).
+  /// Runs in a background isolate to avoid freezing the UI on large files.
   static Future<bool> extractArchive({
     required String inputPath,
     required String outputArchivePath,
-  }) async {
+  }) =>
+      Isolate.run(() => _doExtractArchive(inputPath, outputArchivePath));
+
+  static bool _doExtractArchive(String inputPath, String outputArchivePath) {
+    const chunkSize = 1024 * 1024;
     final input = File(inputPath).openSync();
     try {
-      final fileLen = await File(inputPath).length();
-      const chunkSize = 1024 * 1024; // 1 MB read window
+      final fileLen = input.lengthSync();
+      final tailSize = _separatorBytes.length - 1; // 12 bytes — only what's needed to catch splits
       int offset = 0;
       int sepOffset = -1;
-
-      // Sliding-window search for separator
       Uint8List? tail;
+
       while (offset < fileLen) {
         final toRead = (offset + chunkSize > fileLen)
             ? (fileLen - offset).toInt()
@@ -43,39 +47,41 @@ class FormatService {
         input.setPositionSync(offset);
         final chunk = input.readSync(toRead);
 
-        // Combine tail of previous read with current chunk to handle splits
-        final search = tail != null
-            ? Uint8List.fromList([...tail, ...chunk])
-            : Uint8List.fromList(chunk);
+        final Uint8List search;
+        if (tail != null) {
+          search = Uint8List(tail.length + chunk.length)
+            ..setRange(0, tail.length, tail)
+            ..setRange(tail.length, tail.length + chunk.length, chunk);
+        } else {
+          search = chunk;
+        }
 
         final idx = _findSeparator(search);
         if (idx != -1) {
-          // Absolute offset of separator start
           final tailLen = tail?.length ?? 0;
           sepOffset = offset - tailLen + idx;
           break;
         }
 
-        tail = chunk.length >= _separatorBytes.length
-            ? Uint8List.fromList(
-                chunk.sublist(chunk.length - _separatorBytes.length))
-            : chunk;
+        tail = chunk.length >= tailSize
+            ? Uint8List.fromList(chunk.sublist(chunk.length - tailSize))
+            : Uint8List.fromList(chunk);
         offset += toRead;
       }
 
       if (sepOffset == -1) return false;
 
       final payloadStart = sepOffset + _separatorBytes.length;
-      final out = File(outputArchivePath).openWrite();
+      final out = File(outputArchivePath).openSync(mode: FileMode.write);
       try {
         input.setPositionSync(payloadStart);
         while (true) {
           final block = input.readSync(chunkSize);
           if (block.isEmpty) break;
-          out.add(block);
+          out.writeFromSync(block);
         }
       } finally {
-        await out.close();
+        out.closeSync();
       }
       return true;
     } finally {
@@ -85,9 +91,11 @@ class FormatService {
 
   static int _findSeparator(Uint8List data) {
     final sep = _separatorBytes;
+    final first = sep[0];
     outer:
     for (int i = 0; i <= data.length - sep.length; i++) {
-      for (int j = 0; j < sep.length; j++) {
+      if (data[i] != first) continue;
+      for (int j = 1; j < sep.length; j++) {
         if (data[i + j] != sep[j]) continue outer;
       }
       return i;

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -27,6 +27,7 @@ const _kSyncplayRoom = 'syncplay_room';
 const _kStartupTab = 'startup_tab';
 const _kLastVideoPath = 'last_video_path';
 const _kTabOrder = 'tab_order';
+const _kDeleteAfterDecode = 'setting_delete_after_decode';
 
 class SettingsNotifier extends Notifier<AppSettings> {
   late SharedPreferences _prefs;
@@ -52,6 +53,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
           ?.split(',')
           .map(int.parse)
           .toList(),
+      deleteAfterDecode: _prefs.getBool(_kDeleteAfterDecode) ?? false,
     );
   }
 
@@ -110,6 +112,11 @@ class SettingsNotifier extends Notifier<AppSettings> {
     await _prefs.setInt(_kStartupTab, value);
   }
 
+  Future<void> setDeleteAfterDecode(bool value) async {
+    state = state.copyWith(deleteAfterDecode: value);
+    await _prefs.setBool(_kDeleteAfterDecode, value);
+  }
+
   Future<void> setTabOrder(List<int> value) async {
     state = state.copyWith(tabOrder: value);
     await _prefs.setString(_kTabOrder, value.join(','));
@@ -130,6 +137,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
       startupTab: state.startupTab,
       lastVideoPath: state.lastVideoPath,
       tabOrder: null,
+      deleteAfterDecode: state.deleteAfterDecode,
     );
   }
 

--- a/lib/features/catalog/catalog_notifier.dart
+++ b/lib/features/catalog/catalog_notifier.dart
@@ -470,22 +470,29 @@ class DownloadNotifier extends Notifier<DownloadState> {
   Future<void> _processQueue() async {
     _running = true;
     String? lastFilePath;
+    final failed = <String>[];
 
     while (_queue.isNotEmpty && !_cancelled) {
       final job = _queue.removeAt(0);
       try {
-        lastFilePath = await _runJob(job);
+        final path = await _runJob(job);
+        if (path.isNotEmpty) lastFilePath = path;
       } catch (e) {
-        if (!_cancelled && !_disposed) state = DownloadError('Download failed: $e');
-        _queue.clear();
-        _running = false;
-        return;
+        if (_cancelled || _disposed) break;
+        failed.add('"${job.title}": $e');
+        // Continue with remaining jobs.
       }
     }
 
     _running = false;
-    if (!_cancelled && !_disposed && state is! DownloadError) {
-      state = lastFilePath != null ? DownloadDone(lastFilePath) : DownloadIdle();
+    if (_cancelled || _disposed) return;
+    if (failed.isNotEmpty) {
+      final summary = '${failed.length} download(s) failed:\n${failed.join('\n')}';
+      state = DownloadError(summary);
+    } else if (lastFilePath != null) {
+      state = DownloadDone(lastFilePath);
+    } else {
+      state = DownloadIdle();
     }
   }
 
@@ -540,6 +547,7 @@ class DownloadNotifier extends Notifier<DownloadState> {
     int received = 0;
     var lastTick = DateTime.now();
     int bytesInWindow = 0;
+    bool downloadError = false;
 
     try {
       await for (final chunk in response.stream) {
@@ -563,16 +571,19 @@ class DownloadNotifier extends Notifier<DownloadState> {
           bytesInWindow = 0;
         }
       }
+    } catch (_) {
+      downloadError = true;
+      rethrow;
     } finally {
       await sink.flush();
       await sink.close();
       _client?.close();
+      if (_cancelled || downloadError) {
+        try { file.deleteSync(); } catch (_) {}
+      }
     }
 
-    if (_cancelled) {
-      try { file.deleteSync(); } catch (_) {}
-      return '';
-    }
+    if (_cancelled) return '';
 
     // Record in history.
     await ref.read(downloadHistoryProvider.notifier).add(DownloadRecord(

--- a/lib/features/decode/decode_notifier.dart
+++ b/lib/features/decode/decode_notifier.dart
@@ -53,7 +53,8 @@ class DecodeNotifier extends Notifier<DecodeState> {
 
     try {
       final tmpDir = await getTemporaryDirectory();
-      final cacheDir = Directory(p.join(tmpDir.path, 'mstorage_cache'));
+      final uid = DateTime.now().microsecondsSinceEpoch.toString();
+      final cacheDir = Directory(p.join(tmpDir.path, 'mstorage_cache', uid));
       await cacheDir.create(recursive: true);
 
       final title = p.basenameWithoutExtension(config.videoPath);
@@ -112,7 +113,7 @@ class DecodeNotifier extends Notifier<DecodeState> {
           .map((f) => f.path)
           .toList();
 
-      await cacheDir.delete(recursive: true);
+      try { await cacheDir.delete(recursive: true); } catch (_) {}
 
       state = state.copyWith(
         step: DecodeStep.done,

--- a/lib/features/decode/decode_screen.dart
+++ b/lib/features/decode/decode_screen.dart
@@ -98,6 +98,7 @@ class _DecodeScreenState extends ConsumerState<DecodeScreen> {
     // Keep the history record so Downloads still shows the entry with a Play button.
     ref.listen<DecodeState>(decodeProvider, (previous, next) {
       if (previous?.step != DecodeStep.done && next.step == DecodeStep.done) {
+        if (!ref.read(settingsProvider).deleteAfterDecode) return;
         final path = _videoPath;
         if (path != null) {
           try {

--- a/lib/features/encode/encode_notifier.dart
+++ b/lib/features/encode/encode_notifier.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:ui' as ui;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -47,15 +48,21 @@ class EncodeState {
 }
 
 class EncodeNotifier extends Notifier<EncodeState> {
+  Process? _ffmpegProcess;
+  Process? _zipProcess;
+  bool _cancelled = false;
+
   @override
   EncodeState build() => const EncodeState();
 
   Future<void> run(EncodeConfig config) async {
+    _cancelled = false;
     state = const EncodeState(step: EncodeStep.generatingMask);
 
     try {
       final tmpDir = await getTemporaryDirectory();
-      final cacheDir = Directory(p.join(tmpDir.path, 'mstorage_cache'));
+      final uid = DateTime.now().microsecondsSinceEpoch.toString();
+      final cacheDir = Directory(p.join(tmpDir.path, 'mstorage_cache', uid));
       await cacheDir.create(recursive: true);
 
       final maskPath = p.join(cacheDir.path, 'mask.mp4');
@@ -95,7 +102,7 @@ class EncodeNotifier extends Notifier<EncodeState> {
         }
       }
 
-      final maskResult = await FfmpegService.generateMaskVideo(
+      final ffmpegProcess = await FfmpegService.startMaskGeneration(
         posterPath: posterPath,
         outputPath: maskPath,
         date: config.date,
@@ -105,10 +112,17 @@ class EncodeNotifier extends Notifier<EncodeState> {
         targetWidth: targetWidth,
         targetHeight: targetHeight,
       );
-      if (maskResult.exitCode != 0 || !File(maskPath).existsSync()) {
+      _ffmpegProcess = ffmpegProcess;
+      final stderr = StringBuffer();
+      ffmpegProcess.stderr.transform(utf8.decoder).listen(stderr.write);
+      final ffmpegExit = await ffmpegProcess.exitCode;
+      _ffmpegProcess = null;
+
+      if (_cancelled) return;
+      if (ffmpegExit != 0 || !File(maskPath).existsSync()) {
         state = state.copyWith(
           step: EncodeStep.error,
-          errorMessage: 'ffmpeg failed: ${maskResult.stderr}',
+          errorMessage: 'ffmpeg failed: ${stderr.toString()}',
         );
         return;
       }
@@ -122,12 +136,43 @@ class EncodeNotifier extends Notifier<EncodeState> {
         if (config.posterPath != null && config.posterPath!.isNotEmpty)
           (config.posterPath!, '${config.title}${p.extension(config.posterPath!)}'),
       ];
-      await ArchiveService.createZip(
-        fileEntries: filesToArchive,
-        outputPath: archivePath,
-        password: config.password,
-        onProgress: (prog) => state = state.copyWith(compressProgress: prog),
-      );
+
+      // For unencrypted ZIP (runs in isolate), poll output file size for progress.
+      int totalInputBytes = 0;
+      if (config.password.isEmpty) {
+        for (final (path, _) in filesToArchive) {
+          try { totalInputBytes += File(path).lengthSync(); } catch (_) {}
+        }
+      }
+      Timer? zipPoll;
+      if (totalInputBytes > 0) {
+        zipPoll = Timer.periodic(const Duration(milliseconds: 250), (_) {
+          try {
+            final written = File(archivePath).lengthSync();
+            state = state.copyWith(
+              compressProgress: (written / totalInputBytes).clamp(0.0, 0.99),
+            );
+          } catch (_) {}
+        });
+      }
+      try {
+        await ArchiveService.createZip(
+          fileEntries: filesToArchive,
+          outputPath: archivePath,
+          password: config.password,
+          onProgress: config.password.isNotEmpty
+              ? (prog) => state = state.copyWith(compressProgress: prog)
+              : null,
+          onProcessStarted: config.password.isNotEmpty
+              ? (proc) => _zipProcess = proc
+              : null,
+        );
+      } finally {
+        zipPoll?.cancel();
+        _zipProcess = null;
+      }
+
+      if (_cancelled) return;
       if (!File(archivePath).existsSync()) {
         state = state.copyWith(
           step: EncodeStep.error,
@@ -167,16 +212,26 @@ class EncodeNotifier extends Notifier<EncodeState> {
         combinePoll?.cancel();
       }
 
-      // Cleanup cache
-      await cacheDir.delete(recursive: true);
+      // Cleanup own cache dir only
+      try { await cacheDir.delete(recursive: true); } catch (_) {}
 
       state = state.copyWith(step: EncodeStep.done, outputPath: outputPath);
     } catch (e) {
+      if (_cancelled) return;
       state = state.copyWith(
         step: EncodeStep.error,
         errorMessage: e.toString(),
       );
     }
+  }
+
+  void cancel() {
+    _cancelled = true;
+    _ffmpegProcess?.kill();
+    _ffmpegProcess = null;
+    _zipProcess?.kill();
+    _zipProcess = null;
+    state = const EncodeState();
   }
 
   void reset() => state = const EncodeState();

--- a/lib/features/encode/encode_screen.dart
+++ b/lib/features/encode/encode_screen.dart
@@ -191,6 +191,28 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
         ? AppDirectories.encoded
         : settings.encodeOutputDirectory;
 
+    final outputFile = File(p.join(outDir, '$title.mp4'));
+    if (outputFile.existsSync()) {
+      final overwrite = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('File already exists'),
+          content: Text('"$title.mp4" already exists in the output folder. Overwrite?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Overwrite'),
+            ),
+          ],
+        ),
+      );
+      if (overwrite != true) return;
+    }
+
     await ref.read(encodeProvider.notifier).run(
           EncodeConfig(
             videoPath: _videoPath!,
@@ -237,6 +259,17 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
                         color: accent,
                       ),
                     ),
+                    if (encodeState.isRunning)
+                      TextButton.icon(
+                        onPressed: () =>
+                            ref.read(encodeProvider.notifier).cancel(),
+                        icon: const Icon(Icons.cancel_rounded, size: 16),
+                        label: const Text('Cancel'),
+                        style: TextButton.styleFrom(
+                          foregroundColor: kTextMuted,
+                          textStyle: const TextStyle(fontSize: 12),
+                        ),
+                      ).animate().fadeIn(duration: 200.ms),
                     if (anyFieldSet && encodeState.step == EncodeStep.idle)
                       TextButton.icon(
                         onPressed: _clearAll,

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -732,6 +732,33 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           const SizedBox(height: 20),
 
+          // ── Decode Options ───────────────────────────────────────────────
+          _SettingsGroup(
+            label: 'Decode Options',
+            accent: accent,
+            children: [
+              _SettingRow(
+                icon: Icons.delete_outline_rounded,
+                title: 'Delete Source After Decode',
+                subtitle:
+                    'Automatically delete the encoded mask MP4 once decoding completes successfully.',
+                accent: accent,
+                control: Switch(
+                  value: settings.deleteAfterDecode,
+                  onChanged: (v) => ref
+                      .read(settingsProvider.notifier)
+                      .setDeleteAfterDecode(v),
+                  activeThumbColor: accent,
+                  activeTrackColor: accent.withValues(alpha: 0.3),
+                  inactiveThumbColor: kTextMuted,
+                  inactiveTrackColor: kSurface2Color,
+                ),
+              ),
+            ],
+          ).animate().fadeIn(duration: 300.ms, delay: 200.ms),
+
+          const SizedBox(height: 20),
+
           if (!updatePending) ...[
             // ── Updates ────────────────────────────────────────────────────
             updatesGroup,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.3.0+9
+version: 1.4.0+10
 
 environment:
   sdk: ^3.11.5

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -1,0 +1,248 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_storage/core/services/archive_service.dart';
+import 'package:m_storage/core/services/format_service.dart';
+import 'package:m_storage/features/catalog/models/catalog_entry.dart';
+import 'package:m_storage/features/updater/update_service.dart';
+
+void main() {
+  // ── UpdateService.isNewer ───────────────────────────────────────────────────
+
+  group('UpdateService.isNewer', () {
+    test('newer major version', () =>
+        expect(UpdateService.isNewer('2.0.0', '1.9.9'), isTrue));
+    test('newer minor version', () =>
+        expect(UpdateService.isNewer('1.4.0', '1.3.0'), isTrue));
+    test('newer patch version', () =>
+        expect(UpdateService.isNewer('1.3.1', '1.3.0'), isTrue));
+    test('same version returns false', () =>
+        expect(UpdateService.isNewer('1.3.0', '1.3.0'), isFalse));
+    test('older version returns false', () =>
+        expect(UpdateService.isNewer('1.2.9', '1.3.0'), isFalse));
+    test('v-prefix stripped correctly', () =>
+        expect(UpdateService.isNewer('v1.4.0', 'v1.3.0'), isTrue));
+    test('shorter version treated as trailing zeros', () {
+      expect(UpdateService.isNewer('2', '1.9.9'), isTrue);
+      expect(UpdateService.isNewer('1.3', '1.3.0'), isFalse);
+    });
+  });
+
+  // ── FormatService ───────────────────────────────────────────────────────────
+
+  group('FormatService', () {
+    late Directory tmp;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('mstorage_test_');
+    });
+
+    tearDown(() async {
+      try {
+        await tmp.delete(recursive: true);
+      } catch (_) {}
+    });
+
+    test('combine → extractArchive round-trips payload exactly', () async {
+      final maskPath = '${tmp.path}/mask.mp4';
+      final archivePath = '${tmp.path}/payload.zip';
+      final outputPath = '${tmp.path}/encoded.mp4';
+      final extractedPath = '${tmp.path}/extracted.zip';
+
+      await File(maskPath).writeAsBytes(List.generate(512, (i) => i & 0xFF));
+      await File(archivePath).writeAsBytes(List.generate(256, (i) => (i + 100) & 0xFF));
+
+      await FormatService.combine(
+        maskPath: maskPath,
+        archivePath: archivePath,
+        outputPath: outputPath,
+      );
+
+      final found = await FormatService.extractArchive(
+        inputPath: outputPath,
+        outputArchivePath: extractedPath,
+      );
+
+      expect(found, isTrue);
+      final extracted = await File(extractedPath).readAsBytes();
+      final original = await File(archivePath).readAsBytes();
+      expect(extracted, equals(original));
+    });
+
+    test('extractArchive returns false when separator absent', () async {
+      final inputPath = '${tmp.path}/nosep.mp4';
+      final extractedPath = '${tmp.path}/out.zip';
+      await File(inputPath).writeAsBytes(List.generate(1024, (i) => i & 0xFF));
+
+      final found = await FormatService.extractArchive(
+        inputPath: inputPath,
+        outputArchivePath: extractedPath,
+      );
+      expect(found, isFalse);
+    });
+
+    test('extractArchive handles separator split across 1 MB chunk boundary', () async {
+      // '\nbreakpoint\n' = 12 bytes; split so first 6 land in chunk 1, last 6 in chunk 2.
+      const sep = '\nbreakpoint\n';
+      final sepBytes = Uint8List.fromList(sep.codeUnits);
+      const chunkSize = 1024 * 1024;
+      const splitAt = chunkSize - 6; // separator starts here
+
+      final payload = List.generate(200, (i) => (i * 3) & 0xFF);
+      final data = Uint8List(splitAt + sepBytes.length + payload.length)
+        ..setRange(0, splitAt, List.generate(splitAt, (i) => (i * 7) & 0xFF))
+        ..setRange(splitAt, splitAt + sepBytes.length, sepBytes)
+        ..setRange(splitAt + sepBytes.length, splitAt + sepBytes.length + payload.length, payload);
+
+      final inputPath = '${tmp.path}/split.mp4';
+      final extractedPath = '${tmp.path}/split_out.zip';
+      await File(inputPath).writeAsBytes(data);
+
+      final found = await FormatService.extractArchive(
+        inputPath: inputPath,
+        outputArchivePath: extractedPath,
+      );
+      expect(found, isTrue);
+      final extracted = await File(extractedPath).readAsBytes();
+      expect(extracted, equals(payload));
+    });
+  });
+
+  // ── ArchiveService ZIP round-trip ───────────────────────────────────────────
+
+  group('ArchiveService ZIP (unencrypted)', () {
+    late Directory tmp;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('mstorage_zip_test_');
+    });
+
+    tearDown(() async {
+      try {
+        await tmp.delete(recursive: true);
+      } catch (_) {}
+    });
+
+    test('createZip produces valid ZIP with correct entry contents', () async {
+      final file1 = File('${tmp.path}/movie.mp4');
+      final file2 = File('${tmp.path}/movie.srt');
+      final mp4Bytes = List.generate(4096, (i) => i & 0xFF);
+      final srtContent = '1\n00:00:01,000 --> 00:00:02,000\nHello World';
+
+      await file1.writeAsBytes(mp4Bytes);
+      await file2.writeAsString(srtContent);
+
+      final zipPath = '${tmp.path}/out.zip';
+      await ArchiveService.createZip(
+        fileEntries: [
+          (file1.path, 'movie.mp4'),
+          (file2.path, 'movie.srt'),
+        ],
+        outputPath: zipPath,
+      );
+
+      expect(File(zipPath).existsSync(), isTrue);
+      final zipBytes = await File(zipPath).readAsBytes();
+
+      // Verify ZIP local file header magic
+      expect(zipBytes[0], equals(0x50));
+      expect(zipBytes[1], equals(0x4B));
+      expect(zipBytes[2], equals(0x03));
+      expect(zipBytes[3], equals(0x04));
+
+      // Decode and verify round-trip
+      final archive = ZipDecoder().decodeBytes(zipBytes);
+      expect(archive.files.length, equals(2));
+
+      final names = archive.files.map((f) => f.name).toSet();
+      expect(names, containsAll(['movie.mp4', 'movie.srt']));
+
+      final mp4Entry = archive.files.firstWhere((f) => f.name == 'movie.mp4');
+      expect(mp4Entry.content, equals(mp4Bytes));
+
+      final srtEntry = archive.files.firstWhere((f) => f.name == 'movie.srt');
+      expect(String.fromCharCodes(srtEntry.content as List<int>), equals(srtContent));
+    });
+  });
+
+  // ── CatalogEntry CSV parsing ────────────────────────────────────────────────
+
+  group('CatalogEntry.fromRow', () {
+    Map<String, int> mkHeaders(List<String> cols) => {
+          for (var i = 0; i < cols.length; i++)
+            cols[i].toLowerCase().replaceAll(RegExp(r'[\s_\-]+'), ''): i,
+        };
+
+    test('parses canonical column names', () {
+      final h = mkHeaders([
+        'imdbId', 'title', 'videoUrl', 'genres', 'tags',
+        'plot', 'posterUrl', 'sizeMb', 'encoded', 'date',
+      ]);
+      final row = [
+        'tt1234567', 'Test Movie', 'https://photos.google.com/abc',
+        'Action, Thriller', 'Marvel', 'A hero rises.',
+        'https://example.com/poster.jpg', '4200', 'true', '2024-06-15',
+      ];
+      final entry = CatalogEntry.fromRow(row, h);
+
+      expect(entry.imdbId, equals('tt1234567'));
+      expect(entry.title, equals('Test Movie'));
+      expect(entry.videoUrl, equals('https://photos.google.com/abc'));
+      expect(entry.genres, containsAll(['Action', 'Thriller']));
+      expect(entry.tags, contains('Marvel'));
+      expect(entry.plot, equals('A hero rises.'));
+      expect(entry.sizeMb, equals(4200));
+      expect(entry.encoded, isTrue);
+      expect(entry.date, equals(DateTime(2024, 6, 15)));
+    });
+
+    test('falls back to imdbId as title when title column absent', () {
+      final h = mkHeaders(['imdbId', 'videoUrl']);
+      final entry = CatalogEntry.fromRow(['tt9876543', 'https://example.com'], h);
+      expect(entry.title, equals('tt9876543'));
+    });
+
+    test('legacy url alias accepted', () {
+      final h = mkHeaders(['imdbId', 'title', 'url']);
+      final entry = CatalogEntry.fromRow(['tt1', 'Movie', 'https://example.com/v'], h);
+      expect(entry.videoUrl, equals('https://example.com/v'));
+    });
+
+    test('encoded defaults to false when column absent', () {
+      final h = mkHeaders(['title']);
+      final entry = CatalogEntry.fromRow(['A Movie'], h);
+      expect(entry.encoded, isFalse);
+    });
+
+    test('genres parsed from comma-separated string', () {
+      final h = mkHeaders(['title', 'genres']);
+      final entry = CatalogEntry.fromRow(['X', 'Action, Drama, Sci-Fi'], h);
+      expect(entry.genres, equals(['Action', 'Drama', 'Sci-Fi']));
+    });
+
+    test('Google Drive URL converted to thumbnail URL', () {
+      final h = mkHeaders(['title', 'posterUrl']);
+      final entry = CatalogEntry.fromRow(
+          ['X', 'https://drive.google.com/file/d/ABCDEF123/view'], h);
+      expect(entry.thumbnailUrl, contains('ABCDEF123'));
+      expect(entry.thumbnailUrl, contains('thumbnail'));
+    });
+
+    test('show=false rows are filtered — encoded false when value is false', () {
+      // Direct test of the visibility logic via the encoded column (same false-string check)
+      final h = mkHeaders(['title', 'encoded']);
+      final entry = CatalogEntry.fromRow(['X', 'false'], h);
+      expect(entry.encoded, isFalse);
+    });
+
+    test('slide_images parsed from comma-separated URLs', () {
+      final h = mkHeaders(['title', 'slideImages']);
+      final entry = CatalogEntry.fromRow(
+          ['X', 'https://a.com/1.jpg, https://b.com/2.jpg'], h);
+      expect(entry.slideImages.length, equals(2));
+      expect(entry.slideImages[0], equals('https://a.com/1.jpg'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- All encode/decode jobs now use isolated temp directories, eliminating cache collisions when running both simultaneously
- CPU/IO-heavy work (separator scan, ZIP writer) moved off the UI thread to background isolates
- Encode cancel support added with process handle tracking; overwrite guard prevents silent clobbers
- Download queue continues on per-job failures instead of aborting; partial files cleaned up on error
- Auto-delete source after decode is now an opt-in Settings toggle (was always-on)
- 19 unit tests added covering FormatService, ArchiveService, UpdateService, and catalog CSV parsing

## Test plan

- [ ] Encode and decode simultaneously — confirm no cache collision
- [ ] Encode a large file — progress bar moves during ZIP and combine steps
- [ ] Cancel encode mid-run — Cancel button appears, encode stops cleanly
- [ ] Encode to a path where output already exists — overwrite dialog shown
- [ ] Decode with "Delete Source After Decode" off (default) — source file preserved
- [ ] Decode with "Delete Source After Decode" on — source file deleted after success
- [ ] Queue multiple downloads with one bad URL — queue continues, summary error shown
- [ ] `flutter test test/core_test.dart` — all 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)