### PR TITLE
feat: v1.5.0 — Performance, resilience, and UX improvements

### DIFF
--- a/lib/features/catalog/catalog_notifier.dart
+++ b/lib/features/catalog/catalog_notifier.dart
@@ -134,10 +134,10 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
     } catch (_) {}
   }
 
-  // ── CSV → entries pipeline (shared by cached and fresh paths) ─────────────
+  // ── CSV → entries pipeline ─────────────────────────────────────────────────
 
-  Future<List<CatalogEntry>> _buildEntries(String csvBody) async {
-    // Normalize CRLF → LF so the parser works regardless of what Google returns.
+  /// Parses CSV into raw entries (no network). Fast — safe to call before showing UI.
+  List<CatalogEntry> _parseRaw(String csvBody) {
     final normalized = csvBody.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
     final rows = const CsvToListConverter(eol: '\n').convert(normalized);
     if (rows.length < 2) return [];
@@ -151,11 +151,10 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
             .replaceAll(RegExp(r'[\s_\-]+'), ''): i,
     };
 
-    // Index of the visibility column. Canonical name is 'show'; legacy aliases kept for backward compat.
     final visIdx = headers['show'] ?? headers['enabled'] ?? headers['visible'] ??
         headers['active'];
 
-    final rawEntries = rows
+    return rows
         .skip(1)
         .where((row) {
           if (row.isEmpty || row[0].toString().trim().isEmpty) return false;
@@ -167,8 +166,11 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
         })
         .map((row) => CatalogEntry.fromRow(row, headers))
         .toList();
+  }
 
-    final imdbIds = rawEntries
+  /// Merges IMDB metadata into [raw] entries. Makes network calls for uncached IDs.
+  Future<List<CatalogEntry>> _mergeImdb(List<CatalogEntry> raw) async {
+    final imdbIds = raw
         .where((e) => e.imdbId.isNotEmpty)
         .map((e) => e.imdbId)
         .toList();
@@ -177,7 +179,7 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
         ? await ImdbService().resolve(imdbIds)
         : <String, dynamic>{};
 
-    return rawEntries.map((e) {
+    return raw.map((e) {
       final data = imdbMap[e.imdbId];
       return data != null ? e.mergeImdb(data) : e;
     }).toList();
@@ -210,7 +212,10 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
       // Serve from disk cache immediately if available.
       final cached = await _loadCsvCache(sheetId);
       if (cached != null) {
-        final entries = await _buildEntries(cached.body);
+        // Show raw entries immediately, then merge IMDB (likely instant from cache).
+        final raw = _parseRaw(cached.body);
+        if (mounted) state = CatalogLoaded(raw);
+        final entries = await _mergeImdb(raw);
         if (mounted) state = CatalogLoaded(entries);
 
         final age = DateTime.now().difference(cached.fetchedAt);
@@ -238,7 +243,9 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
       }
 
       unawaited(_saveCsvCache(sheetId, response.body));
-      final entries = await _buildEntries(response.body);
+      final raw = _parseRaw(response.body);
+      if (mounted) state = CatalogLoaded(raw);
+      final entries = await _mergeImdb(raw);
       if (mounted) state = CatalogLoaded(entries);
     } on TimeoutException {
       if (mounted) {
@@ -263,7 +270,8 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
         return;
       }
       unawaited(_saveCsvCache(sheetId, response.body));
-      final entries = await _buildEntries(response.body);
+      final raw = _parseRaw(response.body);
+      final entries = await _mergeImdb(raw);
       if (mounted) state = CatalogLoaded(entries);
     } catch (_) {}
   }
@@ -443,6 +451,7 @@ final downloadProvider =
 
 class DownloadNotifier extends Notifier<DownloadState> {
   final _queue = <_DownloadJob>[];
+  final _failedJobs = <_DownloadJob>[];
   http.Client? _client;
   bool _cancelled = false;
   bool _running = false;
@@ -475,8 +484,9 @@ class DownloadNotifier extends Notifier<DownloadState> {
 
   Future<void> _processQueue() async {
     _running = true;
+    _failedJobs.clear();
     String? lastFilePath;
-    final failed = <String>[];
+    final failedMessages = <String>[];
 
     while (_queue.isNotEmpty && !_cancelled) {
       final job = _queue.removeAt(0);
@@ -485,21 +495,29 @@ class DownloadNotifier extends Notifier<DownloadState> {
         if (path.isNotEmpty) lastFilePath = path;
       } catch (e) {
         if (_cancelled || _disposed) break;
-        failed.add('"${job.title}": $e');
-        // Continue with remaining jobs.
+        _failedJobs.add(job);
+        failedMessages.add('"${job.title}": $e');
       }
     }
 
     _running = false;
     if (_cancelled || _disposed) return;
-    if (failed.isNotEmpty) {
-      final summary = '${failed.length} download(s) failed:\n${failed.join('\n')}';
+    if (failedMessages.isNotEmpty) {
+      final summary = '${failedMessages.length} download(s) failed:\n${failedMessages.join('\n')}';
       state = DownloadError(summary);
     } else if (lastFilePath != null) {
       state = DownloadDone(lastFilePath);
     } else {
       state = DownloadIdle();
     }
+  }
+
+  void retryFailed() {
+    if (_failedJobs.isEmpty) return;
+    _queue.addAll(_failedJobs);
+    _failedJobs.clear();
+    _cancelled = false;
+    _processQueue();
   }
 
   /// Runs a single download job. Returns the saved file path on success.

--- a/lib/features/catalog/catalog_screen.dart
+++ b/lib/features/catalog/catalog_screen.dart
@@ -279,6 +279,11 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
               },
               onToggleDownloads: () =>
                   setState(() => _showDownloads = !_showDownloads),
+              onOpenFolder: () {
+                final dir = ref.read(settingsProvider).catalogDownloadDirectory;
+                Process.run('explorer.exe',
+                    [dir.isNotEmpty ? dir : AppDirectories.downloaded]);
+              },
             ),
             const SizedBox(height: 12),
             if (!isSeriesTab && !_showDownloads && catalogState is CatalogLoaded) ...[
@@ -380,6 +385,8 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
                                   ref.read(downloadProvider.notifier).dismiss(),
                               onCancel: () =>
                                   ref.read(downloadProvider.notifier).cancel(),
+                              onRetry: () =>
+                                  ref.read(downloadProvider.notifier).retryFailed(),
                               onDecodeThis: (path) {
                                 ref.read(downloadProvider.notifier).dismiss();
                                 ref
@@ -531,6 +538,7 @@ class _TopBar extends StatelessWidget {
   final VoidCallback? onRefresh;
   final VoidCallback onClearUrl;
   final VoidCallback onToggleDownloads;
+  final VoidCallback onOpenFolder;
 
   const _TopBar({
     required this.palette,
@@ -544,6 +552,7 @@ class _TopBar extends StatelessWidget {
     required this.onRefresh,
     required this.onClearUrl,
     required this.onToggleDownloads,
+    required this.onOpenFolder,
   });
 
   @override
@@ -571,6 +580,14 @@ class _TopBar extends StatelessWidget {
           palette: palette,
           onTap: onToggleDownloads,
         ),
+        if (showDownloads) ...[
+          const SizedBox(width: 6),
+          _IconBtn(
+            icon: Icons.folder_open_rounded,
+            tooltip: 'Open downloads folder',
+            onTap: onOpenFolder,
+          ),
+        ],
         if (sheetUrl != null) ...[
           const SizedBox(width: 6),
           _IconBtn(
@@ -1053,6 +1070,7 @@ class _DownloadPanel extends StatelessWidget {
   final TabPalette palette;
   final VoidCallback onDismiss;
   final VoidCallback onCancel;
+  final VoidCallback onRetry;
   final void Function(String filePath) onDecodeThis;
 
   const _DownloadPanel({
@@ -1061,6 +1079,7 @@ class _DownloadPanel extends StatelessWidget {
     required this.palette,
     required this.onDismiss,
     required this.onCancel,
+    required this.onRetry,
     required this.onDecodeThis,
   });
 
@@ -1109,6 +1128,7 @@ class _DownloadPanel extends StatelessWidget {
         DownloadError(:final message) => _ErrorDownload(
             message: message,
             onDismiss: onDismiss,
+            onRetry: onRetry,
           ),
         _ => const SizedBox.shrink(),
       },
@@ -1294,8 +1314,13 @@ class _DoneDownload extends StatelessWidget {
 class _ErrorDownload extends StatelessWidget {
   final String message;
   final VoidCallback onDismiss;
+  final VoidCallback onRetry;
 
-  const _ErrorDownload({required this.message, required this.onDismiss});
+  const _ErrorDownload({
+    required this.message,
+    required this.onDismiss,
+    required this.onRetry,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1304,9 +1329,15 @@ class _ErrorDownload extends StatelessWidget {
         const Icon(Icons.error_outline_rounded, size: 18, color: Colors.redAccent),
         const SizedBox(width: 8),
         Expanded(
-          child: Text(message, maxLines: 2, style: TextStyle(fontSize: 12, color: kTextSecondary)),
+          child: Text(message, maxLines: 2, style: const TextStyle(fontSize: 12, color: kTextSecondary)),
         ),
         const SizedBox(width: 12),
+        TextButton(
+          onPressed: onRetry,
+          style: TextButton.styleFrom(foregroundColor: Colors.redAccent, padding: EdgeInsets.zero),
+          child: const Text('Retry', style: TextStyle(fontSize: 12)),
+        ),
+        const SizedBox(width: 4),
         TextButton(
           onPressed: onDismiss,
           style: TextButton.styleFrom(foregroundColor: kTextMuted, padding: EdgeInsets.zero),
@@ -1532,6 +1563,7 @@ class _DownloadRecordRow extends StatelessWidget {
                     ? CachedNetworkImage(
                         imageUrl: record.thumbnailUrl,
                         cacheManager: CatalogCacheManager.instance,
+                        memCacheWidth: 200,
                         fit: BoxFit.cover,
                         errorWidget: (_, _, _) => Container(
                           color: kSurface2Color,

--- a/lib/features/catalog/imdb_service.dart
+++ b/lib/features/catalog/imdb_service.dart
@@ -127,9 +127,14 @@ class ImdbService {
     }
 
     if (toFetch.isNotEmpty) {
+      // Split into batches of _batchSize, fetch up to 4 concurrently.
+      final batches = <List<String>>[];
       for (var i = 0; i < toFetch.length; i += _batchSize) {
-        final batch = toFetch.sublist(i, min(i + _batchSize, toFetch.length));
-        await _fetchBatch(batch, result);
+        batches.add(toFetch.sublist(i, min(i + _batchSize, toFetch.length)));
+      }
+      for (var i = 0; i < batches.length; i += 4) {
+        final window = batches.sublist(i, min(i + 4, batches.length));
+        await Future.wait(window.map((b) => _fetchBatch(b, result)));
       }
       await _persist();
     }

--- a/lib/features/catalog/widgets/catalog_card.dart
+++ b/lib/features/catalog/widgets/catalog_card.dart
@@ -844,6 +844,7 @@ class _ThumbnailState extends State<_Thumbnail> {
                   CachedNetworkImage(
                     imageUrl: widget.url,
                     cacheManager: CatalogCacheManager.instance,
+                    memCacheWidth: 400,
                     fit: BoxFit.cover,
                     placeholder: (_, _) => _placeholder(),
                     errorWidget: (_, _, _) => _placeholder(),
@@ -857,6 +858,7 @@ class _ThumbnailState extends State<_Thumbnail> {
                   CachedNetworkImage(
                     imageUrl: widget.url,
                     cacheManager: CatalogCacheManager.instance,
+                    memCacheWidth: 400,
                     fit: foregroundFit,
                     placeholder: (_, _) => const SizedBox.shrink(),
                     errorWidget: (_, _, _) => const SizedBox.shrink(),

--- a/lib/features/catalog/widgets/series_card.dart
+++ b/lib/features/catalog/widgets/series_card.dart
@@ -637,6 +637,7 @@ class _SeriesThumbnail extends StatelessWidget {
                   CachedNetworkImage(
                     imageUrl: url,
                     cacheManager: CatalogCacheManager.instance,
+                    memCacheWidth: 400,
                     fit: BoxFit.cover,
                     placeholder: (_, _) => _placeholder(),
                     errorWidget: (_, _, _) => _placeholder(),
@@ -651,6 +652,7 @@ class _SeriesThumbnail extends StatelessWidget {
                   CachedNetworkImage(
                     imageUrl: url,
                     cacheManager: CatalogCacheManager.instance,
+                    memCacheWidth: 400,
                     fit: BoxFit.cover,
                     placeholder: (_, _) => const SizedBox.shrink(),
                     errorWidget: (_, _, _) => const SizedBox.shrink(),

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -53,6 +53,7 @@ class _AppShellState extends ConsumerState<AppShell>
 
   AppTab? _exitingTab;
   bool _isMaximized = false;
+  final List<_ToastEntry> _toasts = [];
 
   @override
   void initState() {
@@ -85,10 +86,25 @@ class _AppShellState extends ConsumerState<AppShell>
     if (mounted) setState(() {});
   }
 
+  void _addToast(String message, TabPalette palette, AppTab target) {
+    final id = DateTime.now().microsecondsSinceEpoch;
+    final entry = _ToastEntry(
+      id: id,
+      message: message,
+      palette: palette,
+      target: target,
+      timer: Timer(const Duration(seconds: 4), () {
+        if (mounted) setState(() => _toasts.removeWhere((t) => t.id == id));
+      }),
+    );
+    if (mounted) setState(() => _toasts.add(entry));
+  }
+
   @override
   void dispose() {
     windowManager.removeListener(this);
     _ctrl.dispose();
+    for (final t in _toasts) { t.timer.cancel(); }
     super.dispose();
   }
 
@@ -249,79 +265,127 @@ class _AppShellState extends ConsumerState<AppShell>
       }
     });
 
+    ref.listen(encodeProvider, (prev, next) {
+      if (prev?.step != EncodeStep.done && next.step == EncodeStep.done) {
+        if (ref.read(activeTabProvider) != AppTab.encode) {
+          _addToast('Encode complete', AppTab.encode.palette, AppTab.encode);
+        }
+      }
+    });
+
+    ref.listen(decodeProvider, (prev, next) {
+      if (prev?.step != DecodeStep.done && next.step == DecodeStep.done) {
+        if (ref.read(activeTabProvider) != AppTab.decode) {
+          _addToast('Decode complete', AppTab.decode.palette, AppTab.decode);
+        }
+      }
+    });
+
+    ref.listen(downloadProvider, (prev, next) {
+      if (prev is! DownloadDone && next is DownloadDone) {
+        if (ref.read(activeTabProvider) != AppTab.catalog) {
+          _addToast('Download complete', AppTab.catalog.palette, AppTab.catalog);
+        }
+      }
+    });
+
     return AnimatedTheme(
       duration: const Duration(milliseconds: 300),
       data: Theme.of(context),
       child: Scaffold(
         backgroundColor: kBgColor,
-        body: Column(
+        body: Stack(
           children: [
-            if (!isFullscreen)
-              _TitleBar(
-                activeTab: activeTab,
-                palette: palette,
-                isMaximized: _isMaximized,
-              ),
-            Expanded(
-              child: Row(
-                children: [
-                  if (!isFullscreen)
-                    _Sidebar(activeTab: activeTab, palette: palette),
-                  Expanded(
-                    child: AnimatedContainer(
-                      duration: const Duration(milliseconds: 300),
-                      color: palette.surface,
-                      child: Stack(
-                        fit: StackFit.expand,
-                        children: AppTab.values.map((tab) {
-                          final isActive  = tab == activeTab;
-                          final isExiting = tab == _exitingTab;
-
-                          if (!isActive && !isExiting) {
-                            // Player keeps tickers so audio continues off-tab;
-                            // all other tabs are fully frozen.
-                            return Offstage(
-                              offstage: true,
-                              child: tab == AppTab.player
-                                  ? _screenFor(tab)
-                                  : TickerMode(
-                                      enabled: false,
-                                      child: _screenFor(tab),
-                                    ),
-                            );
-                          }
-
-                          if (isActive) {
-                            return AnimatedBuilder(
-                              animation: _ctrl,
-                              builder: (_, child) => FadeTransition(
-                                opacity: _enterFade,
-                                child: SlideTransition(
-                                  position: _enterSlide,
-                                  child: child,
-                                ),
-                              ),
-                              child: _screenFor(tab),
-                            );
-                          }
-
-                          return IgnorePointer(
-                            child: AnimatedBuilder(
-                              animation: _ctrl,
-                              builder: (_, child) => FadeTransition(
-                                opacity: _exitFade,
-                                child: child,
-                              ),
-                              child: _screenFor(tab),
-                            ),
-                          );
-                        }).toList(),
-                      ),
-                    ),
+            Column(
+              children: [
+                if (!isFullscreen)
+                  _TitleBar(
+                    activeTab: activeTab,
+                    palette: palette,
+                    isMaximized: _isMaximized,
                   ),
-                ],
-              ),
+                Expanded(
+                  child: Row(
+                    children: [
+                      if (!isFullscreen)
+                        _Sidebar(activeTab: activeTab, palette: palette),
+                      Expanded(
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 300),
+                          color: palette.surface,
+                          child: Stack(
+                            fit: StackFit.expand,
+                            children: AppTab.values.map((tab) {
+                              final isActive  = tab == activeTab;
+                              final isExiting = tab == _exitingTab;
+
+                              if (!isActive && !isExiting) {
+                                // Player keeps tickers so audio continues off-tab;
+                                // all other tabs are fully frozen.
+                                return Offstage(
+                                  offstage: true,
+                                  child: tab == AppTab.player
+                                      ? _screenFor(tab)
+                                      : TickerMode(
+                                          enabled: false,
+                                          child: _screenFor(tab),
+                                        ),
+                                );
+                              }
+
+                              if (isActive) {
+                                return AnimatedBuilder(
+                                  animation: _ctrl,
+                                  builder: (_, child) => FadeTransition(
+                                    opacity: _enterFade,
+                                    child: SlideTransition(
+                                      position: _enterSlide,
+                                      child: child,
+                                    ),
+                                  ),
+                                  child: _screenFor(tab),
+                                );
+                              }
+
+                              return IgnorePointer(
+                                child: AnimatedBuilder(
+                                  animation: _ctrl,
+                                  builder: (_, child) => FadeTransition(
+                                    opacity: _exitFade,
+                                    child: child,
+                                  ),
+                                  child: _screenFor(tab),
+                                ),
+                              );
+                            }).toList(),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
+            if (_toasts.isNotEmpty)
+              Positioned(
+                top: 60,
+                right: 16,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: _toasts.map((t) => _ToastCard(
+                    toast: t,
+                    onTap: () {
+                      t.timer.cancel();
+                      setState(() => _toasts.removeWhere((e) => e.id == t.id));
+                      ref.read(activeTabProvider.notifier).state = t.target;
+                    },
+                    onDismiss: () {
+                      t.timer.cancel();
+                      setState(() => _toasts.removeWhere((e) => e.id == t.id));
+                    },
+                  )).toList(),
+                ),
+              ),
           ],
         ),
       ),
@@ -693,5 +757,97 @@ class _SidebarItem extends StatelessWidget {
       ),
     ),
     );
+  }
+}
+
+// ── Toast data ──────────────────────────────────────────────────────────────
+
+class _ToastEntry {
+  final int id;
+  final String message;
+  final TabPalette palette;
+  final AppTab target;
+  final Timer timer;
+
+  const _ToastEntry({
+    required this.id,
+    required this.message,
+    required this.palette,
+    required this.target,
+    required this.timer,
+  });
+}
+
+// ── Toast card widget ───────────────────────────────────────────────────────
+
+class _ToastCard extends StatelessWidget {
+  final _ToastEntry toast;
+  final VoidCallback onTap;
+  final VoidCallback onDismiss;
+
+  const _ToastCard({
+    required this.toast,
+    required this.onTap,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: onTap,
+          child: Container(
+            width: 240,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: kSurfaceColor,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                  color: toast.palette.primary.withValues(alpha: 0.4)),
+              boxShadow: [
+                BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.35),
+                    blurRadius: 14,
+                    offset: const Offset(0, 4)),
+              ],
+            ),
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: BoxDecoration(
+                    color: toast.palette.primary.withValues(alpha: 0.15),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(Icons.check_rounded,
+                      color: toast.palette.primary, size: 14),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    toast.message,
+                    style: const TextStyle(
+                        fontSize: 12,
+                        color: kTextPrimary,
+                        fontWeight: FontWeight.w500),
+                  ),
+                ),
+                GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: onDismiss,
+                  child: const Padding(
+                    padding: EdgeInsets.all(4),
+                    child: Icon(Icons.close_rounded, color: kTextMuted, size: 14),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ).animate().fadeIn(duration: 180.ms).slideX(begin: 0.25, end: 0, duration: 180.ms);
   }
 }


### PR DESCRIPTION
## Summary

- Progressive IMDB loading: catalog shows entries immediately after CSV parse, then enriches with IMDB metadata in the background (concurrent batches of 4)
- Open downloads folder button in catalog toolbar when downloads panel is visible
- Download queue retry: failed jobs are stored and can be retried with a single button
- Memory-efficient thumbnails: `memCacheWidth` capped at 400px for catalog cards, 200px for download list
- Cross-tab completion toasts: non-intrusive overlay notifications when encode/decode/download finish while the user is on a different tab

## Test plan

- [ ] Catalog loads and shows entries before IMDB data arrives; cards enrich progressively
- [ ] Folder button appears next to downloads toggle when downloads are visible; clicking opens Explorer
- [ ] Trigger a download failure; Retry button appears and re-queues the failed job
- [ ] Verify memory usage is lower with large catalogs (memCacheWidth applied)
- [ ] Start an encode, switch to another tab — toast appears at top-right with encode palette; clicking jumps back to encode tab; auto-dismisses after 4s

🤖 Generated with [Claude Code](https://claude.ai/claude-code)