### PR TITLE
feat: v1.5.0 — Content request flow and admin enhancements

### DIFF
--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -1,13 +1,17 @@
 import 'dart:async';
 import 'dart:math' show min;
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:csv/csv.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/catalog_cache_manager.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
+import '../catalog/config_service.dart';
 import '../catalog/imdb_service.dart';
 import '../catalog/models/imdb_data.dart';
 import '../catalog/models/episode_sheet_schema.dart';
@@ -21,7 +25,9 @@ final _adminPalette = AppTab.admin.palette;
 // Amber badge for top-4 slide picks.
 const _kTop4Color = Color(0xFFF59E0B);
 
-enum _AdminMode { movie, series, episode }
+enum _AdminMode { movie, series, episode, requests }
+
+const _kAdminMode = 'admin_last_mode';
 
 class AdminScreen extends ConsumerStatefulWidget {
   const AdminScreen({super.key});
@@ -97,6 +103,14 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
     ]) {
       c.addListener(_onFieldChanged);
     }
+    _restoreMode();
+  }
+
+  Future<void> _restoreMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final idx = prefs.getInt(_kAdminMode) ?? 0;
+    final mode = _AdminMode.values[idx.clamp(0, _AdminMode.values.length - 1)];
+    if (mounted && mode != _mode) setState(() => _mode = mode);
   }
 
   @override
@@ -162,6 +176,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
 
   void _setMode(_AdminMode mode) {
     if (mode == _mode) return;
+    SharedPreferences.getInstance().then((p) => p.setInt(_kAdminMode, mode.index));
     setState(() {
       _mode             = mode;
       _data             = null;
@@ -185,13 +200,39 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
     });
   }
 
+  Future<void> _loadRequest(String imdbId) async {
+    _imdbIdCtrl.text = imdbId;
+    setState(() { _fetching = true; _error = null; _data = null; });
+
+    final results = await ImdbService().resolve([imdbId]);
+    if (!mounted) return;
+
+    final data = results[imdbId];
+    // Detect series: ended series have endYear; ongoing series typically lack
+    // runtimeSeconds (episodes have per-ep runtime, not a single feature length).
+    final isSeries = data != null &&
+        data.parentId == null &&
+        data.seasonNumber == null &&
+        (data.endYear != null || data.runtimeSeconds == null);
+
+    _setMode(isSeries ? _AdminMode.series : _AdminMode.movie);
+    _imdbIdCtrl.text = imdbId;
+
+    if (isSeries) {
+      await _fetchSeries(imdbId);
+    } else {
+      await _fetchMovie(imdbId);
+    }
+  }
+
   Future<void> _fetch() async {
     final id = _imdbIdCtrl.text.trim();
     if (id.isEmpty) return;
     switch (_mode) {
-      case _AdminMode.movie:   await _fetchMovie(id);
-      case _AdminMode.series:  await _fetchSeries(id);
-      case _AdminMode.episode: await _fetchEpisode(id, _seriesImdbCtrl.text.trim());
+      case _AdminMode.movie:    await _fetchMovie(id);
+      case _AdminMode.series:   await _fetchSeries(id);
+      case _AdminMode.episode:  await _fetchEpisode(id, _seriesImdbCtrl.text.trim());
+      case _AdminMode.requests: return;
     }
   }
 
@@ -640,7 +681,11 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                   ),
           ),
           const SizedBox(height: 20),
-          if (_fetching)
+          if (_mode == _AdminMode.requests)
+            Expanded(
+              child: _AdminRequestsPanel(onLoad: _loadRequest),
+            )
+          else if (_fetching)
             Expanded(
               child: Center(
                 child: Column(mainAxisSize: MainAxisSize.min, children: [
@@ -762,78 +807,82 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
               style: TextStyle(fontSize: 13, color: kTextPrimary),
               icon: Icon(Icons.expand_more_rounded, size: 16, color: kTextMuted),
               items: const [
-                DropdownMenuItem(value: _AdminMode.movie,   child: Text('Movie')),
-                DropdownMenuItem(value: _AdminMode.series,  child: Text('Series')),
-                DropdownMenuItem(value: _AdminMode.episode, child: Text('Episode')),
+                DropdownMenuItem(value: _AdminMode.movie,    child: Text('Movie')),
+                DropdownMenuItem(value: _AdminMode.series,   child: Text('Series')),
+                DropdownMenuItem(value: _AdminMode.episode,  child: Text('Episode')),
+                DropdownMenuItem(value: _AdminMode.requests, child: Text('Requests')),
               ],
               onChanged: (v) { if (v != null) _setMode(v); },
             ),
           ),
         ),
-        const SizedBox(width: 12),
-        // Primary IMDB ID field
-        Expanded(
-          child: TextField(
-            controller: _imdbIdCtrl,
-            style: TextStyle(fontSize: 13, color: kTextPrimary),
-            decoration: InputDecoration(
-              hintText: switch (_mode) {
-                _AdminMode.movie    => 'IMDB ID  (e.g. tt30825738)',
-                _AdminMode.series   => 'Series IMDB ID  (tt…)',
-                _AdminMode.episode  => 'Episode IMDB ID  (tt…)',
-              },
-              hintStyle: TextStyle(fontSize: 13, color: kTextMuted),
-              filled: true,
-              fillColor: kSurfaceColor,
-              border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: kBorderColor)),
-              enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: kBorderColor)),
-              focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: _adminPalette.primary)),
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        if (_mode != _AdminMode.requests) ...[
+          const SizedBox(width: 12),
+          // Primary IMDB ID field
+          Expanded(
+            child: TextField(
+              controller: _imdbIdCtrl,
+              style: TextStyle(fontSize: 13, color: kTextPrimary),
+              decoration: InputDecoration(
+                hintText: switch (_mode) {
+                  _AdminMode.movie    => 'IMDB ID  (e.g. tt30825738)',
+                  _AdminMode.series   => 'Series IMDB ID  (tt…)',
+                  _AdminMode.episode  => 'Episode IMDB ID  (tt…)',
+                  _AdminMode.requests => '',
+                },
+                hintStyle: TextStyle(fontSize: 13, color: kTextMuted),
+                filled: true,
+                fillColor: kSurfaceColor,
+                border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: BorderSide(color: kBorderColor)),
+                enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: BorderSide(color: kBorderColor)),
+                focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: BorderSide(color: _adminPalette.primary)),
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              ),
+              onSubmitted: (_) => _fetch(),
             ),
-            onSubmitted: (_) => _fetch(),
           ),
-        ),
-        // Series IMDB ID — Episode mode only
-        if (isEpisode) ...[
+          // Series IMDB ID — Episode mode only
+          if (isEpisode) ...[
+            const SizedBox(width: 8),
+            Expanded(child: _buildSeriesIdField()),
+          ],
           const SizedBox(width: 8),
-          Expanded(child: _buildSeriesIdField()),
-        ],
-        const SizedBox(width: 8),
-        Tooltip(
-          message: 'Paste row from clipboard',
-          child: IconButton(
-            onPressed: _pasteFromClipboard,
-            icon: const Icon(Icons.content_paste_rounded, size: 18),
-            style: IconButton.styleFrom(
-              foregroundColor: kTextSecondary,
-              backgroundColor: kSurfaceColor,
-              side: BorderSide(color: kBorderColor),
+          Tooltip(
+            message: 'Paste row from clipboard',
+            child: IconButton(
+              onPressed: _pasteFromClipboard,
+              icon: const Icon(Icons.content_paste_rounded, size: 18),
+              style: IconButton.styleFrom(
+                foregroundColor: kTextSecondary,
+                backgroundColor: kSurfaceColor,
+                side: BorderSide(color: kBorderColor),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8)),
+                padding: const EdgeInsets.all(12),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          FilledButton.icon(
+            onPressed: _fetching ? null : _fetch,
+            icon: const Icon(Icons.search_rounded, size: 16),
+            label: const Text('Fetch'),
+            style: FilledButton.styleFrom(
+              backgroundColor: _adminPalette.primary,
+              foregroundColor: Colors.black,
+              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
               shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(8)),
-              padding: const EdgeInsets.all(12),
             ),
           ),
-        ),
-        const SizedBox(width: 8),
-        FilledButton.icon(
-          onPressed: _fetching ? null : _fetch,
-          icon: const Icon(Icons.search_rounded, size: 16),
-          label: const Text('Fetch'),
-          style: FilledButton.styleFrom(
-            backgroundColor: _adminPalette.primary,
-            foregroundColor: Colors.black,
-            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-            shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(8)),
-          ),
-        ),
+        ],
       ],
     );
   }
@@ -1834,6 +1883,8 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
             : List.filled(EpisodeSheetSchema.columnCount, '');
         columns = EpisodeSheetSchema.columns;
         tsvRow  = EpisodeSheetSchema.buildTsv(values);
+      case _AdminMode.requests:
+        return const SizedBox.shrink();
     }
 
     return Column(
@@ -2382,6 +2433,355 @@ class _ToggleChip extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+// ── Admin Requests Panel ──────────────────────────────────────────────────────
+
+typedef _RequestRow = ({
+  String timestamp,
+  String imdbId,
+  String imdbUrl,
+  String title,
+  String posterUrl,
+  int? year,
+  String type,
+});
+
+class _AdminRequestsPanel extends ConsumerStatefulWidget {
+  final void Function(String imdbId) onLoad;
+  const _AdminRequestsPanel({required this.onLoad});
+
+  @override
+  ConsumerState<_AdminRequestsPanel> createState() =>
+      _AdminRequestsPanelState();
+}
+
+class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
+  bool _loading = false;
+  String? _error;
+  List<_RequestRow> _rows = [];
+
+  static final _imdbUrlRe =
+      RegExp(r'imdb\.com/title/(tt\d+)', caseSensitive: false);
+  static final _sheetIdRe =
+      RegExp(r'/spreadsheets/d/([a-zA-Z0-9_-]+)');
+
+  static String _inferType(ImdbData? data) {
+    if (data == null) return 'Movie';
+    if (data.parentId != null || data.seasonNumber != null) return 'Episode';
+    if (data.endYear != null) return 'Series';
+    if (data.runtimeSeconds == null) return 'Series';
+    return 'Movie';
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() { _loading = true; _error = null; });
+    try {
+      final config =
+          ref.read(sheetConfigProvider).valueOrNull ?? const SheetConfig();
+      final resUrl = config.requestResUrl;
+      if (resUrl == null || resUrl.isEmpty) {
+        setState(() {
+          _loading = false;
+          _error = 'request_res_url not configured in the Config sheet.';
+        });
+        return;
+      }
+
+      final sheetId = _sheetIdRe.firstMatch(resUrl)?.group(1);
+      if (sheetId == null) {
+        setState(() { _loading = false; _error = 'Invalid responses sheet URL.'; });
+        return;
+      }
+
+      final csvUrl =
+          'https://docs.google.com/spreadsheets/d/$sheetId/gviz/tq?tqx=out:csv';
+      final response = await http
+          .get(Uri.parse(csvUrl))
+          .timeout(const Duration(seconds: 15));
+
+      if (response.statusCode != 200 ||
+          response.body.trimLeft().startsWith('<')) {
+        setState(() {
+          _loading = false;
+          _error =
+              'Could not load responses sheet. Make sure it is shared publicly.';
+        });
+        return;
+      }
+
+      final normalized =
+          response.body.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+      final allRows =
+          const CsvToListConverter(eol: '\n').convert(normalized);
+
+      if (allRows.isEmpty) {
+        setState(() { _loading = false; _rows = []; });
+        return;
+      }
+
+      final headers = allRows[0]
+          .map((h) => h.toString().trim().toLowerCase())
+          .toList();
+      final tsIdx = headers.indexOf('timestamp');
+      final linkIdx = headers.indexOf('imdb link');
+
+      final rawRows = <({String timestamp, String imdbId, String imdbUrl})>[];
+      for (final row in allRows.skip(1)) {
+        final ts = tsIdx >= 0 && tsIdx < row.length
+            ? row[tsIdx].toString().trim()
+            : '';
+        final url = linkIdx >= 0 && linkIdx < row.length
+            ? row[linkIdx].toString().trim()
+            : '';
+        final id = _imdbUrlRe.firstMatch(url)?.group(1) ?? '';
+        if (id.isNotEmpty) {
+          rawRows.add((timestamp: ts, imdbId: id, imdbUrl: url));
+        }
+      }
+
+      final ids = rawRows.map((r) => r.imdbId).toSet().toList();
+      final imdbMap = ids.isEmpty
+          ? <String, ImdbData>{}
+          : await ImdbService().resolve(ids);
+
+      final parsed = rawRows.map((r) {
+        final data = imdbMap[r.imdbId];
+        return (
+          timestamp: r.timestamp,
+          imdbId: r.imdbId,
+          imdbUrl: r.imdbUrl,
+          title: data?.title ?? r.imdbId,
+          posterUrl: data?.posterUrl ?? '',
+          year: data?.releaseDate?.year,
+          type: _inferType(data),
+        );
+      }).toList();
+
+      if (mounted) {
+        setState(() {
+          _loading = false;
+          _rows = parsed.reversed.toList(); // newest first
+        });
+      }
+    } catch (e) {
+      if (mounted) setState(() { _loading = false; _error = e.toString(); });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return Center(
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          CircularProgressIndicator(color: _adminPalette.primary),
+          const SizedBox(height: 12),
+          Text('Loading requests…',
+              style: TextStyle(fontSize: 13, color: kTextMuted)),
+        ]),
+      );
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          const Icon(Icons.error_outline_rounded,
+              size: 40, color: Colors.redAccent),
+          const SizedBox(height: 12),
+          Text(_error!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 13, color: kTextSecondary)),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: _load,
+            icon: const Icon(Icons.refresh_rounded, size: 16),
+            label: const Text('Retry'),
+            style: FilledButton.styleFrom(
+              backgroundColor: _adminPalette.primary,
+              foregroundColor: Colors.black,
+            ),
+          ),
+        ]),
+      );
+    }
+
+    if (_rows.isEmpty) {
+      return Center(
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          Icon(Icons.inbox_rounded, size: 48, color: kTextMuted),
+          const SizedBox(height: 12),
+          Text('No requests yet.',
+              style: TextStyle(fontSize: 14, color: kTextMuted)),
+          const SizedBox(height: 16),
+          TextButton.icon(
+            onPressed: _load,
+            icon: const Icon(Icons.refresh_rounded, size: 16),
+            label: const Text('Refresh'),
+            style: TextButton.styleFrom(
+                foregroundColor: _adminPalette.primary),
+          ),
+        ]),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(children: [
+          Text('${_rows.length} request${_rows.length == 1 ? '' : 's'}',
+              style: TextStyle(
+                  fontSize: 13,
+                  color: _adminPalette.primary,
+                  fontWeight: FontWeight.w600)),
+          const Spacer(),
+          TextButton.icon(
+            onPressed: _load,
+            icon: const Icon(Icons.refresh_rounded, size: 15),
+            label: const Text('Refresh', style: TextStyle(fontSize: 12)),
+            style: TextButton.styleFrom(
+                foregroundColor: _adminPalette.primary),
+          ),
+        ]),
+        const SizedBox(height: 8),
+        Expanded(
+          child: ListView.separated(
+            itemCount: _rows.length,
+            separatorBuilder: (_, _) =>
+                Divider(height: 1, color: kBorderColor),
+            itemBuilder: (_, i) {
+              final row = _rows[i];
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(6),
+                      child: row.posterUrl.isNotEmpty
+                          ? CachedNetworkImage(
+                              imageUrl: row.posterUrl,
+                              cacheManager: CatalogCacheManager.instance,
+                              width: 48,
+                              height: 68,
+                              fit: BoxFit.cover,
+                              placeholder: (_, _) => Container(
+                                width: 48,
+                                height: 68,
+                                color: kSurfaceColor,
+                              ),
+                              errorWidget: (_, _, _) => Container(
+                                width: 48,
+                                height: 68,
+                                color: kSurfaceColor,
+                                child: const Icon(Icons.broken_image_rounded,
+                                    size: 20, color: kTextMuted),
+                              ),
+                            )
+                          : Container(
+                              width: 48,
+                              height: 68,
+                              decoration: BoxDecoration(
+                                color: kSurfaceColor,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: const Icon(Icons.movie_rounded,
+                                  size: 22, color: kTextMuted),
+                            ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            row.title,
+                            style: const TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w600,
+                                color: kTextPrimary),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          const SizedBox(height: 4),
+                          Wrap(
+                            spacing: 6,
+                            runSpacing: 4,
+                            children: [
+                              if (row.year != null)
+                                _ReqChip(label: '${row.year}'),
+                              _ReqChip(label: row.type),
+                              _ReqChip(
+                                  label: row.imdbId,
+                                  color: _adminPalette.primary
+                                      .withValues(alpha: 0.15),
+                                  textColor: _adminPalette.primary),
+                            ],
+                          ),
+                          if (row.timestamp.isNotEmpty) ...[
+                            const SizedBox(height: 4),
+                            Text(row.timestamp,
+                                style: const TextStyle(
+                                    fontSize: 10, color: kTextMuted)),
+                          ],
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    FilledButton(
+                      onPressed: () => widget.onLoad(row.imdbId),
+                      style: FilledButton.styleFrom(
+                        backgroundColor: _adminPalette.primary,
+                        foregroundColor: Colors.black,
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 14, vertical: 8),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(7)),
+                        textStyle: const TextStyle(fontSize: 12),
+                      ),
+                      child: const Text('Load'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ReqChip extends StatelessWidget {
+  final String label;
+  final Color? color;
+  final Color? textColor;
+
+  const _ReqChip({required this.label, this.color, this.textColor});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: color ?? kSurfaceColor,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: kBorderColor),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+            fontSize: 10,
+            color: textColor ?? kTextSecondary,
+            fontWeight: FontWeight.w500),
       ),
     );
   }

--- a/lib/features/catalog/catalog_screen.dart
+++ b/lib/features/catalog/catalog_screen.dart
@@ -17,8 +17,10 @@ import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
 import '../shell/app_shell.dart';
 import 'catalog_notifier.dart';
+import 'config_service.dart';
 import 'models/catalog_entry.dart';
 import 'models/series_entry.dart';
+import 'request_notifier.dart';
 import 'screens/series_detail_screen.dart';
 import 'series_notifier.dart';
 import 'widgets/catalog_card.dart';
@@ -187,11 +189,20 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
     setState(() => _openedSeries = entry);
   }
 
+  void _showRequestDialog(BuildContext context) {
+    ref.read(requestProvider.notifier).reset();
+    showDialog<void>(
+      context: context,
+      builder: (_) => const _RequestDialog(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isSeriesTab = _subTabIndex == 1;
     final palette = isSeriesTab ? kSeriesPalette : AppTab.catalog.palette;
     final sheetUrl = ref.watch(sheetUrlProvider);
+    final config = ref.watch(sheetConfigProvider).valueOrNull ?? const SheetConfig();
     final catalogState = ref.watch(catalogProvider);
     final seriesState = ref.watch(seriesProvider);
     final downloadState = ref.watch(downloadProvider);
@@ -257,6 +268,7 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
               searchController: _searchController,
               showDownloads: _showDownloads,
               historyCount: historyCount,
+              hasRequestFeature: config.hasRequestFeature,
               onSearch: (v) => setState(() => _search = v),
               onSubmitUrl: (url) async {
                 await ref.read(sheetUrlProvider.notifier).save(url);
@@ -284,6 +296,9 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
                 Process.run('explorer.exe',
                     [dir.isNotEmpty ? dir : AppDirectories.downloaded]);
               },
+              onRequest: config.hasRequestFeature
+                  ? () => _showRequestDialog(context)
+                  : null,
             ),
             const SizedBox(height: 12),
             if (!isSeriesTab && !_showDownloads && catalogState is CatalogLoaded) ...[
@@ -533,12 +548,14 @@ class _TopBar extends StatelessWidget {
   final TextEditingController searchController;
   final bool showDownloads;
   final int historyCount;
+  final bool hasRequestFeature;
   final ValueChanged<String> onSearch;
   final ValueChanged<String> onSubmitUrl;
   final VoidCallback? onRefresh;
   final VoidCallback onClearUrl;
   final VoidCallback onToggleDownloads;
   final VoidCallback onOpenFolder;
+  final VoidCallback? onRequest;
 
   const _TopBar({
     required this.palette,
@@ -547,12 +564,14 @@ class _TopBar extends StatelessWidget {
     required this.searchController,
     required this.showDownloads,
     required this.historyCount,
+    required this.hasRequestFeature,
     required this.onSearch,
     required this.onSubmitUrl,
     required this.onRefresh,
     required this.onClearUrl,
     required this.onToggleDownloads,
     required this.onOpenFolder,
+    this.onRequest,
   });
 
   @override
@@ -600,6 +619,14 @@ class _TopBar extends StatelessWidget {
             icon: Icons.link_off_rounded,
             tooltip: 'Change sheet URL',
             onTap: onClearUrl,
+          ),
+        ],
+        if (hasRequestFeature && onRequest != null) ...[
+          const SizedBox(width: 6),
+          _IconBtn(
+            icon: Icons.add_circle_outline_rounded,
+            tooltip: 'Request a movie or series',
+            onTap: onRequest,
           ),
         ],
       ],
@@ -2403,6 +2430,359 @@ class _SeriesGridState extends State<_SeriesGrid> {
                 delay: Duration(milliseconds: min(i, 9) * 35))
             .slideY(begin: 0.06, duration: 280.ms, curve: Curves.easeOut);
       },
+    );
+  }
+}
+
+// ── Request Dialog ─────────────────────────────────────────────────────────────
+
+class _RequestDialog extends ConsumerStatefulWidget {
+  const _RequestDialog();
+
+  @override
+  ConsumerState<_RequestDialog> createState() => _RequestDialogState();
+}
+
+class _RequestDialogState extends ConsumerState<_RequestDialog> {
+  final _ctrl = TextEditingController();
+  final _palette = AppTab.catalog.palette;
+  RequestReady? _lastReady;
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  void _onChanged(String value) {
+    // Auto-validate once a plausible IMDB URL is pasted.
+    if (value.contains('imdb.com/title/tt')) {
+      ref.read(requestProvider.notifier).validate(value);
+    } else {
+      ref.read(requestProvider.notifier).reset();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(requestProvider);
+
+    return Dialog(
+      backgroundColor: kSurfaceColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Header
+              Row(children: [
+                Icon(Icons.add_circle_outline_rounded,
+                    color: _palette.primary, size: 18),
+                const SizedBox(width: 8),
+                Text('Request',
+                    style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                        color: _palette.primary)),
+                const Spacer(),
+                GestureDetector(
+                  onTap: () => Navigator.pop(context),
+                  child: Icon(Icons.close_rounded,
+                      size: 18, color: kTextMuted),
+                ),
+              ]),
+              const SizedBox(height: 16),
+
+              // URL input
+              TextField(
+                controller: _ctrl,
+                autofocus: true,
+                enabled: state is! RequestSubmitting && state is! RequestSuccess,
+                onChanged: _onChanged,
+                style: TextStyle(fontSize: 13, color: kTextPrimary),
+                decoration: InputDecoration(
+                  hintText: 'Paste IMDB URL  (imdb.com/title/tt…)',
+                  hintStyle: TextStyle(fontSize: 13, color: kTextMuted),
+                  filled: true,
+                  fillColor: kSurface2Color,
+                  border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: BorderSide(color: kBorderColor)),
+                  enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: BorderSide(color: kBorderColor)),
+                  focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: BorderSide(color: _palette.primary)),
+                  contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 12, vertical: 12),
+                  suffixIcon: state is RequestValidating
+                      ? Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: _palette.primary),
+                          ),
+                        )
+                      : null,
+                ),
+              ),
+
+              // State-driven content
+              AnimatedSize(
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeInOut,
+                child: _buildStateContent(state),
+              ),
+
+              const SizedBox(height: 20),
+
+              // Footer actions
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    style: TextButton.styleFrom(
+                        foregroundColor: kTextSecondary),
+                    child: const Text('Cancel'),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: state is RequestReady
+                        ? () => ref.read(requestProvider.notifier).submit()
+                        : state is RequestSuccess
+                            ? () => Navigator.pop(context)
+                            : null,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: _palette.primary,
+                      foregroundColor: Colors.black,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 20, vertical: 12),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8)),
+                    ),
+                    child: state is RequestSubmitting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: Colors.black54),
+                          )
+                        : Text(state is RequestSuccess ? 'Done' : 'Submit'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStateContent(RequestState state) {
+    if (state is RequestReady) {
+      _lastReady = state;
+      return Padding(
+        padding: const EdgeInsets.only(top: 16),
+        child: _PreviewCard(state: state, palette: _palette),
+      );
+    }
+    if (state is RequestSubmitting) {
+      return _lastReady != null
+          ? Padding(
+              padding: const EdgeInsets.only(top: 16),
+              child: _PreviewCard(state: _lastReady!, palette: _palette),
+            )
+          : const SizedBox.shrink();
+    }
+    if (state is RequestSuccess) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (_lastReady != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 16),
+              child: _PreviewCard(state: _lastReady!, palette: _palette),
+            ),
+          _StatusBanner(
+            icon: Icons.check_circle_outline_rounded,
+            color: const Color(0xFF4ADE80),
+            message: 'Request submitted! The admin will review it shortly.',
+          ),
+        ],
+      );
+    }
+    if (state is RequestDuplicate) {
+      final preview = RequestReady(
+        imdbId: state.imdbId,
+        imdbUrl: state.imdbUrl,
+        title: state.title,
+        year: state.year,
+        type: state.type,
+        posterUrl: state.posterUrl,
+      );
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 16),
+            child: _PreviewCard(state: preview, palette: _palette),
+          ),
+          _StatusBanner(
+            icon: Icons.info_outline_rounded,
+            color: const Color(0xFFF59E0B),
+            message: '"${state.title}" has already been requested.',
+          ),
+        ],
+      );
+    }
+    if (state is RequestError) {
+      return _StatusBanner(
+        icon: Icons.error_outline_rounded,
+        color: Colors.redAccent,
+        message: state.message,
+      );
+    }
+    return const SizedBox.shrink();
+  }
+}
+
+class _PreviewCard extends StatelessWidget {
+  final RequestReady state;
+  final TabPalette palette;
+
+  const _PreviewCard({required this.state, required this.palette});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: kSurface2Color,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: kBorderColor),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (state.posterUrl.isNotEmpty)
+            ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: CachedNetworkImage(
+                imageUrl: state.posterUrl,
+                width: 56,
+                height: 84,
+                fit: BoxFit.cover,
+                cacheManager: CatalogCacheManager.instance,
+                errorWidget: (_, _, _) => _posterPlaceholder(),
+              ),
+            )
+          else
+            _posterPlaceholder(),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  state.title,
+                  style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: kTextPrimary),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Wrap(spacing: 6, children: [
+                  if (state.year != null)
+                    _Chip(label: '${state.year}'),
+                  _Chip(label: state.type),
+                  _Chip(label: state.imdbId),
+                ]),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _posterPlaceholder() => Container(
+        width: 56,
+        height: 84,
+        decoration: BoxDecoration(
+          color: kSurface2Color,
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: kBorderColor),
+        ),
+        child: const Icon(Icons.movie_rounded, size: 24, color: kTextMuted),
+      );
+}
+
+class _StatusBanner extends StatelessWidget {
+  final IconData icon;
+  final Color color;
+  final String message;
+
+  const _StatusBanner({
+    required this.icon,
+    required this.color,
+    required this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12),
+      child: Container(
+        padding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: color.withValues(alpha: 0.35)),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, size: 16, color: color),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                message,
+                style: TextStyle(fontSize: 12, color: kTextSecondary),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  final String label;
+
+  const _Chip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: kSurface2Color,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: kBorderColor),
+      ),
+      child: Text(label,
+          style: const TextStyle(fontSize: 10, color: kTextSecondary)),
     );
   }
 }

--- a/lib/features/catalog/config_service.dart
+++ b/lib/features/catalog/config_service.dart
@@ -1,0 +1,139 @@
+import 'dart:async' show unawaited;
+import 'dart:convert';
+import 'dart:io';
+import 'package:csv/csv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'catalog_notifier.dart';
+
+class SheetConfig {
+  final String? requestFormUrl;
+  final String? requestResUrl;
+
+  const SheetConfig({this.requestFormUrl, this.requestResUrl});
+
+  bool get hasRequestFeature =>
+      requestFormUrl != null && requestFormUrl!.isNotEmpty;
+}
+
+final sheetConfigProvider =
+    StateNotifierProvider<SheetConfigNotifier, AsyncValue<SheetConfig>>((ref) {
+  final notifier = SheetConfigNotifier(ref);
+  final url = ref.read(sheetUrlProvider);
+  if (url != null) notifier.load(url);
+  ref.listen<String?>(sheetUrlProvider, (_, next) {
+    if (next != null) notifier.load(next);
+  });
+  return notifier;
+});
+
+class SheetConfigNotifier extends StateNotifier<AsyncValue<SheetConfig>> {
+  SheetConfigNotifier(Ref ref) : super(const AsyncValue.data(SheetConfig()));
+
+  static const _kCacheTtl = Duration(minutes: 30);
+
+  static String? _extractSheetId(String url) {
+    final m = RegExp(r'/spreadsheets/d/([a-zA-Z0-9_-]+)').firstMatch(url);
+    return m?.group(1);
+  }
+
+  Future<void> load(String sheetUrl) async {
+    final sheetId = _extractSheetId(sheetUrl);
+    if (sheetId == null) return;
+
+    final cached = await _loadCache(sheetId);
+    if (cached != null) {
+      if (mounted) state = AsyncValue.data(cached.config);
+      if (DateTime.now().difference(cached.fetchedAt) < _kCacheTtl) return;
+      unawaited(_fetch(sheetId, silent: true));
+      return;
+    }
+
+    await _fetch(sheetId, silent: false);
+  }
+
+  Future<void> _fetch(String sheetId, {required bool silent}) async {
+    if (!silent && mounted) state = const AsyncValue.loading();
+    try {
+      final url =
+          'https://docs.google.com/spreadsheets/d/$sheetId/gviz/tq?tqx=out:csv&sheet=Config';
+      final response = await http
+          .get(Uri.parse(url))
+          .timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200 ||
+          response.body.trimLeft().startsWith('<')) {
+        if (!silent && mounted) {
+          state = const AsyncValue.data(SheetConfig());
+        }
+        return;
+      }
+      final config = _parse(response.body);
+      unawaited(_saveCache(sheetId, config));
+      if (mounted) state = AsyncValue.data(config);
+    } catch (_) {
+      if (!silent && mounted) state = const AsyncValue.data(SheetConfig());
+    }
+  }
+
+  static SheetConfig _parse(String csvBody) {
+    final normalized =
+        csvBody.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    final rows = const CsvToListConverter(eol: '\n').convert(normalized);
+    final map = <String, String>{};
+    for (final row in rows) {
+      if (row.length >= 2) {
+        final key = row[0].toString().trim();
+        final value = row[1].toString().trim();
+        if (key.isNotEmpty && value.isNotEmpty) map[key] = value;
+      }
+    }
+    return SheetConfig(
+      requestFormUrl: map['request_form_url'],
+      requestResUrl: map['request_res_url'],
+    );
+  }
+
+  // ── Cache helpers ──────────────────────────────────────────────────────────
+
+  Future<({SheetConfig config, DateTime fetchedAt})?> _loadCache(
+      String sheetId) async {
+    try {
+      final dir = (await getApplicationSupportDirectory()).path;
+      final file = File(p.join(dir, 'sheet_config_$sheetId.json'));
+      if (!file.existsSync()) return null;
+      final map =
+          jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+      final at = DateTime.tryParse(map['fetchedAt'] as String? ?? '');
+      if (at == null) return null;
+      final data = map['data'] as Map<String, dynamic>;
+      return (
+        config: SheetConfig(
+          requestFormUrl: data['request_form_url'] as String?,
+          requestResUrl: data['request_res_url'] as String?,
+        ),
+        fetchedAt: at,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _saveCache(String sheetId, SheetConfig config) async {
+    try {
+      final dir = (await getApplicationSupportDirectory()).path;
+      await File(p.join(dir, 'sheet_config_$sheetId.json')).writeAsString(
+        jsonEncode({
+          'fetchedAt': DateTime.now().toIso8601String(),
+          'data': {
+            if (config.requestFormUrl != null)
+              'request_form_url': config.requestFormUrl,
+            if (config.requestResUrl != null)
+              'request_res_url': config.requestResUrl,
+          },
+        }),
+      );
+    } catch (_) {}
+  }
+}

--- a/lib/features/catalog/request_notifier.dart
+++ b/lib/features/catalog/request_notifier.dart
@@ -1,0 +1,261 @@
+import 'package:csv/csv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'config_service.dart';
+import 'imdb_service.dart';
+import 'models/imdb_data.dart';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+sealed class RequestState {}
+
+class RequestIdle extends RequestState {}
+
+class RequestValidating extends RequestState {}
+
+class RequestReady extends RequestState {
+  final String imdbId;
+  final String imdbUrl;
+  final String title;
+  final int? year;
+  final String type;
+  final String posterUrl;
+
+  RequestReady({
+    required this.imdbId,
+    required this.imdbUrl,
+    required this.title,
+    this.year,
+    required this.type,
+    required this.posterUrl,
+  });
+}
+
+class RequestDuplicate extends RequestState {
+  final String imdbId;
+  final String imdbUrl;
+  final String title;
+  final int? year;
+  final String type;
+  final String posterUrl;
+
+  RequestDuplicate({
+    required this.imdbId,
+    required this.imdbUrl,
+    required this.title,
+    this.year,
+    required this.type,
+    required this.posterUrl,
+  });
+}
+
+class RequestSubmitting extends RequestState {}
+
+class RequestSuccess extends RequestState {}
+
+class RequestError extends RequestState {
+  final String message;
+  RequestError(this.message);
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+final requestProvider =
+    StateNotifierProvider<RequestNotifier, RequestState>((ref) {
+  return RequestNotifier(ref);
+});
+
+// ---------------------------------------------------------------------------
+// Notifier
+// ---------------------------------------------------------------------------
+
+class RequestNotifier extends StateNotifier<RequestState> {
+  final Ref _ref;
+  RequestNotifier(this._ref) : super(RequestIdle());
+
+  static final _imdbUrlRe =
+      RegExp(r'imdb\.com/title/(tt\d+)', caseSensitive: false);
+  static final _sheetIdRe =
+      RegExp(r'/spreadsheets/d/([a-zA-Z0-9_-]+)');
+
+  String? _extractImdbId(String url) =>
+      _imdbUrlRe.firstMatch(url)?.group(1);
+
+  // ── Validate ───────────────────────────────────────────────────────────────
+
+  Future<void> validate(String imdbUrl) async {
+    final id = _extractImdbId(imdbUrl.trim());
+    if (id == null) {
+      state =
+          RequestError('Not a valid IMDB URL. Expected: imdb.com/title/tt…');
+      return;
+    }
+
+    state = RequestValidating();
+
+    try {
+      final config =
+          _ref.read(sheetConfigProvider).valueOrNull ?? const SheetConfig();
+
+      final results = await Future.wait([
+        ImdbService().resolve([id]),
+        _fetchExistingIds(config.requestResUrl),
+      ]);
+
+      if (!mounted) return;
+
+      final imdbMap = results[0] as Map<String, ImdbData>;
+      final existingIds = results[1] as Set<String>;
+
+      final data = imdbMap[id];
+
+      if (existingIds.contains(id)) {
+        state = RequestDuplicate(
+          imdbId: id,
+          imdbUrl: 'https://www.imdb.com/title/$id/',
+          title: data?.title ?? id,
+          year: data?.releaseDate?.year,
+          type: _inferType(data),
+          posterUrl: data?.posterUrl ?? '',
+        );
+        return;
+      }
+
+      state = RequestReady(
+        imdbId: id,
+        imdbUrl: 'https://www.imdb.com/title/$id/',
+        title: data?.title ?? id,
+        year: data?.releaseDate?.year,
+        type: _inferType(data),
+        posterUrl: data?.posterUrl ?? '',
+      );
+    } catch (e) {
+      if (mounted) state = RequestError('Could not fetch IMDB data: $e');
+    }
+  }
+
+  static String _inferType(ImdbData? data) {
+    if (data == null) return 'Movie';
+    if (data.parentId != null || data.seasonNumber != null) return 'Episode';
+    if (data.endYear != null) return 'Series';
+    // Ongoing series have no runtimeSeconds and no endYear — heuristic only.
+    if (data.runtimeSeconds == null) return 'Series';
+    return 'Movie';
+  }
+
+  // ── Submit ─────────────────────────────────────────────────────────────────
+
+  Future<void> submit() async {
+    final ready = state;
+    if (ready is! RequestReady) return;
+
+    final config =
+        _ref.read(sheetConfigProvider).valueOrNull ?? const SheetConfig();
+    final formUrl = config.requestFormUrl;
+    if (formUrl == null || formUrl.isEmpty) return;
+
+    state = RequestSubmitting();
+
+    try {
+      final prefill = Uri.parse(formUrl);
+      final submissionPath =
+          prefill.path.replaceFirst('/viewform', '/formResponse');
+      final submissionUri = Uri(
+        scheme: prefill.scheme,
+        host: prefill.host,
+        path: submissionPath,
+      );
+
+      // Extract the first entry.XXXXXXXXXX parameter from the pre-fill URL.
+      final entryParam = prefill.queryParameters.entries
+          .firstWhere(
+            (e) => e.key.startsWith('entry.'),
+            orElse: () => const MapEntry('', ''),
+          )
+          .key;
+
+      if (entryParam.isEmpty) {
+        if (mounted) {
+          state = RequestError(
+              'Form configuration error — no entry field found in the URL.');
+        }
+        return;
+      }
+
+      final body =
+          '$entryParam=${Uri.encodeComponent(ready.imdbUrl)}';
+
+      final response = await http
+          .post(
+            submissionUri,
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: body,
+          )
+          .timeout(const Duration(seconds: 15));
+
+      if (!mounted) return;
+
+      // Google Forms returns 200 (thank-you HTML) on success, or a redirect.
+      if (response.statusCode >= 200 && response.statusCode < 400) {
+        state = RequestSuccess();
+      } else {
+        state = RequestError(
+            'Submission failed (HTTP ${response.statusCode}). Try again.');
+      }
+    } catch (e) {
+      if (mounted) state = RequestError('Submission failed: $e');
+    }
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  Future<Set<String>> _fetchExistingIds(String? resUrl) async {
+    if (resUrl == null || resUrl.isEmpty) return {};
+    try {
+      final sheetId = _sheetIdRe.firstMatch(resUrl)?.group(1);
+      if (sheetId == null) return {};
+
+      final csvUrl =
+          'https://docs.google.com/spreadsheets/d/$sheetId/gviz/tq?tqx=out:csv';
+      final response = await http
+          .get(Uri.parse(csvUrl))
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode != 200 ||
+          response.body.trimLeft().startsWith('<')) {
+        return {};
+      }
+
+      final normalized =
+          response.body.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+      final rows =
+          const CsvToListConverter(eol: '\n').convert(normalized);
+      if (rows.isEmpty) return {};
+
+      final headers = rows[0]
+          .map((h) => h.toString().trim().toLowerCase())
+          .toList();
+      final linkIdx = headers.indexOf('imdb link');
+      if (linkIdx < 0) return {};
+
+      final ids = <String>{};
+      for (final row in rows.skip(1)) {
+        if (linkIdx < row.length) {
+          final m = _imdbUrlRe.firstMatch(row[linkIdx].toString());
+          if (m != null) ids.add(m.group(1)!);
+        }
+      }
+      return ids;
+    } catch (_) {
+      return {};
+    }
+  }
+
+  void reset() => state = RequestIdle();
+}

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -29,8 +29,7 @@ final activeTabProvider = StateProvider<AppTab>((ref) {
   if (settings.tabOrder != null && settings.tabOrder!.isNotEmpty) {
     return AppTab.values[settings.tabOrder!.first.clamp(0, AppTab.settings.index)];
   }
-  final sheetUrl = ref.read(sheetUrlProvider);
-  return sheetUrl != null ? AppTab.catalog : AppTab.encode;
+  return AppTab.catalog;
 });
 
 final ghAuthProvider = FutureProvider<bool>(


### PR DESCRIPTION
## What's New

### Features
- **Content Request Flow** — Users can request a movie or series by pasting an IMDB URL directly in the Catalog page; the app validates via the IMDB API, shows a preview card (poster, title, year, type), detects duplicates against the responses sheet, and submits to a Google Form without opening a browser
- **Admin Requests Panel** — New "Requests" mode in the Admin panel fetches all submitted requests from the responses sheet, enriched with IMDB metadata (poster thumbnail, title, year, type badges) and a one-click Load button
- **Admin Mode Memory** — The Admin panel remembers the last selected mode (Movie / Series / Episode / Requests) and restores it on next launch

### Improvements
- **Config Sheet** — `request_form_url` and `request_res_url` are read from a `Config` tab in the Google Sheet (key-value CSV, 30-min cache with background refresh)
- **Startup Tab** — App always opens on the Catalog tab at startup, regardless of sheet URL async load timing

## Test plan
- [ ] Paste a valid IMDB URL in Catalog → verify preview card appears with poster, title, year, type
- [ ] Submit → verify form receives the entry without opening a browser
- [ ] Paste the same URL again → verify duplicate warning shown
- [ ] Open Admin → Requests → verify rows appear with poster + metadata
- [ ] Click Load on a request row → verify it loads into the correct Movie/Series form
- [ ] Switch Admin to Series, close app, reopen → verify it opens on Series

🤖 Generated with [Claude Code](https://claude.com/claude-code)