### PR TITLE
feat: v1.4.2 — Performance, UX & correctness improvements

### DIFF
--- a/lib/core/models/settings_model.dart
+++ b/lib/core/models/settings_model.dart
@@ -8,16 +8,10 @@ class AppSettings {
   final int syncplayPort;
   final String syncplayUsername;
   final String syncplayRoom;
-  final int startupTab;
   final String lastVideoPath;
   final List<int>? tabOrder;
   final bool deleteAfterDecode;
   final double playerVolume;
-  final double windowX;
-  final double windowY;
-  final double windowWidth;
-  final double windowHeight;
-  final bool windowMaximized;
 
   const AppSettings({
     this.password = '',
@@ -29,16 +23,10 @@ class AppSettings {
     this.syncplayPort = 8999,
     this.syncplayUsername = '',
     this.syncplayRoom = '',
-    this.startupTab = 0,
     this.lastVideoPath = '',
     this.tabOrder,
     this.deleteAfterDecode = false,
     this.playerVolume = 100.0,
-    this.windowX = -1,
-    this.windowY = -1,
-    this.windowWidth = -1,
-    this.windowHeight = -1,
-    this.windowMaximized = false,
   });
 
   AppSettings copyWith({
@@ -51,16 +39,10 @@ class AppSettings {
     int? syncplayPort,
     String? syncplayUsername,
     String? syncplayRoom,
-    int? startupTab,
     String? lastVideoPath,
     List<int>? tabOrder,
     bool? deleteAfterDecode,
     double? playerVolume,
-    double? windowX,
-    double? windowY,
-    double? windowWidth,
-    double? windowHeight,
-    bool? windowMaximized,
   }) {
     return AppSettings(
       password: password ?? this.password,
@@ -75,16 +57,10 @@ class AppSettings {
       syncplayPort: syncplayPort ?? this.syncplayPort,
       syncplayUsername: syncplayUsername ?? this.syncplayUsername,
       syncplayRoom: syncplayRoom ?? this.syncplayRoom,
-      startupTab: startupTab ?? this.startupTab,
       lastVideoPath: lastVideoPath ?? this.lastVideoPath,
       tabOrder: tabOrder ?? this.tabOrder,
       deleteAfterDecode: deleteAfterDecode ?? this.deleteAfterDecode,
       playerVolume: playerVolume ?? this.playerVolume,
-      windowX: windowX ?? this.windowX,
-      windowY: windowY ?? this.windowY,
-      windowWidth: windowWidth ?? this.windowWidth,
-      windowHeight: windowHeight ?? this.windowHeight,
-      windowMaximized: windowMaximized ?? this.windowMaximized,
     );
   }
 }

--- a/lib/core/providers/player_request_provider.dart
+++ b/lib/core/providers/player_request_provider.dart
@@ -7,3 +7,6 @@ final playerOpenRequestProvider = StateProvider<String?>((ref) => null);
 /// True while the player is in fullscreen mode.
 /// AppShell hides the title bar and sidebar while this is true.
 final playerFullscreenProvider = StateProvider<bool>((ref) => false);
+
+/// Mirrors _sharedPlayer.state.playing so the sidebar can show a playing dot.
+final playerPlayingProvider = StateProvider<bool>((ref) => false);

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -24,16 +24,10 @@ const _kMaskDuration = 'setting_mask_duration';
 const _kSyncplayPort = 'syncplay_port';
 const _kSyncplayUsername = 'syncplay_username';
 const _kSyncplayRoom = 'syncplay_room';
-const _kStartupTab = 'startup_tab';
 const _kLastVideoPath = 'last_video_path';
 const _kTabOrder = 'tab_order';
 const _kDeleteAfterDecode = 'setting_delete_after_decode';
 const _kPlayerVolume = 'player_volume';
-const _kWindowX = 'window_x';
-const _kWindowY = 'window_y';
-const _kWindowWidth = 'window_width';
-const _kWindowHeight = 'window_height';
-const _kWindowMaximized = 'window_maximized';
 
 class SettingsNotifier extends Notifier<AppSettings> {
   late SharedPreferences _prefs;
@@ -53,7 +47,6 @@ class SettingsNotifier extends Notifier<AppSettings> {
       syncplayPort: _prefs.getInt(_kSyncplayPort) ?? 8999,
       syncplayUsername: _prefs.getString(_kSyncplayUsername) ?? '',
       syncplayRoom: _prefs.getString(_kSyncplayRoom) ?? '',
-      startupTab: _prefs.getInt(_kStartupTab) ?? 0,
       lastVideoPath: _prefs.getString(_kLastVideoPath) ?? '',
       tabOrder: _prefs.getString(_kTabOrder)
           ?.split(',')
@@ -61,11 +54,6 @@ class SettingsNotifier extends Notifier<AppSettings> {
           .toList(),
       deleteAfterDecode: _prefs.getBool(_kDeleteAfterDecode) ?? false,
       playerVolume: _prefs.getDouble(_kPlayerVolume) ?? 100.0,
-      windowX: _prefs.getDouble(_kWindowX) ?? -1,
-      windowY: _prefs.getDouble(_kWindowY) ?? -1,
-      windowWidth: _prefs.getDouble(_kWindowWidth) ?? -1,
-      windowHeight: _prefs.getDouble(_kWindowHeight) ?? -1,
-      windowMaximized: _prefs.getBool(_kWindowMaximized) ?? false,
     );
   }
 
@@ -119,11 +107,6 @@ class SettingsNotifier extends Notifier<AppSettings> {
     await _prefs.setString(_kLastVideoPath, value);
   }
 
-  Future<void> setStartupTab(int value) async {
-    state = state.copyWith(startupTab: value);
-    await _prefs.setInt(_kStartupTab, value);
-  }
-
   Future<void> setDeleteAfterDecode(bool value) async {
     state = state.copyWith(deleteAfterDecode: value);
     await _prefs.setBool(_kDeleteAfterDecode, value);
@@ -132,24 +115,6 @@ class SettingsNotifier extends Notifier<AppSettings> {
   Future<void> setPlayerVolume(double value) async {
     state = state.copyWith(playerVolume: value);
     await _prefs.setDouble(_kPlayerVolume, value);
-  }
-
-  Future<void> setWindowBounds({
-    required double x,
-    required double y,
-    required double width,
-    required double height,
-  }) async {
-    state = state.copyWith(windowX: x, windowY: y, windowWidth: width, windowHeight: height);
-    await _prefs.setDouble(_kWindowX, x);
-    await _prefs.setDouble(_kWindowY, y);
-    await _prefs.setDouble(_kWindowWidth, width);
-    await _prefs.setDouble(_kWindowHeight, height);
-  }
-
-  Future<void> setWindowMaximized(bool value) async {
-    state = state.copyWith(windowMaximized: value);
-    await _prefs.setBool(_kWindowMaximized, value);
   }
 
   Future<void> setTabOrder(List<int> value) async {
@@ -169,16 +134,10 @@ class SettingsNotifier extends Notifier<AppSettings> {
       syncplayPort: state.syncplayPort,
       syncplayUsername: state.syncplayUsername,
       syncplayRoom: state.syncplayRoom,
-      startupTab: state.startupTab,
       lastVideoPath: state.lastVideoPath,
       tabOrder: null,
       deleteAfterDecode: state.deleteAfterDecode,
       playerVolume: state.playerVolume,
-      windowX: state.windowX,
-      windowY: state.windowY,
-      windowWidth: state.windowWidth,
-      windowHeight: state.windowHeight,
-      windowMaximized: state.windowMaximized,
     );
   }
 

--- a/lib/features/catalog/catalog_notifier.dart
+++ b/lib/features/catalog/catalog_notifier.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show unawaited;
+import 'dart:async' show TimeoutException, unawaited;
 import 'dart:convert';
 import 'dart:io';
 import 'package:csv/csv.dart';
@@ -224,7 +224,8 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
 
     // No cache — fetch fresh (show loading until done).
     try {
-      final response = await http.get(Uri.parse(csvUrl));
+      final response = await http.get(Uri.parse(csvUrl))
+          .timeout(const Duration(seconds: 15));
 
       if (response.statusCode != 200 ||
           response.body.trimLeft().startsWith('<')) {
@@ -239,6 +240,10 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
       unawaited(_saveCsvCache(sheetId, response.body));
       final entries = await _buildEntries(response.body);
       if (mounted) state = CatalogLoaded(entries);
+    } on TimeoutException {
+      if (mounted) {
+        state = CatalogError('Request timed out — check your connection and try again.');
+      }
     } catch (e) {
       if (mounted) state = CatalogError('Failed to fetch catalog: $e');
     }
@@ -248,7 +253,8 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
   Future<void> _silentRefresh(
       String sheetId, String csvUrl, String cachedBody) async {
     try {
-      final response = await http.get(Uri.parse(csvUrl));
+      final response = await http.get(Uri.parse(csvUrl))
+          .timeout(const Duration(seconds: 15));
       if (response.statusCode != 200 ||
           response.body.trimLeft().startsWith('<')) { return; }
       if (response.body == cachedBody) {

--- a/lib/features/decode/decode_notifier.dart
+++ b/lib/features/decode/decode_notifier.dart
@@ -100,9 +100,12 @@ class DecodeNotifier extends Notifier<DecodeState> {
       if (_cancelled) return;
 
       if (exitCode != 0) {
+        final errText = stderr.toString();
+        final isWrongPassword = errText.contains('Wrong password') ||
+            errText.contains('CRC Failed');
         state = state.copyWith(
           step: DecodeStep.error,
-          errorMessage: 'Extraction failed: ${stderr.toString()}',
+          errorMessage: isWrongPassword ? 'wrong_password' : 'Extraction failed: $errText',
         );
         return;
       }

--- a/lib/features/decode/decode_screen.dart
+++ b/lib/features/decode/decode_screen.dart
@@ -213,7 +213,15 @@ class _DecodeScreenState extends ConsumerState<DecodeScreen> {
                   .fadeIn(),
 
             if (state.step == DecodeStep.error)
-              ErrorBanner(message: state.errorMessage ?? 'Unknown error')
+              (state.errorMessage == 'wrong_password'
+                  ? PasswordWarningBanner(
+                      accentColor: accent,
+                      message: 'Incorrect password — the file could not be decrypted.',
+                      onGoToSettings: () => ref
+                          .read(activeTabProvider.notifier)
+                          .state = AppTab.settings,
+                    )
+                  : ErrorBanner(message: state.errorMessage ?? 'Unknown error'))
                   .animate()
                   .fadeIn()
                   .shakeX(),

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -66,8 +66,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   bool _showLogs = false;
   StreamSubscription<String>? _stdoutSub;
   StreamSubscription<String>? _stderrSub;
+  StreamSubscription<bool>? _playingSub;
 
-  // v1.4.1 additions
   List<String> _availableSubtitles = [];
   String? _activeSubtitle;
 
@@ -86,6 +86,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     _initVolume();
     HardwareKeyboard.instance.addHandler(_handleKeyEvent);
 
+    // Mirror playing state into a provider so the sidebar dot can react.
+    _playingSub = _sharedPlayer.stream.playing.listen((playing) {
+      if (mounted) ref.read(playerPlayingProvider.notifier).state = playing;
+    });
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final path = ref.read(playerOpenRequestProvider);
@@ -99,6 +104,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   @override
   void dispose() {
     HardwareKeyboard.instance.removeHandler(_handleKeyEvent);
+    _playingSub?.cancel();
+    ref.read(playerPlayingProvider.notifier).state = false;
     _player.stop();
     _usernameCtrl.dispose();
     _roomCtrl.dispose();
@@ -369,6 +376,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       if (path != null && ref.read(activeTabProvider) == AppTab.player) {
         ref.read(playerOpenRequestProvider.notifier).state = null;
         _openVideo(path);
+      }
+    });
+
+    // Pause automatically when leaving the Player tab.
+    ref.listen<AppTab>(activeTabProvider, (prev, next) {
+      if (prev == AppTab.player && next != AppTab.player) {
+        _player.pause();
       }
     });
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -306,27 +306,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         AppTab.admin    => (Icons.admin_panel_settings_rounded, 'Admin'),
       };
 
-  static int _effectiveStartupTab(AppSettings settings, String? sheetUrl) {
-    if (settings.startupTab != 0) return settings.startupTab;
-    return sheetUrl != null ? AppTab.catalog.index : AppTab.encode.index;
-  }
-
   static List<int> _effectiveOrder(AppSettings settings, String? sheetUrl) {
     if (settings.tabOrder != null) return settings.tabOrder!;
-    const defaultOrder = [
-      AppTab.encode,
-      AppTab.decode,
-      AppTab.player,
-      AppTab.catalog,
-      AppTab.settings,
-    ];
-    if (settings.startupTab != 0) {
-      final startupIdx = settings.startupTab.clamp(0, AppTab.settings.index);
-      return [
-        startupIdx,
-        ...defaultOrder.map((t) => t.index).where((i) => i != startupIdx),
-      ];
-    }
     if (sheetUrl != null) {
       return [
         AppTab.catalog.index,
@@ -336,7 +317,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         AppTab.settings.index,
       ];
     }
-    return defaultOrder.map((t) => t.index).toList();
+    return [
+      AppTab.encode.index,
+      AppTab.decode.index,
+      AppTab.player.index,
+      AppTab.catalog.index,
+      AppTab.settings.index,
+    ];
   }
 
   Widget _buildLayoutSection(AppSettings settings, Color accent, String? sheetUrl) {
@@ -369,11 +356,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 _ActionButton(
                   label: 'Reset',
                   accent: accent,
-                  onTap: () async {
-                    final n = ref.read(settingsProvider.notifier);
-                    await n.resetTabOrder();
-                    await n.setStartupTab(0);
-                  },
+                  onTap: () => ref.read(settingsProvider.notifier).resetTabOrder(),
                 ),
             ],
           ),
@@ -474,24 +457,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final sheetUrl = ref.watch(sheetUrlProvider);
     final accent = _palette.primary;
     final updateState = ref.watch(updateProvider);
-    final updatePending = updateState.status == UpdateStatus.available ||
-        updateState.status == UpdateStatus.downloading ||
-        updateState.status == UpdateStatus.readyToInstall;
-
-    final updatesGroup = _SettingsGroup(
-      label: 'Updates',
-      accent: accent,
-      children: [
-        _SettingRow(
-          icon: Icons.system_update_rounded,
-          title: 'Check for Updates',
-          subtitle: '',
-          subtitleWidget: _buildUpdateSubtitle(updateState, accent),
-          accent: accent,
-          control: _buildUpdateControl(updateState),
-        ),
-      ],
-    ).animate().fadeIn(duration: 300.ms, delay: 40.ms);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(28),
@@ -506,50 +471,21 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ),
           const SizedBox(height: 32),
 
-          if (updatePending) ...[
-            updatesGroup,
-            const SizedBox(height: 20),
-          ],
-
-          // ── General ──────────────────────────────────────────────────────
+          // ── Updates ──────────────────────────────────────────────────────
           _SettingsGroup(
-            label: 'General',
+            label: 'Updates',
             accent: accent,
             children: [
               _SettingRow(
-                icon: Icons.home_rounded,
-                title: 'Startup Page',
-                subtitle: 'Which tab opens when the app launches.',
+                icon: Icons.system_update_rounded,
+                title: 'Check for Updates',
+                subtitle: '',
+                subtitleWidget: _buildUpdateSubtitle(updateState, accent),
                 accent: accent,
-                control: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    for (final tab in [AppTab.encode, AppTab.decode, AppTab.player, AppTab.catalog])
-                      Padding(
-                        padding: const EdgeInsets.only(left: 6),
-                        child: _ChipButton(
-                          label: tab.name[0].toUpperCase() + tab.name.substring(1),
-                          selected: _effectiveStartupTab(settings, sheetUrl) == tab.index,
-                          accent: accent,
-                          onTap: () => ref
-                              .read(settingsProvider.notifier)
-                              .setStartupTab(tab.index),
-                        ),
-                      ),
-                  ],
-                ),
+                control: _buildUpdateControl(updateState),
               ),
             ],
           ).animate().fadeIn(duration: 300.ms, delay: 40.ms),
-
-          const SizedBox(height: 20),
-
-          // ── Layout ───────────────────────────────────────────────────────
-          _SettingsGroup(
-            label: 'Layout',
-            accent: accent,
-            children: [_buildLayoutSection(settings, accent, sheetUrl)],
-          ).animate().fadeIn(duration: 300.ms, delay: 60.ms),
 
           const SizedBox(height: 20),
 
@@ -606,6 +542,15 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               ),
             ],
           ).animate().fadeIn(duration: 300.ms, delay: 60.ms),
+
+          const SizedBox(height: 20),
+
+          // ── Layout ───────────────────────────────────────────────────────
+          _SettingsGroup(
+            label: 'Layout',
+            accent: accent,
+            children: [_buildLayoutSection(settings, accent, sheetUrl)],
+          ).animate().fadeIn(duration: 300.ms, delay: 80.ms),
 
           const SizedBox(height: 20),
 
@@ -758,12 +703,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ).animate().fadeIn(duration: 300.ms, delay: 200.ms),
 
           const SizedBox(height: 20),
-
-          if (!updatePending) ...[
-            // ── Updates ────────────────────────────────────────────────────
-            updatesGroup,
-            const SizedBox(height: 20),
-          ],
 
           // ── Cache ─────────────────────────────────────────────────────────
           _SettingsGroup(

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -22,13 +22,13 @@ import '../catalog/catalog_notifier.dart';
 import '../catalog/series_notifier.dart' show catalogSubPaletteProvider;
 import '../settings/settings_screen.dart';
 
-// Reads startupTab from already-loaded settings (main() loads before runApp).
+// Startup tab = first item in the effective page order.
 // ref.read (not watch) so user navigation doesn't get overridden on rebuilds.
 final activeTabProvider = StateProvider<AppTab>((ref) {
   final settings = ref.read(settingsProvider);
-  final idx = settings.startupTab;
-  if (idx != 0) return AppTab.values[idx.clamp(0, AppTab.settings.index)];
-  // At default (0): open Catalog if sheet URL is configured, otherwise Encode.
+  if (settings.tabOrder != null && settings.tabOrder!.isNotEmpty) {
+    return AppTab.values[settings.tabOrder!.first.clamp(0, AppTab.settings.index)];
+  }
   final sheetUrl = ref.read(sheetUrlProvider);
   return sheetUrl != null ? AppTab.catalog : AppTab.encode;
 });
@@ -53,7 +53,6 @@ class _AppShellState extends ConsumerState<AppShell>
 
   AppTab? _exitingTab;
   bool _isMaximized = false;
-  Timer? _boundsSaveTimer;
 
   @override
   void initState() {
@@ -89,7 +88,6 @@ class _AppShellState extends ConsumerState<AppShell>
   @override
   void dispose() {
     windowManager.removeListener(this);
-    _boundsSaveTimer?.cancel();
     _ctrl.dispose();
     super.dispose();
   }
@@ -97,50 +95,17 @@ class _AppShellState extends ConsumerState<AppShell>
   // ── WindowListener ─────────────────────────────────────────────────────
 
   @override
-  void onWindowMaximize() {
-    setState(() => _isMaximized = true);
-    ref.read(settingsProvider.notifier).setWindowMaximized(true);
-  }
+  void onWindowMaximize() => setState(() => _isMaximized = true);
 
   @override
-  void onWindowUnmaximize() {
-    setState(() => _isMaximized = false);
-    ref.read(settingsProvider.notifier).setWindowMaximized(false);
-  }
-
-  @override
-  void onWindowResize() => _scheduleBoundsSave();
-
-  @override
-  void onWindowMove() => _scheduleBoundsSave();
-
-  // Also handle the "resized" / "moved" final events if available
-  @override
-  void onWindowResized() => _scheduleBoundsSave();
-
-  @override
-  void onWindowMoved() => _scheduleBoundsSave();
-
-  void _scheduleBoundsSave() {
-    _boundsSaveTimer?.cancel();
-    _boundsSaveTimer = Timer(const Duration(milliseconds: 500), () async {
-      if (!mounted || _isMaximized) return;
-      try {
-        final bounds = await windowManager.getBounds();
-        if (mounted && !_isMaximized) {
-          ref.read(settingsProvider.notifier).setWindowBounds(
-            x: bounds.left,
-            y: bounds.top,
-            width: bounds.width,
-            height: bounds.height,
-          );
-        }
-      } catch (_) {}
-    });
-  }
+  void onWindowUnmaximize() => setState(() => _isMaximized = false);
 
   // ── WindowListener no-ops ───────────────────────────────────────────────
 
+  @override void onWindowResize() {}
+  @override void onWindowResized() {}
+  @override void onWindowMove() {}
+  @override void onWindowMoved() {}
   @override void onWindowEvent(String eventName) {}
   @override void onWindowFocus() {}
   @override void onWindowBlur() {}
@@ -313,11 +278,16 @@ class _AppShellState extends ConsumerState<AppShell>
                           final isExiting = tab == _exitingTab;
 
                           if (!isActive && !isExiting) {
-                            return IgnorePointer(
-                              child: Opacity(
-                                opacity: 0,
-                                child: _screenFor(tab),
-                              ),
+                            // Player keeps tickers so audio continues off-tab;
+                            // all other tabs are fully frozen.
+                            return Offstage(
+                              offstage: true,
+                              child: tab == AppTab.player
+                                  ? _screenFor(tab)
+                                  : TickerMode(
+                                      enabled: false,
+                                      child: _screenFor(tab),
+                                    ),
                             );
                           }
 
@@ -539,6 +509,7 @@ class _SidebarState extends ConsumerState<_Sidebar> {
   Widget build(BuildContext context) {
     final encodeRunning = ref.watch(encodeProvider).isRunning;
     final decodeRunning = ref.watch(decodeProvider).isRunning;
+    final playerPlaying = ref.watch(playerPlayingProvider);
     final isAdmin = ref.watch(ghAuthProvider).valueOrNull ?? false;
     final updateStatus = ref.watch(updateProvider).status;
 
@@ -549,13 +520,6 @@ class _SidebarState extends ConsumerState<_Sidebar> {
           .where((i) => i <= AppTab.settings.index)
           .map((i) => _baseItems.firstWhere((item) => item.$1.index == i))
           .toList();
-    } else if (settings.startupTab != 0) {
-      final startupTab =
-          AppTab.values[settings.startupTab.clamp(0, AppTab.settings.index)];
-      base = [
-        ..._baseItems.where((i) => i.$1 == startupTab),
-        ..._baseItems.where((i) => i.$1 != startupTab),
-      ];
     } else {
       final sheetUrl = ref.watch(sheetUrlProvider);
       if (sheetUrl != null) {
@@ -590,7 +554,8 @@ class _SidebarState extends ConsumerState<_Sidebar> {
               isActive: widget.activeTab == item.$1,
               isHovered: _hovered == item.$1,
               isRunning: (item.$1 == AppTab.encode && encodeRunning) ||
-                  (item.$1 == AppTab.decode && decodeRunning),
+                  (item.$1 == AppTab.decode && decodeRunning) ||
+                  (item.$1 == AppTab.player && playerPlaying),
               hasBadge: item.$1 == AppTab.settings &&
                   (updateStatus == UpdateStatus.available ||
                    updateStatus == UpdateStatus.downloading ||

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,31 +15,17 @@ void main() async {
   final container = ProviderContainer();
   await container.read(settingsProvider.notifier).load();
 
-  final settings = container.read(settingsProvider);
-  final hasSavedBounds = settings.windowWidth > 0 && settings.windowHeight > 0;
-
   await windowManager.ensureInitialized();
   await windowManager.waitUntilReadyToShow(
-    WindowOptions(
-      size: hasSavedBounds
-          ? Size(settings.windowWidth, settings.windowHeight)
-          : const Size(1100, 740),
-      minimumSize: const Size(860, 600),
-      // Only center when no saved position exists
-      center: !hasSavedBounds,
+    const WindowOptions(
+      size: Size(1100, 740),
+      minimumSize: Size(860, 600),
+      center: true,
       title: 'mStorage',
       titleBarStyle: TitleBarStyle.hidden,
       backgroundColor: Colors.transparent,
     ),
     () async {
-      // Restore saved position if valid (both axes non-negative)
-      if (hasSavedBounds && settings.windowX >= 0 && settings.windowY >= 0) {
-        await windowManager.setPosition(Offset(settings.windowX, settings.windowY));
-      }
-      // Restore maximized state
-      if (settings.windowMaximized) {
-        await windowManager.maximize();
-      }
       await windowManager.show();
       await windowManager.focus();
     },


### PR DESCRIPTION
## Summary

- **Offstage hidden tabs** — replaces `Opacity(0)` with `Offstage`+`TickerMode`, eliminating layout and animation cost for all inactive tabs (Player tab exempt so audio continues)
- **Auto-pause on tab-leave** — switching away from Player tab pauses playback; sidebar shows pulsing dot while audio is playing
- **Wrong-password decode error** — detects 7za `Wrong password`/`CRC Failed` markers and shows a friendly message with a "Go to Settings" button instead of raw stderr
- **Catalog fetch timeout** — 15s timeout on CSV fetch with a human-readable error on expiry
- **Reverted window bounds memory** — removed size/position/maximized persistence (not needed for a preview-focused player)
- **Settings UX** — removed Startup Page selector (app opens on the first page in the order), Updates section always pinned to top, Archive Password moved above Layout

## Test plan

- [ ] Hidden tabs: switch between tabs rapidly — no animation jank, audio continues from Player while on another tab
- [ ] Tab-leave pause: open a video in Player, switch to Encode — playback pauses; sidebar dot disappears
- [ ] Wrong password: encode a file with a password, clear the password in Settings, try to decode — friendly error appears with Settings button
- [ ] Catalog timeout: set an invalid sheet URL — error shows within ~15s
- [ ] Settings order: Updates → Archive Password → Layout → Output Directories
- [ ] Page order reset: drag pages to a custom order, Reset button appears; clicking it reverts to default (Catalog-first if sheet URL set, Encode-first otherwise)
- [ ] App startup: with custom order set, app opens on whichever page is first in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)