### PR TITLE
feat: v1.6.0 — Runtime theme switching with 7 named themes

### DIFF
--- a/docs/ui-themes.md
+++ b/docs/ui-themes.md
@@ -1,0 +1,476 @@
+# mStorage — UI Theme Exploration
+
+> **What this document is.** A catalogue of alternative visual identities for mStorage.
+> Each theme is a *complete* aesthetic — colours, typography, layout, navigation, shape
+> language and motion — designed so the app can look like an entirely different product
+> **without changing a single line of feature logic**.
+>
+> **How to use it with Claude Code.** Point Claude at this file and say something like:
+> *"Apply the **Phosphor** theme from `docs/ui-themes.md` on a new branch. Presentation
+> only — do not touch any feature logic, providers, services, or async flows."*
+> The [Implementation Playbook](#implementation-playbook) at the bottom is the contract
+> Claude should follow every time.
+>
+> Themes are **mutually exclusive explorations**, not features to ship together. Pick one,
+> try it, throw it away or keep it. The baseline ("Spectrum") is what ships today.
+
+---
+
+## 0. The current look, named: **"Spectrum"**
+
+So we have a shared reference point, here is today's design language written in the same
+vocabulary as the alternatives below.
+
+| Axis | Spectrum (today) |
+|---|---|
+| **Concept** | Dark "developer-tool" surface where **each page owns one neon colour**; the entire chrome (title-bar dot, sidebar accent, content tint) morphs to that colour as you navigate. |
+| **Base** | Near-black `#0A0A0F`, layered surfaces `#13131A` / `#1C1C26`, hairline border `#2A2A38`. |
+| **Accent model** | **Per-page neon.** Encode = blue, Decode = green, Player = rose, Catalog = amber, Settings = violet, Admin = cyan, Series = orange. Each is a `TabPalette {primary, secondary, glow, surface}`. |
+| **Typography** | Space Grotesk (geometric, techy). |
+| **Shape** | 10–12 px radius, soft. |
+| **Elevation** | Translucent **glows** behind icons/dots (`blurRadius` + low-alpha accent). |
+| **Navigation** | 72 px vertical **icon rail** on the left; active item has a 3 px left border + tinted fill + glowing icon. |
+| **Motion** | Fade + slide-up page transitions (280 ms); whole-chrome colour morph on tab switch; pulsing "running" dots; toast slide-ins. |
+| **Vibe** | Linear / cyberpunk-lite / neon dashboard. |
+
+Everything below is a deliberate departure from this.
+
+---
+
+## 1. How the theme system is wired (read before implementing anything)
+
+A re-skin is safe because presentation is concentrated in a few seams. Touch these; leave
+everything else alone.
+
+| File | Role | What a theme changes here |
+|---|---|---|
+| `lib/core/theme/app_theme.dart` | Global `ThemeData`, the `k*` colour constants, the Google Font. | All base colours, font, input/card styling, radius defaults. |
+| `lib/core/theme/tab_colors.dart` | `TabPalette` + the per-tab `tabPalettes` map + `kSeriesPalette`. | The accent model. A theme may keep per-page colours, collapse them to one brand accent, or desaturate them — but **keep the `TabPalette` shape and the map keys** so call-sites don't break. |
+| `lib/features/shell/app_shell.dart` | Custom title bar, the 72 px icon rail, page-transition animations, content-surface tint, toasts. | Navigation style, window chrome, transition feel, overall layout frame. |
+| `lib/features/shell/widgets/shared_widgets.dart` | `SectionHeader`, `SmallButton`, `ErrorBanner`, `PasswordWarningBanner`, `OutDirRow`. | The repeated building blocks every screen uses — restyle these and most screens follow automatically. |
+
+**The token contract.** Every theme is defined by filling in the same set of tokens. If a
+theme supplies all of these, the screens inherit it for free:
+
+- **Surfaces:** `bg`, `surface`, `surface2`, `border`
+- **Text tiers:** `textPrimary`, `textSecondary`, `textMuted`
+- **Accent model:** either one brand accent or a per-page `TabPalette` map
+- **Type:** font family (heading + body if split), weights, letter-spacing, case
+- **Shape:** corner radius scale, border weight
+- **Elevation:** shadow / glow / glass / extrusion model
+- **Spacing:** base unit, page padding, control padding
+- **Navigation:** rail vs top-tabs vs floating dock vs command-bar
+- **Motion:** transition type, duration, easing
+
+**Hard rules for any re-skin (functionality preservation):**
+1. Change only widget *appearance* — never provider logic, notifiers, services, async flows, file I/O, or media-kit / webview wiring.
+2. Keep the `AppTab` enum and every `tabPalettes` key. Keep `TabPalette`'s four fields (you may repurpose `glow`, e.g. as a gradient stop, but the field must exist).
+3. Keep all public widget constructors/params used by screens (`SectionHeader(icon, title, subtitle, color)` etc.). Restyle the body, preserve the signature.
+4. Preserve all interaction affordances: drag-and-drop zones, hover states, tooltips, running indicators, update badge, toasts, fullscreen-hides-chrome behaviour.
+5. After applying, run `flutter analyze` and `flutter build windows --release` — both must pass.
+
+---
+
+## 2. The themes at a glance
+
+| # | Name | One-liner | Light/Dark | Accent model | Nav | Font feel |
+|---|---|---|---|---|---|---|
+| 1 | **Monolith** | Swiss-brutalist; structure as decoration | Light | Mono + 1 loud accent | Top text tabs | Grotesk + mono |
+| 2 | **Aurora** | Frosted glass over a living gradient | Dark | One gradient | Floating glass dock | Soft sans |
+| 3 | **Manuscript** | A printed magazine you can run | Light (paper) | One restrained ink accent | TOC-style list | Serif display + sans |
+| 4 | **Phosphor** | A hacker terminal — on-theme for stego | Dark (CRT) | One phosphor hue | Command bar | Monospace |
+| 5 | **Clay** | Soft, tactile, extruded toy UI | Light/soft | One candy accent | Soft pill rail | Rounded sans |
+| 6 | **Halcyon** | The calm, muted, anti-neon pro tool | Dark | Desaturated per-page | Quiet rail | Neutral sans |
+
+Pick by feeling: want **serious & quiet** → Halcyon. **Premium & literary** → Manuscript.
+**Bold & opinionated** → Monolith. **Lush & modern** → Aurora. **Playful** → Clay.
+**On-brand for a steganography tool** → Phosphor.
+
+---
+
+## 3. Theme specs
+
+Each spec is written so it can be lifted directly into an implementation prompt.
+
+---
+
+### 1 — Monolith
+*Swiss / brutalist. Loud type, hard edges, no glow, one screaming accent. Looks like a
+design studio's internal tool.*
+
+**Concept.** Decoration is banned; **structure is the decoration.** Visible grid, hard
+black hairlines, oversized typographic hierarchy, and exactly one high-voltage accent used
+sparingly. The per-page rainbow is gone — there is one accent for the whole app.
+
+**Colour tokens**
+
+| Token | Hex |
+|---|---|
+| bg | `#FAFAF7` (paper white) |
+| surface | `#FFFFFF` |
+| surface2 | `#F0F0EC` |
+| border | `#0B0B0B` (hard black, 1.5 px) |
+| textPrimary | `#0B0B0B` |
+| textSecondary | `#3A3A38` |
+| textMuted | `#8A8A86` |
+| **accent** | `#1F1FFF` electric blue *(or `#FF3B00` signal orange — pick one)* |
+
+**Typography.** Headings: **Archivo** / **Space Grotesk** in 800 weight, tight tracking,
+large. Labels & metadata: **Space Mono** uppercase, `letterSpacing: 1.5`. Body: same
+grotesk, regular.
+
+**Shape & elevation.** Radius `0`. Borders `1.5 px` solid black on every panel, input and
+button. **No shadows, no glows.** Optional 1 px grid rules between sections.
+
+**Navigation & layout.** Replace the icon rail with a **top horizontal tab bar**: uppercase
+text labels (`ENCODE  DECODE  PLAYER  …`), active tab = solid black block with white text
+(or a thick 3 px underline). Title bar becomes a stark black band with the wordmark in mono.
+Content area is plain `bg` (no per-page tint).
+
+**Components.**
+- *Buttons:* sharp filled rectangles — accent fill, white label, OR black outline + black label. Hover = invert.
+- *Inputs:* white box, 1.5 px black border, label uppercase mono above the field.
+- *Cards:* white, hard black border, no radius; header bar separated by a 1.5 px rule.
+- *SectionHeader:* drop the glowing icon chip → big black title + thin mono subtitle, accent only on a small leading square.
+- *ErrorBanner:* black border, accent-tinted fill, mono text.
+
+**Motion.** Near-instant. 100 ms hard fades, no slide, no colour morph. Brutalism doesn't
+animate much.
+
+**What makes it feel different.** Light, sharp, typographic, monochrome — the literal
+opposite of soft glowing neon.
+
+---
+
+### 2 — Aurora
+*Glassmorphism / spatial UI. Frosted translucent panels floating over an animated gradient
+mesh. visionOS / macOS Big Sur energy.*
+
+**Concept.** Depth through **blur and translucency**, not borders. A slow-moving multi-stop
+gradient lives behind everything; UI panels are frosted glass that let it bleed through. One
+gradient accent replaces the rainbow.
+
+**Colour tokens**
+
+| Token | Value |
+|---|---|
+| bg | animated gradient mesh: `#1E1B4B` → `#312E81` → `#0F766E` (indigo→violet→teal), very slow drift |
+| surface (glass) | `Colors.white @ 6%` over `BackdropFilter(blur: 24)` |
+| surface2 (glass) | `Colors.white @ 10%` |
+| border | `Colors.white @ 14%` (1 px hairline) |
+| textPrimary | `#F5F5FF` |
+| textSecondary | `#C4C2E0` |
+| textMuted | `#8E8CB0` |
+| **accent gradient** | `#6EE7F9` → `#A78BFA` (cyan→violet) |
+
+**Typography.** **Inter** (or Manrope) — soft, modern, slightly rounded. Medium weights,
+generous line height.
+
+**Shape & elevation.** Large radius `20–28 px`. Elevation = blur + a soft coloured ambient
+glow under floating panels. Frosted everything.
+
+**Navigation & layout.** Turn the rail into a **floating glass dock** — either a vertical
+pill on the left margin or a horizontal pill centered at the bottom — detached from the
+edges with margin around it. Title bar becomes a translucent strip. Active nav item = the
+accent gradient as a filled rounded chip.
+
+**Components.**
+- *Buttons:* pill-shaped, accent-gradient fill with a soft outer glow; secondary = glass with hairline.
+- *Inputs:* glass field, inner hairline, gradient focus ring.
+- *Cards:* frosted glass with 1 px white-alpha border and a faint inner top highlight.
+- *SectionHeader:* icon in a frosted circle, title in white, gradient used only on the icon.
+
+**Motion.** Smooth and springy. Panels scale-fade in (`Curves.easeOutBack`). Background
+gradient drifts continuously. Subtle parallax: background shifts slightly opposite to page
+transitions.
+
+**Implementation note.** Wrap the content area in a `Stack` → animated gradient
+`Container` at the back, then `BackdropFilter` glass panels. `flutter_animate` (already a
+dep) covers the drift and entrances.
+
+**What makes it feel different.** Colour comes from *light and gradient*, not solid blocks;
+everything floats and blurs instead of sitting on flat dark cards.
+
+---
+
+### 3 — Manuscript
+*Editorial light theme. Warm paper, serif display headings, ink text, hairline rules,
+generous whitespace. Reads like a premium magazine or a Kindle.*
+
+**Concept.** Content-first and literary. Calm, warm, printed. The app feels less like a
+"tool" and more like a **publication**. One restrained ink accent; whitespace does the work
+the neon used to do.
+
+**Colour tokens**
+
+| Token | Hex |
+|---|---|
+| bg | `#F6F2E9` (warm paper) |
+| surface | `#FBF9F3` |
+| surface2 | `#EFE9DA` |
+| border (hairline) | `#E2DBCB` |
+| textPrimary (ink) | `#1C1A17` |
+| textSecondary | `#6B6357` |
+| textMuted | `#A39A88` |
+| **accent** | `#2B4C7E` ink-blue *(or `#B4552D` terracotta)* |
+
+**Typography.** Headings: **Fraunces** (or Playfair Display / Libre Caslon) — a real serif
+display face, used large. Body: **Source Sans 3** / **Inter** at comfortable reading size,
+`height: 1.6`. Labels: small-caps, tracked.
+
+**Shape & elevation.** Radius `4 px`. **Hairline rules** instead of borders+shadows. No
+glow. Optional very subtle paper grain. Lots of breathing room (page padding `40 px`+).
+
+**Navigation & layout.** Left side becomes a **table-of-contents menu**: serif/small-caps
+text items, active = ink accent with a thin left rule — no icons-as-buttons, more like a
+chapter list. Title bar = thin band with a serif wordmark and a hairline underneath.
+
+**Components.**
+- *Buttons:* understated — ink-accent text buttons with a hairline box, or a quiet filled accent for the single primary action.
+- *Inputs:* underlined fields (bottom hairline only) with small-caps labels.
+- *Cards:* paper cards separated by hairlines and whitespace rather than heavy borders.
+- *SectionHeader:* large serif title + sans subtitle; accent reserved for a small leading mark.
+- *ErrorBanner:* warm, low-key — terracotta hairline + ink text, no alarm-red.
+
+**Motion.** Gentle. Slow cross-fades (page-turn feel), no sliding chrome, no pulsing.
+
+**What makes it feel different.** Light, warm, serif, spacious — a tonal and emotional
+inversion of the dark neon dashboard.
+
+---
+
+### 4 — Phosphor
+*Retro terminal / CRT. Monospace everything, one phosphor colour, ASCII frames, scanlines.
+Thematically perfect for a steganography tool.*
+
+**Concept.** The whole app pretends to be a **CRT terminal**. One phosphor hue (classic
+green or amber) at varying brightness is the entire palette. Panels are drawn as boxes with
+corner brackets and title-in-the-border. Hidden-data tool → hacker aesthetic is on-brand.
+
+**Colour tokens**
+
+| Token | Hex |
+|---|---|
+| bg | `#020402` (near-black with green cast) |
+| surface | `#050A05` |
+| surface2 | `#08120A` |
+| border | `#1C3D1C` (dim phosphor) |
+| textPrimary | `#33FF66` (bright phosphor) |
+| textSecondary | `#1FA847` |
+| textMuted | `#0F5C28` |
+| **accent** | `#5BFF8F` (hot phosphor) — *amber variant: bg same, hue `#FFB000`* |
+
+**Typography.** **JetBrains Mono** / **IBM Plex Mono** / Space Mono — monospace
+*everywhere*, including headings. Slight glow on text (thin shadow in accent).
+
+**Shape & elevation.** Radius `0`. Elevation = a soft phosphor **bloom** (low-alpha accent
+blur) instead of drop shadows. Optional full-screen overlays: faint horizontal **scanlines**
++ very subtle flicker/vignette.
+
+**Navigation & layout.** Replace the rail with a **command bar**: a left list rendered like
+a menu — `> ENCODE`, `  DECODE`, `  PLAYER` — active row prefixed with a blinking `>` cursor;
+or a numbered bar `[1] ENCODE  [2] DECODE …`. Title bar = a status line:
+`mstorage v1.5.0 — [ENCODE] ───────── ● READY`.
+
+**Components.**
+- *Panels:* drawn as boxes with `┌─ TITLE ─────┐ … └────────────┘` corner brackets; the title sits in the top rule.
+- *Buttons:* `[ RUN ]`, `[ BROWSE ]` — bracketed labels; hover = inverted (accent bg, black text).
+- *Inputs:* underline or full box with a blinking cursor glyph; mono placeholder.
+- *Progress / pipeline:* ASCII bars `[####------] 41%`, spinner from `| / - \`.
+- *SectionHeader:* `// SECTION NAME` comment-style, accent on the `//`.
+
+**Motion.** Typewriter text reveals on screen entry; blinking cursor; flicker on the bloom.
+Snappy, no smooth slides.
+
+**Implementation note.** A reusable `TerminalBox` wrapper (CustomPaint border + title) and a
+`BlinkingCursor` widget will cover most screens. Scanlines = a single `IgnorePointer` overlay
+with a repeating gradient; keep it subtle.
+
+**What makes it feel different.** It stops looking like a 2020s app entirely — it looks like
+a machine. Maximum distance from Spectrum.
+
+---
+
+### 5 — Clay
+*Neumorphism / claymorphism. Soft monochrome surfaces, extruded dual-shadow shapes, candy
+accent, big round corners. Tactile and friendly.*
+
+**Concept.** Everything is made of the **same soft material as the background** and pops out
+(or presses in) via paired light/dark shadows. Chunky, rounded, squishy, playful — a
+complete personality flip from the sharp neon dashboard.
+
+**Colour tokens** (light variant)
+
+| Token | Hex |
+|---|---|
+| bg | `#E8EAF1` (soft warm grey) |
+| surface | `#E8EAF1` (same as bg — pop is from shadow) |
+| surface2 | `#EDEFF5` |
+| border | none (use shadows) |
+| shadow-light | `#FFFFFF @ 80%` (top-left) |
+| shadow-dark | `#A6ABBD @ 55%` (bottom-right) |
+| textPrimary | `#3A3D4D` |
+| textSecondary | `#6E7287` |
+| textMuted | `#A0A4B8` |
+| **accent** | `#9B8CFF` lavender *(or `#5BD6A8` mint)* |
+
+*Dark variant: bg `#23252E`, light-shadow `#2C2F3A`, dark-shadow `#171922`.*
+
+**Typography.** **Nunito** / **Quicksand** (rounded sans). Friendly, medium-bold.
+
+**Shape & elevation.** Big radius `18–28 px`. **No borders or glow** — elevation is the dual
+soft-shadow ("extruded") look. Pressed/active state = **inset** shadows (concave).
+
+**Navigation & layout.** Rail items become soft extruded **pills**; the active item is
+*pressed in* (inset) with an accent icon. Title bar is a soft raised bar. Content sits on the
+same material, no tint.
+
+**Components.**
+- *Buttons:* raised clay pills; on press they depress (inset) with a spring.
+- *Inputs:* inset (concave) fields, as if carved into the surface.
+- *Cards:* raised clay panels with generous padding and big radius.
+- *Toggles:* physical-switch look. *Progress:* an inset track with a raised accent fill.
+- *SectionHeader:* icon in a raised clay circle, accent-tinted.
+
+**Motion.** Bouncy springs on press/release; gentle scale on hover. Soft, toy-like.
+
+**Implementation note.** A `ClayContainer` helper taking `depth` and `isPressed` (two
+`BoxShadow`s, opposite offsets) is the core primitive — almost every component composes from
+it. Keep shadow offsets small (4–6 px) so it reads as "soft," not "embossed."
+
+**What makes it feel different.** No hard edges, no glow, no color blocks — just soft
+extruded material. Warm and toy-like vs. cold and techy.
+
+---
+
+### 6 — Halcyon
+*The calm, muted, anti-neon pro tool. Stays dark, but trades the neon rainbow for a
+low-saturation, restful Nord / Tokyo-Night palette. The "serious mode."*
+
+**Concept.** Keep the dark, professional layout the user already likes — but **turn the
+saturation way down.** No glows, no electric colours. This is the smallest leap from
+Spectrum while still feeling like a different, more grown-up app: an IDE/Obsidian mood.
+
+**Colour tokens**
+
+| Token | Hex |
+|---|---|
+| bg | `#1A1B26` |
+| surface | `#1F2335` |
+| surface2 | `#24283B` |
+| border | `#2E3350` |
+| textPrimary | `#C0CAF5` |
+| textSecondary | `#9AA5CE` |
+| textMuted | `#565F89` |
+
+**Accent model — desaturated per-page** (keeps the per-page identity, drops the neon):
+
+| Tab | Hex |
+|---|---|
+| Encode | `#7AA2F7` steel blue |
+| Decode | `#9ECE6A` sage |
+| Player | `#F7768E` dusty rose |
+| Catalog | `#E0AF68` muted gold |
+| Settings | `#BB9AF7` soft lilac |
+| Admin | `#7DCFFF` pale sky |
+| Series | `#FF9E64` muted orange |
+
+> *Alternative:* collapse to a single accent (`#7AA2F7`) for an even quieter, more unified
+> feel — decide at implementation time.
+
+**Typography.** **Inter** or **IBM Plex Sans** — neutral, professional, no personality
+quirks. Normal weights.
+
+**Shape & elevation.** Radius `8 px`. Thin 1 px borders. **Remove glows** — replace
+`BoxShadow(glow)` with either nothing or a barely-there `Colors.black @ 30%` drop. Active
+states use a soft accent fill (`@ 12%`) + a 2 px left border, no bloom.
+
+**Navigation & layout.** Same 72 px rail and top bar (familiar), but quiet: muted icon
+colours, no glow, subtle fill on active. The "running" dot pulses gently instead of glowing.
+
+**Components.** Same structures as today, restyled flat: calm focus rings, understated
+buttons (`@ 10%` fill), flat cards, soft non-alarming banners.
+
+**Motion.** Keep the existing transitions but shorten/soften (200 ms crossfade, less slide).
+Drop the whole-chrome neon morph or make it a subtle tint shift.
+
+**Implementation note.** Lowest-effort theme — mostly a swap of the `k*` constants and the
+`tabPalettes` values plus deleting/softening glow `BoxShadow`s. Layout untouched.
+
+**What makes it feel different.** Same bones, completely different temperature — from
+"energetic neon dashboard" to "focused, quiet workspace."
+
+---
+
+## Implementation Playbook
+
+Follow this every time a theme from this doc is applied.
+
+**Step 0 — Branch.** `git checkout -b theme/<name>` (e.g. `theme/phosphor`). One theme per
+branch.
+
+**Step 1 — Tokens first.** Rewrite `lib/core/theme/app_theme.dart`:
+- Swap the `k*` colour constants to the theme's surface/text tokens.
+- Swap the Google Font (`GoogleFonts.<family>TextTheme`). Split heading/body fonts if the theme calls for it.
+- Update `inputDecorationTheme`, `cardColor`, radius defaults, focus border.
+
+**Step 2 — Accent model.** Edit `lib/core/theme/tab_colors.dart`:
+- Keep `TabPalette`'s fields and every `tabPalettes` key + `kSeriesPalette`.
+- For per-page themes (Halcyon): replace the colour values.
+- For single-accent themes (all others): set every palette's `primary`/`secondary` to the one brand accent (and repurpose `glow` as needed). This makes the whole app drop the rainbow with zero call-site edits.
+
+**Step 3 — Shell / navigation.** Edit `lib/features/shell/app_shell.dart`:
+- Reshape `_TitleBar`, `_Sidebar`/`_SidebarItem` (or replace the rail with top-tabs / dock / command-bar per the theme).
+- Adjust page-transition animations and the content-surface tint.
+- **Preserve behaviour:** dragging, maximize/restore/close, fullscreen-hides-chrome, the update badge, running indicators, and the toast stack.
+
+**Step 4 — Shared widgets.** Restyle `lib/features/shell/widgets/shared_widgets.dart`
+(`SectionHeader`, `SmallButton`, `ErrorBanner`, `PasswordWarningBanner`, `OutDirRow`) —
+**keep their constructor signatures.** Most screens update for free once these change.
+
+**Step 5 — Per-screen sweep.** Grep for hardcoded styling that bypasses tokens and fix it:
+- `withValues(alpha:` glow `BoxShadow`s (kill/soften for flat themes),
+- hardcoded hex literals (e.g. `ErrorBanner`'s reds, drop-zone colours),
+- `BorderRadius.circular(<n>)` literals → align to the theme's radius,
+- any `GoogleFonts.` or `TextStyle(fontFamily:` overrides in screens.
+- Screens to check: `encode_screen`, `decode_screen`, `player_screen`, `catalog_screen`,
+  `settings_screen`, `admin_screen`, `series_detail_screen`, and the `widgets/` under each
+  feature (`drop_zone`, `progress_pipeline`, `catalog_card`, `series_card`,
+  `catalog_detail_panel`, `extracted_files_list`, `webview_overlay`).
+
+**Step 6 — Verify.**
+- `flutter analyze` → clean.
+- `flutter build windows --release` → succeeds.
+- Manually click through every tab: navigation, drag-drop, encode/decode runs, player,
+  catalog grid, settings, update flow, toasts — all must behave exactly as before.
+
+**Guardrails (do not cross):**
+- No edits to providers, notifiers, services, models, or async/file/media/webview logic.
+- No renaming of `AppTab` values or `tabPalettes` keys.
+- No changes to widget *behaviour* — only paint.
+
+---
+
+## Optional: make themes switchable instead of swap-and-throw
+
+If, after trying a few, the goal becomes "let the user choose," the clean path is:
+
+1. Promote tokens to a `ThemeSpec` object (all the tokens in §1) rather than top-level
+   `const`s, and provide them via a Riverpod provider (`activeThemeProvider`).
+2. Define one `ThemeSpec` per theme in `lib/core/theme/specs/`.
+3. Replace direct `k*` references with `context`/`ref` lookups (a `Theme.of`-style extension).
+4. Add a theme picker in Settings persisting to `shared_preferences` (the settings service
+   already exists).
+
+This is a larger refactor — only worth it once a shortlist of keepers exists. For pure
+exploration, swap-on-a-branch (the Playbook above) is faster.
+
+---
+
+## Adding more themes later
+
+Append a new `### N — Name` section using the same spec shape (Concept → Colour tokens →
+Typography → Shape & elevation → Navigation & layout → Components → Motion → What makes it
+feel different). Ideas not yet specced: **Sunset** (warm gradient light), **Carbon** (IBM
+Carbon enterprise), **Vapor** (80s synthwave), **Mono** (pure greyscale + one accent),
+**Kawaii** (pastel maximalist).

--- a/lib/core/models/settings_model.dart
+++ b/lib/core/models/settings_model.dart
@@ -12,6 +12,7 @@ class AppSettings {
   final List<int>? tabOrder;
   final bool deleteAfterDecode;
   final double playerVolume;
+  final String themeId;
 
   const AppSettings({
     this.password = '',
@@ -27,6 +28,7 @@ class AppSettings {
     this.tabOrder,
     this.deleteAfterDecode = false,
     this.playerVolume = 100.0,
+    this.themeId = 'spectrum',
   });
 
   AppSettings copyWith({
@@ -43,6 +45,7 @@ class AppSettings {
     List<int>? tabOrder,
     bool? deleteAfterDecode,
     double? playerVolume,
+    String? themeId,
   }) {
     return AppSettings(
       password: password ?? this.password,
@@ -61,6 +64,7 @@ class AppSettings {
       tabOrder: tabOrder ?? this.tabOrder,
       deleteAfterDecode: deleteAfterDecode ?? this.deleteAfterDecode,
       playerVolume: playerVolume ?? this.playerVolume,
+      themeId: themeId ?? this.themeId,
     );
   }
 }

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -3,9 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/settings_model.dart';
+import '../theme/theme_spec.dart';
 
 String _mStorageBase() {
-  final home = Platform.environment['USERPROFILE'] ?? Platform.environment['HOME'] ?? '';
+  final home =
+      Platform.environment['USERPROFILE'] ?? Platform.environment['HOME'] ?? '';
   return p.join(home, 'Videos', 'mStorage');
 }
 
@@ -28,6 +30,7 @@ const _kLastVideoPath = 'last_video_path';
 const _kTabOrder = 'tab_order';
 const _kDeleteAfterDecode = 'setting_delete_after_decode';
 const _kPlayerVolume = 'player_volume';
+const _kThemeId = 'setting_theme_id';
 
 class SettingsNotifier extends Notifier<AppSettings> {
   late SharedPreferences _prefs;
@@ -48,13 +51,22 @@ class SettingsNotifier extends Notifier<AppSettings> {
       syncplayUsername: _prefs.getString(_kSyncplayUsername) ?? '',
       syncplayRoom: _prefs.getString(_kSyncplayRoom) ?? '',
       lastVideoPath: _prefs.getString(_kLastVideoPath) ?? '',
-      tabOrder: _prefs.getString(_kTabOrder)
+      tabOrder: _prefs
+          .getString(_kTabOrder)
           ?.split(',')
           .map(int.parse)
           .toList(),
       deleteAfterDecode: _prefs.getBool(_kDeleteAfterDecode) ?? false,
       playerVolume: _prefs.getDouble(_kPlayerVolume) ?? 100.0,
+      themeId: _prefs.getString(_kThemeId) ?? 'spectrum',
     );
+    applyThemeGlobals(appThemeIdFromString(state.themeId));
+  }
+
+  Future<void> setThemeId(AppThemeId id) async {
+    applyThemeGlobals(id);
+    state = state.copyWith(themeId: id.id);
+    await _prefs.setString(_kThemeId, id.id);
   }
 
   Future<void> setPassword(String value) async {
@@ -138,6 +150,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
       tabOrder: null,
       deleteAfterDecode: state.deleteAfterDecode,
       playerVolume: state.playerVolume,
+      themeId: state.themeId,
     );
   }
 
@@ -147,5 +160,6 @@ class SettingsNotifier extends Notifier<AppSettings> {
   }
 }
 
-final settingsProvider =
-    NotifierProvider<SettingsNotifier, AppSettings>(SettingsNotifier.new);
+final settingsProvider = NotifierProvider<SettingsNotifier, AppSettings>(
+  SettingsNotifier.new,
+);

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'theme_spec.dart';
 
+// Re-exported so existing `import app_theme.dart` call sites can use it.
+export 'theme_spec.dart' show onAccentColor;
+
 // Theme tokens. These are GETTERS (not const) so the whole app re-skins at
 // runtime when [applyThemeGlobals] swaps [activeSpec] and the tree rebuilds.
 // Call sites are unchanged (`kBgColor`, `kTextPrimary`, …); the only cost is

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,47 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'theme_spec.dart';
 
-const kBgColor = Color(0xFF0A0A0F);
-const kSurfaceColor = Color(0xFF13131A);
-const kSurface2Color = Color(0xFF1C1C26);
-const kBorderColor = Color(0xFF2A2A38);
-const kTextPrimary = Color(0xFFE8E8F0);
-const kTextSecondary = Color(0xFF8888A8);
-const kTextMuted = Color(0xFF4A4A68);
+// Theme tokens. These are GETTERS (not const) so the whole app re-skins at
+// runtime when [applyThemeGlobals] swaps [activeSpec] and the tree rebuilds.
+// Call sites are unchanged (`kBgColor`, `kTextPrimary`, …); the only cost is
+// that they can no longer appear inside `const` expressions.
+Color get kBgColor => activeSpec.bg;
+Color get kSurfaceColor => activeSpec.surface;
+Color get kSurface2Color => activeSpec.surface2;
+Color get kBorderColor => activeSpec.border;
+Color get kTextPrimary => activeSpec.textPrimary;
+Color get kTextSecondary => activeSpec.textSecondary;
+Color get kTextMuted => activeSpec.textMuted;
 
-ThemeData buildAppTheme() {
-  final base = ThemeData.dark();
-  return base.copyWith(
-    scaffoldBackgroundColor: kBgColor,
-    colorScheme: const ColorScheme.dark(
-      surface: kSurfaceColor,
-      onSurface: kTextPrimary,
-      primary: Color(0xFF3B82F6),
-    ),
-    textTheme: GoogleFonts.spaceGroteskTextTheme(base.textTheme).apply(
-      bodyColor: kTextPrimary,
-      displayColor: kTextPrimary,
-    ),
-    inputDecorationTheme: InputDecorationTheme(
-      filled: true,
-      fillColor: kSurface2Color,
-      border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(10),
-        borderSide: const BorderSide(color: kBorderColor),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(10),
-        borderSide: const BorderSide(color: kBorderColor),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(10),
-        borderSide: const BorderSide(color: Color(0xFF3B82F6), width: 1.5),
-      ),
-      labelStyle: const TextStyle(color: kTextSecondary),
-      hintStyle: const TextStyle(color: kTextMuted),
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-    ),
-    dividerColor: kBorderColor,
-    cardColor: kSurfaceColor,
-  );
-}
+/// Base corner radius for the active theme (0 for Monolith/Phosphor, large for
+/// Aurora/Clay). Use for cards/buttons/inputs so shape adapts per theme.
+double get kRadius => activeSpec.radius;
+
+ThemeData buildAppTheme() => activeSpec.buildThemeData();

--- a/lib/core/theme/tab_colors.dart
+++ b/lib/core/theme/tab_colors.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'theme_spec.dart';
 
 enum AppTab { encode, decode, player, catalog, settings, admin }
 
@@ -16,52 +17,13 @@ class TabPalette {
   });
 }
 
-const tabPalettes = {
-  AppTab.encode: TabPalette(
-    primary: Color(0xFF3B82F6),
-    secondary: Color(0xFF818CF8),
-    glow: Color(0x663B82F6),
-    surface: Color(0xFF0F1629),
-  ),
-  AppTab.decode: TabPalette(
-    primary: Color(0xFF10B981),
-    secondary: Color(0xFF34D399),
-    glow: Color(0x6610B981),
-    surface: Color(0xFF0A1F17),
-  ),
-  AppTab.player: TabPalette(
-    primary: Color(0xFFF43F5E),
-    secondary: Color(0xFFFB7185),
-    glow: Color(0x66F43F5E),
-    surface: Color(0xFF1F0A0F),
-  ),
-  AppTab.catalog: TabPalette(
-    primary: Color(0xFFF59E0B),
-    secondary: Color(0xFFFBBF24),
-    glow: Color(0x66F59E0B),
-    surface: Color(0xFF1F1608),
-  ),
-  AppTab.settings: TabPalette(
-    primary: Color(0xFFA78BFA),
-    secondary: Color(0xFFC4B5FD),
-    glow: Color(0x66A78BFA),
-    surface: Color(0xFF130F1F),
-  ),
-  AppTab.admin: TabPalette(
-    primary: Color(0xFF06B6D4),
-    secondary: Color(0xFF22D3EE),
-    glow: Color(0x6606B6D4),
-    surface: Color(0xFF061921),
-  ),
-};
+/// Per-tab accent map for the active theme. A single-accent theme returns the
+/// same palette for every tab; Spectrum/Halcyon return distinct ones.
+Map<AppTab, TabPalette> get tabPalettes => activeSpec.palettes;
 
 extension TabPaletteX on AppTab {
-  TabPalette get palette => tabPalettes[this]!;
+  TabPalette get palette =>
+      tabPalettes[this] ?? activeSpec.palettes.values.first;
 }
 
-const kSeriesPalette = TabPalette(
-  primary:   Color(0xFFEA580C),
-  secondary: Color(0xFFF97316),
-  glow:      Color(0x66EA580C),
-  surface:   Color(0xFF1A0A02),
-);
+TabPalette get kSeriesPalette => activeSpec.seriesPalette;

--- a/lib/core/theme/theme_spec.dart
+++ b/lib/core/theme/theme_spec.dart
@@ -295,10 +295,11 @@ final _aurora = ThemeSpec(
     glow: const Color(0x66A78BFA),
     surface: _transparent,
   ),
+  // Single-accent theme: series shares the brand accent, not a separate colour.
   seriesPalette: const TabPalette(
-    primary: Color(0xFF6EE7F9),
-    secondary: Color(0xFFA78BFA),
-    glow: Color(0x666EE7F9),
+    primary: Color(0xFFA78BFA),
+    secondary: Color(0xFF6EE7F9),
+    glow: Color(0x66A78BFA),
     surface: _transparent,
   ),
 );
@@ -328,9 +329,10 @@ final _manuscript = ThemeSpec(
     glow: _transparent,
     surface: const Color(0xFFF6F2E9),
   ),
+  // Single-accent theme: series shares the brand accent, not a separate colour.
   seriesPalette: const TabPalette(
-    primary: Color(0xFFB4552D),
-    secondary: Color(0xFF2B4C7E),
+    primary: Color(0xFF2B4C7E),
+    secondary: Color(0xFFB4552D),
     glow: _transparent,
     surface: Color(0xFFF6F2E9),
   ),
@@ -396,10 +398,11 @@ final _clay = ThemeSpec(
     glow: const Color(0x339B8CFF),
     surface: const Color(0xFFE8EAF1),
   ),
+  // Single-accent theme: series shares the brand accent, not a separate colour.
   seriesPalette: const TabPalette(
-    primary: Color(0xFF5BD6A8),
-    secondary: Color(0xFF9B8CFF),
-    glow: Color(0x335BD6A8),
+    primary: Color(0xFF9B8CFF),
+    secondary: Color(0xFF5BD6A8),
+    glow: Color(0x339B8CFF),
     surface: Color(0xFFE8EAF1),
   ),
 );

--- a/lib/core/theme/theme_spec.dart
+++ b/lib/core/theme/theme_spec.dart
@@ -1,0 +1,490 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'tab_colors.dart';
+
+/// Identifies one of the bundled visual themes.
+/// Persisted by name (see [AppThemeIdX.id] / [appThemeIdFromString]).
+enum AppThemeId {
+  spectrum,
+  monolith,
+  aurora,
+  manuscript,
+  phosphor,
+  clay,
+  halcyon,
+}
+
+/// Broad elevation language a theme uses. Drives glows/borders/shadows in the
+/// shell and shared widgets so most components adapt without per-theme code.
+enum ElevationStyle { glow, flat, glass, bloom, clay }
+
+extension AppThemeIdX on AppThemeId {
+  String get id => name;
+}
+
+AppThemeId appThemeIdFromString(String? s) {
+  for (final t in AppThemeId.values) {
+    if (t.name == s) return t;
+  }
+  return AppThemeId.spectrum;
+}
+
+/// A complete visual identity: colour tokens, typography, shape, elevation and
+/// the per-tab accent map. Switching themes = swapping the active [ThemeSpec].
+///
+/// Feature logic never references this directly — it reads the getter-backed
+/// `k*` constants (app_theme.dart) and `tabPalettes` (tab_colors.dart), both of
+/// which resolve through [activeSpec]. That keeps ~1000 call sites untouched.
+class ThemeSpec {
+  final AppThemeId id;
+  final String name;
+  final String tagline;
+  final bool isDark;
+
+  // Surfaces
+  final Color bg;
+  final Color surface;
+  final Color surface2;
+  final Color border;
+
+  // Text tiers
+  final Color textPrimary;
+  final Color textSecondary;
+  final Color textMuted;
+
+  // Accent
+  final Color brandAccent;
+  final Map<AppTab, TabPalette> palettes;
+  final TabPalette seriesPalette;
+
+  // Typography (google_fonts family names)
+  final String headingFont;
+  final String bodyFont;
+  final double letterSpacing;
+
+  // Shape
+  final double radius;
+  final double borderWidth;
+
+  // Elevation / signature flourishes
+  final ElevationStyle elevation;
+  final bool scanlines;
+  final List<Color>? gradientBg;
+
+  const ThemeSpec({
+    required this.id,
+    required this.name,
+    required this.tagline,
+    required this.isDark,
+    required this.bg,
+    required this.surface,
+    required this.surface2,
+    required this.border,
+    required this.textPrimary,
+    required this.textSecondary,
+    required this.textMuted,
+    required this.brandAccent,
+    required this.palettes,
+    required this.seriesPalette,
+    required this.headingFont,
+    required this.bodyFont,
+    this.letterSpacing = 0,
+    required this.radius,
+    this.borderWidth = 1,
+    required this.elevation,
+    this.scanlines = false,
+    this.gradientBg,
+  });
+
+  bool get hasGlow =>
+      elevation == ElevationStyle.glow ||
+      elevation == ElevationStyle.glass ||
+      elevation == ElevationStyle.bloom;
+
+  ThemeData buildThemeData() {
+    final base = isDark ? ThemeData.dark() : ThemeData.light();
+    final scheme =
+        (isDark ? const ColorScheme.dark() : const ColorScheme.light())
+            .copyWith(
+              surface: surface,
+              onSurface: textPrimary,
+              primary: brandAccent,
+              brightness: isDark ? Brightness.dark : Brightness.light,
+            );
+
+    final textTheme = GoogleFonts.getTextTheme(
+      bodyFont,
+      base.textTheme,
+    ).apply(bodyColor: textPrimary, displayColor: textPrimary);
+
+    return base.copyWith(
+      scaffoldBackgroundColor: bg,
+      colorScheme: scheme,
+      textTheme: textTheme,
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: surface2,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(radius),
+          borderSide: BorderSide(color: border, width: borderWidth),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(radius),
+          borderSide: BorderSide(color: border, width: borderWidth),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(radius),
+          borderSide: BorderSide(color: brandAccent, width: borderWidth + 0.5),
+        ),
+        labelStyle: TextStyle(color: textSecondary),
+        hintStyle: TextStyle(color: textMuted),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 14,
+        ),
+      ),
+      dividerColor: border,
+      cardColor: surface,
+    );
+  }
+}
+
+// ── Palette helpers ──────────────────────────────────────────────────────────
+
+const _transparent = Color(0x00000000);
+
+/// Builds a TabPalette map where every tab shares one brand accent — used by the
+/// single-accent themes that deliberately drop the per-page rainbow.
+Map<AppTab, TabPalette> _mono({
+  required Color primary,
+  required Color secondary,
+  required Color glow,
+  required Color surface,
+}) {
+  final p = TabPalette(
+    primary: primary,
+    secondary: secondary,
+    glow: glow,
+    surface: surface,
+  );
+  return {for (final t in AppTab.values) t: p};
+}
+
+// ── The themes ────────────────────────────────────────────────────────────────
+
+/// 0 — Spectrum (current ship look): dark, one neon accent per page, glows.
+const _spectrum = ThemeSpec(
+  id: AppThemeId.spectrum,
+  name: 'Spectrum',
+  tagline: 'Neon dashboard · one colour per page',
+  isDark: true,
+  bg: Color(0xFF0A0A0F),
+  surface: Color(0xFF13131A),
+  surface2: Color(0xFF1C1C26),
+  border: Color(0xFF2A2A38),
+  textPrimary: Color(0xFFE8E8F0),
+  textSecondary: Color(0xFF8888A8),
+  textMuted: Color(0xFF4A4A68),
+  brandAccent: Color(0xFF3B82F6),
+  headingFont: 'Space Grotesk',
+  bodyFont: 'Space Grotesk',
+  radius: 10,
+  elevation: ElevationStyle.glow,
+  palettes: {
+    AppTab.encode: TabPalette(
+      primary: Color(0xFF3B82F6),
+      secondary: Color(0xFF818CF8),
+      glow: Color(0x663B82F6),
+      surface: Color(0xFF0F1629),
+    ),
+    AppTab.decode: TabPalette(
+      primary: Color(0xFF10B981),
+      secondary: Color(0xFF34D399),
+      glow: Color(0x6610B981),
+      surface: Color(0xFF0A1F17),
+    ),
+    AppTab.player: TabPalette(
+      primary: Color(0xFFF43F5E),
+      secondary: Color(0xFFFB7185),
+      glow: Color(0x66F43F5E),
+      surface: Color(0xFF1F0A0F),
+    ),
+    AppTab.catalog: TabPalette(
+      primary: Color(0xFFF59E0B),
+      secondary: Color(0xFFFBBF24),
+      glow: Color(0x66F59E0B),
+      surface: Color(0xFF1F1608),
+    ),
+    AppTab.settings: TabPalette(
+      primary: Color(0xFFA78BFA),
+      secondary: Color(0xFFC4B5FD),
+      glow: Color(0x66A78BFA),
+      surface: Color(0xFF130F1F),
+    ),
+    AppTab.admin: TabPalette(
+      primary: Color(0xFF06B6D4),
+      secondary: Color(0xFF22D3EE),
+      glow: Color(0x6606B6D4),
+      surface: Color(0xFF061921),
+    ),
+  },
+  seriesPalette: TabPalette(
+    primary: Color(0xFFEA580C),
+    secondary: Color(0xFFF97316),
+    glow: Color(0x66EA580C),
+    surface: Color(0xFF1A0A02),
+  ),
+);
+
+/// 1 — Monolith: Swiss/brutalist, light, hard edges, one loud accent.
+final _monolith = ThemeSpec(
+  id: AppThemeId.monolith,
+  name: 'Monolith',
+  tagline: 'Swiss brutalist · structure as decoration',
+  isDark: false,
+  bg: const Color(0xFFFAFAF7),
+  surface: const Color(0xFFFFFFFF),
+  surface2: const Color(0xFFF0F0EC),
+  border: const Color(0xFF0B0B0B),
+  textPrimary: const Color(0xFF0B0B0B),
+  textSecondary: const Color(0xFF3A3A38),
+  textMuted: const Color(0xFF8A8A86),
+  brandAccent: const Color(0xFF1F1FFF),
+  headingFont: 'Archivo',
+  bodyFont: 'Space Grotesk',
+  letterSpacing: 0.3,
+  radius: 0,
+  borderWidth: 1.5,
+  elevation: ElevationStyle.flat,
+  palettes: _mono(
+    primary: const Color(0xFF1F1FFF),
+    secondary: const Color(0xFF1F1FFF),
+    glow: _transparent,
+    surface: const Color(0xFFFAFAF7),
+  ),
+  seriesPalette: const TabPalette(
+    primary: Color(0xFF1F1FFF),
+    secondary: Color(0xFF1F1FFF),
+    glow: _transparent,
+    surface: Color(0xFFFAFAF7),
+  ),
+);
+
+/// 2 — Aurora: glassmorphism over a living gradient.
+final _aurora = ThemeSpec(
+  id: AppThemeId.aurora,
+  name: 'Aurora',
+  tagline: 'Frosted glass · living gradient',
+  isDark: true,
+  bg: const Color(0xFF1E1B4B),
+  surface: const Color(0x29FFFFFF),
+  surface2: const Color(0x1FFFFFFF),
+  border: const Color(0x24FFFFFF),
+  textPrimary: const Color(0xFFF5F5FF),
+  textSecondary: const Color(0xFFC4C2E0),
+  textMuted: const Color(0xFF8E8CB0),
+  brandAccent: const Color(0xFFA78BFA),
+  headingFont: 'Inter',
+  bodyFont: 'Inter',
+  radius: 22,
+  elevation: ElevationStyle.glass,
+  gradientBg: const [Color(0xFF1E1B4B), Color(0xFF312E81), Color(0xFF0F766E)],
+  palettes: _mono(
+    primary: const Color(0xFFA78BFA),
+    secondary: const Color(0xFF6EE7F9),
+    glow: const Color(0x66A78BFA),
+    surface: _transparent,
+  ),
+  seriesPalette: const TabPalette(
+    primary: Color(0xFF6EE7F9),
+    secondary: Color(0xFFA78BFA),
+    glow: Color(0x666EE7F9),
+    surface: _transparent,
+  ),
+);
+
+/// 3 — Manuscript: editorial light, paper + serif display.
+final _manuscript = ThemeSpec(
+  id: AppThemeId.manuscript,
+  name: 'Manuscript',
+  tagline: 'Editorial paper · serif display',
+  isDark: false,
+  bg: const Color(0xFFF6F2E9),
+  surface: const Color(0xFFFBF9F3),
+  surface2: const Color(0xFFEFE9DA),
+  border: const Color(0xFFE2DBCB),
+  textPrimary: const Color(0xFF1C1A17),
+  textSecondary: const Color(0xFF6B6357),
+  textMuted: const Color(0xFFA39A88),
+  brandAccent: const Color(0xFF2B4C7E),
+  headingFont: 'Fraunces',
+  bodyFont: 'Source Sans 3',
+  radius: 4,
+  borderWidth: 1,
+  elevation: ElevationStyle.flat,
+  palettes: _mono(
+    primary: const Color(0xFF2B4C7E),
+    secondary: const Color(0xFFB4552D),
+    glow: _transparent,
+    surface: const Color(0xFFF6F2E9),
+  ),
+  seriesPalette: const TabPalette(
+    primary: Color(0xFFB4552D),
+    secondary: Color(0xFF2B4C7E),
+    glow: _transparent,
+    surface: Color(0xFFF6F2E9),
+  ),
+);
+
+/// 4 — Phosphor: retro CRT terminal, monospace, single phosphor hue.
+final _phosphor = ThemeSpec(
+  id: AppThemeId.phosphor,
+  name: 'Phosphor',
+  tagline: 'CRT terminal · monospace phosphor',
+  isDark: true,
+  bg: const Color(0xFF020402),
+  surface: const Color(0xFF050A05),
+  surface2: const Color(0xFF08120A),
+  border: const Color(0xFF1C3D1C),
+  textPrimary: const Color(0xFF33FF66),
+  textSecondary: const Color(0xFF1FA847),
+  textMuted: const Color(0xFF0F5C28),
+  brandAccent: const Color(0xFF5BFF8F),
+  headingFont: 'JetBrains Mono',
+  bodyFont: 'JetBrains Mono',
+  letterSpacing: 0.4,
+  radius: 0,
+  borderWidth: 1,
+  elevation: ElevationStyle.bloom,
+  scanlines: true,
+  palettes: _mono(
+    primary: const Color(0xFF5BFF8F),
+    secondary: const Color(0xFF33FF66),
+    glow: const Color(0x6633FF66),
+    surface: const Color(0xFF020402),
+  ),
+  seriesPalette: const TabPalette(
+    primary: Color(0xFF5BFF8F),
+    secondary: Color(0xFF33FF66),
+    glow: Color(0x6633FF66),
+    surface: Color(0xFF020402),
+  ),
+);
+
+/// 5 — Clay: neumorphic / claymorphic soft UI, candy accent.
+final _clay = ThemeSpec(
+  id: AppThemeId.clay,
+  name: 'Clay',
+  tagline: 'Soft neumorphic · tactile',
+  isDark: false,
+  bg: const Color(0xFFE8EAF1),
+  surface: const Color(0xFFEDEFF5),
+  surface2: const Color(0xFFF3F5FA),
+  border: const Color(0xFFD2D6E2),
+  textPrimary: const Color(0xFF3A3D4D),
+  textSecondary: const Color(0xFF6E7287),
+  textMuted: const Color(0xFFA0A4B8),
+  brandAccent: const Color(0xFF9B8CFF),
+  headingFont: 'Nunito',
+  bodyFont: 'Nunito',
+  radius: 22,
+  borderWidth: 1,
+  elevation: ElevationStyle.clay,
+  palettes: _mono(
+    primary: const Color(0xFF9B8CFF),
+    secondary: const Color(0xFF5BD6A8),
+    glow: const Color(0x339B8CFF),
+    surface: const Color(0xFFE8EAF1),
+  ),
+  seriesPalette: const TabPalette(
+    primary: Color(0xFF5BD6A8),
+    secondary: Color(0xFF9B8CFF),
+    glow: Color(0x335BD6A8),
+    surface: Color(0xFFE8EAF1),
+  ),
+);
+
+/// 6 — Halcyon: muted, calm, anti-neon dark. Keeps per-page identity, desaturated.
+const _halcyon = ThemeSpec(
+  id: AppThemeId.halcyon,
+  name: 'Halcyon',
+  tagline: 'Muted calm · the quiet pro tool',
+  isDark: true,
+  bg: Color(0xFF1A1B26),
+  surface: Color(0xFF1F2335),
+  surface2: Color(0xFF24283B),
+  border: Color(0xFF2E3350),
+  textPrimary: Color(0xFFC0CAF5),
+  textSecondary: Color(0xFF9AA5CE),
+  textMuted: Color(0xFF565F89),
+  brandAccent: Color(0xFF7AA2F7),
+  headingFont: 'Inter',
+  bodyFont: 'Inter',
+  radius: 8,
+  elevation: ElevationStyle.flat,
+  palettes: {
+    AppTab.encode: TabPalette(
+      primary: Color(0xFF7AA2F7),
+      secondary: Color(0xFF9AB8FF),
+      glow: _transparent,
+      surface: Color(0xFF1A1B26),
+    ),
+    AppTab.decode: TabPalette(
+      primary: Color(0xFF9ECE6A),
+      secondary: Color(0xFFB9E08C),
+      glow: _transparent,
+      surface: Color(0xFF1A1B26),
+    ),
+    AppTab.player: TabPalette(
+      primary: Color(0xFFF7768E),
+      secondary: Color(0xFFFF9CB0),
+      glow: _transparent,
+      surface: Color(0xFF1A1B26),
+    ),
+    AppTab.catalog: TabPalette(
+      primary: Color(0xFFE0AF68),
+      secondary: Color(0xFFF0C788),
+      glow: _transparent,
+      surface: Color(0xFF1A1B26),
+    ),
+    AppTab.settings: TabPalette(
+      primary: Color(0xFFBB9AF7),
+      secondary: Color(0xFFD0B8FF),
+      glow: _transparent,
+      surface: Color(0xFF1A1B26),
+    ),
+    AppTab.admin: TabPalette(
+      primary: Color(0xFF7DCFFF),
+      secondary: Color(0xFFA3DEFF),
+      glow: _transparent,
+      surface: Color(0xFF1A1B26),
+    ),
+  },
+  seriesPalette: TabPalette(
+    primary: Color(0xFFFF9E64),
+    secondary: Color(0xFFFFB888),
+    glow: _transparent,
+    surface: Color(0xFF1A1B26),
+  ),
+);
+
+/// All bundled themes, keyed by id. Order here is the order shown in Settings.
+final Map<AppThemeId, ThemeSpec> themeSpecs = {
+  AppThemeId.spectrum: _spectrum,
+  AppThemeId.halcyon: _halcyon,
+  AppThemeId.monolith: _monolith,
+  AppThemeId.manuscript: _manuscript,
+  AppThemeId.aurora: _aurora,
+  AppThemeId.clay: _clay,
+  AppThemeId.phosphor: _phosphor,
+};
+
+// ── Active theme holder ───────────────────────────────────────────────────────
+// The getter-backed `k*` constants and `tabPalettes` resolve through this.
+// Mutated by [applyThemeGlobals]; the UI then rebuilds (see MStorageApp).
+
+ThemeSpec activeSpec = _spectrum;
+
+void applyThemeGlobals(AppThemeId id) {
+  activeSpec = themeSpecs[id] ?? _spectrum;
+}

--- a/lib/core/theme/theme_spec.dart
+++ b/lib/core/theme/theme_spec.dart
@@ -29,6 +29,15 @@ AppThemeId appThemeIdFromString(String? s) {
   return AppThemeId.spectrum;
 }
 
+/// Readable on-colour (black or white) for text/icons placed on a solid [fill],
+/// chosen by contrast. Bright fills keep black (so Spectrum is unchanged); dark
+/// accent fills (Monolith/Manuscript) flip to white. The crossover sits at the
+/// luminance where black text stops being legible (~0.18).
+Color onAccentColor(Color fill) {
+  final l = fill.computeLuminance();
+  return (l + 0.05) / 0.05 >= 1.05 / (l + 0.05) ? Colors.black : Colors.white;
+}
+
 /// A complete visual identity: colour tokens, typography, shape, elevation and
 /// the per-tab accent map. Switching themes = swapping the active [ThemeSpec].
 ///
@@ -109,6 +118,7 @@ class ThemeSpec {
               surface: surface,
               onSurface: textPrimary,
               primary: brandAccent,
+              onPrimary: onAccentColor(brandAccent),
               brightness: isDark ? Brightness.dark : Brightness.light,
             );
 

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -878,7 +878,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
             label: const Text('Fetch'),
             style: FilledButton.styleFrom(
               backgroundColor: _adminPalette.primary,
-              foregroundColor: Colors.black,
+              foregroundColor: onAccentColor(_adminPalette.primary),
               padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
               shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(8)),
@@ -1215,7 +1215,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
               onPressed: () => _addGenre(_genreInputCtrl.text),
               style: FilledButton.styleFrom(
                 backgroundColor: _adminPalette.primary,
-                foregroundColor: Colors.black,
+                foregroundColor: onAccentColor(_adminPalette.primary),
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8)),
@@ -1308,7 +1308,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
               onPressed: () => _addTag(_tagInputCtrl.text),
               style: FilledButton.styleFrom(
                 backgroundColor: _adminPalette.primary,
-                foregroundColor: Colors.black,
+                foregroundColor: onAccentColor(_adminPalette.primary),
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8)),
@@ -1906,7 +1906,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
               label: const Text('Copy row'),
               style: FilledButton.styleFrom(
                 backgroundColor: _adminPalette.primary,
-                foregroundColor: Colors.black,
+                foregroundColor: onAccentColor(_adminPalette.primary),
                 padding:
                     const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
                 shape: RoundedRectangleBorder(
@@ -2161,7 +2161,7 @@ class _LightboxActionBtn extends StatelessWidget {
       label: Text(label, style: const TextStyle(fontSize: 11)),
       style: FilledButton.styleFrom(
         backgroundColor: bg,
-        foregroundColor: Colors.white,
+        foregroundColor: onAccentColor(bg),
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       ),
@@ -2609,7 +2609,7 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
             label: const Text('Retry'),
             style: FilledButton.styleFrom(
               backgroundColor: _adminPalette.primary,
-              foregroundColor: Colors.black,
+              foregroundColor: onAccentColor(_adminPalette.primary),
             ),
           ),
         ]),
@@ -2742,7 +2742,7 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
                       onPressed: () => widget.onLoad(row.imdbId),
                       style: FilledButton.styleFrom(
                         backgroundColor: _adminPalette.primary,
-                        foregroundColor: Colors.black,
+                        foregroundColor: onAccentColor(_adminPalette.primary),
                         padding: const EdgeInsets.symmetric(
                             horizontal: 14, vertical: 8),
                         shape: RoundedRectangleBorder(

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -705,7 +705,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                   const SizedBox(height: 12),
                   Text(_error!,
                       textAlign: TextAlign.center,
-                      style: const TextStyle(fontSize: 13, color: kTextSecondary)),
+                      style: TextStyle(fontSize: 13, color: kTextSecondary)),
                 ]),
               ),
             )
@@ -1029,7 +1029,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(data.title,
-                  style: const TextStyle(
+                  style: TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.w700,
                       color: kTextPrimary)),
@@ -1051,13 +1051,13 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                 Text(data.plot,
                     maxLines: 4,
                     overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
+                    style: TextStyle(
                         fontSize: 12, color: kTextSecondary, height: 1.5)),
               ],
               if (data.stars.isNotEmpty) ...[
                 const SizedBox(height: 8),
                 Text(data.stars.join(' · '),
-                    style: const TextStyle(fontSize: 11, color: kTextMuted)),
+                    style: TextStyle(fontSize: 11, color: kTextMuted)),
               ],
             ],
           ),
@@ -1068,7 +1068,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
 
   Widget _posterPlaceholder() => Container(
       color: kSurface2Color,
-      child: const Icon(Icons.movie_rounded, size: 36, color: kTextMuted));
+      child: Icon(Icons.movie_rounded, size: 36, color: kTextMuted));
 
   // ── Date editor ───────────────────────────────────────────────────────────
 
@@ -1113,7 +1113,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                     1, _daysInMonth(v ?? currentYear, _selectedMonth).last);
               }),
             ),
-            const Padding(
+            Padding(
                 padding: EdgeInsets.symmetric(horizontal: 6),
                 child: Text('–', style: TextStyle(color: kTextMuted))),
             _DateDropdown<int>(
@@ -1130,7 +1130,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                     1, _daysInMonth(_selectedYear ?? currentYear, v ?? 1).last);
               }),
             ),
-            const Padding(
+            Padding(
                 padding: EdgeInsets.symmetric(horizontal: 6),
                 child: Text('–', style: TextStyle(color: kTextMuted))),
             _DateDropdown<int>(
@@ -1348,7 +1348,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
           cacheManager: CatalogCacheManager.instance,
           errorWidget: (_, _, _) => Container(
             color: kSurface2Color,
-            child: const Icon(Icons.broken_image_rounded, size: 24, color: kTextMuted),
+            child: Icon(Icons.broken_image_rounded, size: 24, color: kTextMuted),
           ),
         ),
       ),
@@ -1629,7 +1629,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                     children: [
                       Text(
                         _episodeData!.title,
-                        style: const TextStyle(
+                        style: TextStyle(
                             fontSize: 13,
                             fontWeight: FontWeight.w600,
                             color: kTextPrimary),
@@ -1638,7 +1638,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                         const SizedBox(height: 3),
                         Text(
                           _fmtDate(_episodeData!.releaseDate!),
-                          style: const TextStyle(
+                          style: TextStyle(
                               fontSize: 11, color: kTextSecondary),
                         ),
                       ],
@@ -2075,7 +2075,7 @@ class _ImageLightboxState extends State<_ImageLightbox> {
                               errorWidget: (_, _, _) => Container(
                                   width: 400, height: 300,
                                   color: kSurface2Color,
-                                  child: const Icon(Icons.broken_image_rounded,
+                                  child: Icon(Icons.broken_image_rounded,
                                       size: 48, color: kTextMuted)),
                             ),
                           ),
@@ -2342,7 +2342,7 @@ class _GenreRow extends StatelessWidget {
         children: [
           ReorderableDragStartListener(
             index: index,
-            child: const Padding(
+            child: Padding(
               padding: EdgeInsets.symmetric(horizontal: 10),
               child: Icon(Icons.drag_handle_rounded, size: 16, color: kTextMuted),
             ),
@@ -2599,7 +2599,7 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
           const SizedBox(height: 12),
           Text(_error!,
               textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 13, color: kTextSecondary)),
+              style: TextStyle(fontSize: 13, color: kTextSecondary)),
           const SizedBox(height: 16),
           FilledButton.icon(
             onPressed: _load,
@@ -2682,7 +2682,7 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
                                 width: 48,
                                 height: 68,
                                 color: kSurfaceColor,
-                                child: const Icon(Icons.broken_image_rounded,
+                                child: Icon(Icons.broken_image_rounded,
                                     size: 20, color: kTextMuted),
                               ),
                             )
@@ -2693,7 +2693,7 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
                                 color: kSurfaceColor,
                                 borderRadius: BorderRadius.circular(6),
                               ),
-                              child: const Icon(Icons.movie_rounded,
+                              child: Icon(Icons.movie_rounded,
                                   size: 22, color: kTextMuted),
                             ),
                     ),
@@ -2704,7 +2704,7 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
                         children: [
                           Text(
                             row.title,
-                            style: const TextStyle(
+                            style: TextStyle(
                                 fontSize: 13,
                                 fontWeight: FontWeight.w600,
                                 color: kTextPrimary),
@@ -2729,7 +2729,7 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
                           if (row.timestamp.isNotEmpty) ...[
                             const SizedBox(height: 4),
                             Text(row.timestamp,
-                                style: const TextStyle(
+                                style: TextStyle(
                                     fontSize: 10, color: kTextMuted)),
                           ],
                         ],
@@ -2853,7 +2853,7 @@ class _ResultRowState extends State<_ResultRow> {
           SizedBox(
             width: 108,
             child: Text(widget.label,
-                style: const TextStyle(
+                style: TextStyle(
                     fontSize: 12,
                     color: kTextMuted,
                     fontWeight: FontWeight.w500)),

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -20,7 +20,9 @@ import '../catalog/models/series_sheet_schema.dart';
 import '../catalog/models/sheet_schema.dart';
 import '../catalog/series_notifier.dart';
 
-final _adminPalette = AppTab.admin.palette;
+// Getter (not a cached top-level final) so the admin accent follows the active
+// theme instead of freezing to whatever theme was loaded first.
+TabPalette get _adminPalette => AppTab.admin.palette;
 
 // Amber badge for top-4 slide picks.
 const _kTop4Color = Color(0xFFF59E0B);

--- a/lib/features/catalog/catalog_screen.dart
+++ b/lib/features/catalog/catalog_screen.dart
@@ -2138,6 +2138,9 @@ class _SubTabBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Themes with a gradient backdrop use a transparent page surface; forcing an
+    // alpha onto it would fade to pure black. Fall back to the theme bg instead.
+    final base = surfaceColor.a == 0 ? kBgColor : surfaceColor;
     return ClipRect(
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
@@ -2147,8 +2150,8 @@ class _SubTabBar extends StatelessWidget {
               begin: Alignment.topCenter,
               end: Alignment.bottomCenter,
               colors: [
-                surfaceColor.withValues(alpha: 0.0),
-                surfaceColor.withValues(alpha: 0.92),
+                base.withValues(alpha: 0.0),
+                base.withValues(alpha: 0.92),
               ],
               stops: const [0.0, 0.38],
             ),

--- a/lib/features/catalog/catalog_screen.dart
+++ b/lib/features/catalog/catalog_screen.dart
@@ -2565,7 +2565,7 @@ class _RequestDialogState extends ConsumerState<_RequestDialog> {
                             : null,
                     style: FilledButton.styleFrom(
                       backgroundColor: _palette.primary,
-                      foregroundColor: Colors.black,
+                      foregroundColor: onAccentColor(_palette.primary),
                       padding: const EdgeInsets.symmetric(
                           horizontal: 20, vertical: 12),
                       shape: RoundedRectangleBorder(

--- a/lib/features/catalog/catalog_screen.dart
+++ b/lib/features/catalog/catalog_screen.dart
@@ -505,16 +505,16 @@ class _CatalogScreenState extends ConsumerState<CatalogScreen>
                 builder: (ctx) => AlertDialog(
                   backgroundColor: kSurfaceColor,
                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  title: const Text('Already Downloaded',
+                  title: Text('Already Downloaded',
                       style: TextStyle(color: kTextPrimary, fontSize: 15, fontWeight: FontWeight.w600)),
-                  content: const Text(
+                  content: Text(
                     'This video is already in your downloads. Downloading again will overwrite the existing file.',
                     style: TextStyle(color: kTextSecondary, fontSize: 13),
                   ),
                   actions: [
                     TextButton(
                       onPressed: () => Navigator.pop(ctx),
-                      child: const Text('Cancel', style: TextStyle(color: kTextMuted)),
+                      child: Text('Cancel', style: TextStyle(color: kTextMuted)),
                     ),
                     TextButton(
                       onPressed: () {
@@ -1305,13 +1305,13 @@ class _DoneDownload extends StatelessWidget {
                   filename,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(fontSize: 12, color: kTextSecondary),
+                  style: TextStyle(fontSize: 12, color: kTextSecondary),
                 ),
                 Text(
                   folder,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(fontSize: 11, color: kTextMuted),
+                  style: TextStyle(fontSize: 11, color: kTextMuted),
                 ),
               ],
             ),
@@ -1356,7 +1356,7 @@ class _ErrorDownload extends StatelessWidget {
         const Icon(Icons.error_outline_rounded, size: 18, color: Colors.redAccent),
         const SizedBox(width: 8),
         Expanded(
-          child: Text(message, maxLines: 2, style: const TextStyle(fontSize: 12, color: kTextSecondary)),
+          child: Text(message, maxLines: 2, style: TextStyle(fontSize: 12, color: kTextSecondary)),
         ),
         const SizedBox(width: 12),
         TextButton(
@@ -1675,7 +1675,7 @@ class _DownloadRecordRow extends StatelessWidget {
               ),
             ),
             IconButton(
-              icon: const Icon(Icons.delete_outline_rounded, color: kTextMuted),
+              icon: Icon(Icons.delete_outline_rounded, color: kTextMuted),
               iconSize: iconSize,
               tooltip: 'Delete file',
               onPressed: () => showDialog(
@@ -1684,7 +1684,7 @@ class _DownloadRecordRow extends StatelessWidget {
                   backgroundColor: kSurfaceColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12)),
-                  title: const Text('Delete download?',
+                  title: Text('Delete download?',
                       style: TextStyle(
                           color: kTextPrimary,
                           fontSize: 15,
@@ -1693,13 +1693,13 @@ class _DownloadRecordRow extends StatelessWidget {
                     decodedVideoPath != null
                         ? 'This will permanently delete the decoded video folder and remove this entry from your download history.'
                         : 'This will permanently delete the file from disk and remove it from your download history.',
-                    style: const TextStyle(
+                    style: TextStyle(
                         color: kTextSecondary, fontSize: 13),
                   ),
                   actions: [
                     TextButton(
                       onPressed: () => Navigator.pop(ctx),
-                      child: const Text('Cancel',
+                      child: Text('Cancel',
                           style: TextStyle(color: kTextMuted)),
                     ),
                     TextButton(
@@ -2311,13 +2311,13 @@ class _SeriesEmptyState extends StatelessWidget {
                   duration: 1800.ms,
                   curve: Curves.easeInOut),
           const SizedBox(height: 16),
-          const Text(
+          Text(
             'No series yet',
             style: TextStyle(
                 fontSize: 16, fontWeight: FontWeight.w600, color: kTextPrimary),
           ),
           const SizedBox(height: 8),
-          const Text(
+          Text(
             'Add a "Series" tab to your spreadsheet to get started.',
             style: TextStyle(fontSize: 13, color: kTextMuted),
           ),
@@ -2693,7 +2693,7 @@ class _PreviewCard extends StatelessWidget {
               children: [
                 Text(
                   state.title,
-                  style: const TextStyle(
+                  style: TextStyle(
                       fontSize: 14,
                       fontWeight: FontWeight.w600,
                       color: kTextPrimary),
@@ -2723,7 +2723,7 @@ class _PreviewCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(6),
           border: Border.all(color: kBorderColor),
         ),
-        child: const Icon(Icons.movie_rounded, size: 24, color: kTextMuted),
+        child: Icon(Icons.movie_rounded, size: 24, color: kTextMuted),
       );
 }
 
@@ -2782,7 +2782,7 @@ class _Chip extends StatelessWidget {
         border: Border.all(color: kBorderColor),
       ),
       child: Text(label,
-          style: const TextStyle(fontSize: 10, color: kTextSecondary)),
+          style: TextStyle(fontSize: 10, color: kTextSecondary)),
     );
   }
 }

--- a/lib/features/catalog/screens/series_detail_screen.dart
+++ b/lib/features/catalog/screens/series_detail_screen.dart
@@ -130,7 +130,7 @@ class _TopBar extends StatelessWidget {
               title,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 15,
                 fontWeight: FontWeight.w700,
                 color: kTextPrimary,
@@ -210,7 +210,7 @@ class _LeftPanel extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child:
-                    const Icon(Icons.live_tv_rounded, color: kTextMuted, size: 48),
+                    Icon(Icons.live_tv_rounded, color: kTextMuted, size: 48),
               ),
             ),
 
@@ -263,7 +263,7 @@ class _LeftPanel extends StatelessWidget {
             const SizedBox(height: 10),
             Text(
               e.plot,
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 12,
                 color: kTextSecondary,
                 height: 1.65,
@@ -305,7 +305,7 @@ class _RightPanel extends StatelessWidget {
           children: [
             Icon(Icons.video_library_outlined, size: 48, color: kTextMuted),
             const SizedBox(height: 16),
-            const Text(
+            Text(
               'No episodes yet',
               style: TextStyle(
                   fontSize: 16,
@@ -313,7 +313,7 @@ class _RightPanel extends StatelessWidget {
                   color: kTextPrimary),
             ),
             const SizedBox(height: 8),
-            const Text(
+            Text(
               'Add rows to the Episodes sheet to get started.',
               style: TextStyle(fontSize: 13, color: kTextMuted),
             ),
@@ -385,7 +385,7 @@ class _SeasonPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const palette = kSeriesPalette;
+    final palette = kSeriesPalette;
     final color = active ? palette.primary : kTextMuted;
     return Padding(
       padding: const EdgeInsets.only(right: 8),
@@ -456,7 +456,7 @@ class _EpisodeDetailRowState extends ConsumerState<_EpisodeDetailRow> {
 
   @override
   Widget build(BuildContext context) {
-    const palette = kSeriesPalette;
+    final palette = kSeriesPalette;
     final ep = widget.episode;
     final dlState = ref.watch(downloadProvider);
     final activeDl = dlState is DownloadActive && dlState.title == ep.displayTitle
@@ -510,7 +510,7 @@ class _EpisodeDetailRowState extends ConsumerState<_EpisodeDetailRow> {
                       )
                     : Container(
                         color: kSurface2Color,
-                        child: const Icon(Icons.movie_rounded,
+                        child: Icon(Icons.movie_rounded,
                             size: 22, color: kTextMuted),
                       ),
               ),
@@ -546,7 +546,7 @@ class _EpisodeDetailRowState extends ConsumerState<_EpisodeDetailRow> {
                                     ep.displayTitle,
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
-                                    style: const TextStyle(
+                                    style: TextStyle(
                                       fontSize: 13,
                                       fontWeight: FontWeight.w600,
                                       color: kTextPrimary,
@@ -580,7 +580,7 @@ class _EpisodeDetailRowState extends ConsumerState<_EpisodeDetailRow> {
                                 ep.plot,
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
+                                style: TextStyle(
                                   fontSize: 11,
                                   color: kTextSecondary,
                                   height: 1.5,
@@ -802,7 +802,7 @@ class _MetaChip extends StatelessWidget {
       ),
       child: Text(
         label,
-        style: const TextStyle(fontSize: 10, color: kTextMuted),
+        style: TextStyle(fontSize: 10, color: kTextMuted),
       ),
     );
   }
@@ -851,7 +851,7 @@ class _Pill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const c = kTextSecondary;
+    final c = kTextSecondary;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
@@ -878,7 +878,7 @@ class _Tag extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const palette = kSeriesPalette;
+    final palette = kSeriesPalette;
     final color = muted ? kTextMuted : palette.primary;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),

--- a/lib/features/catalog/widgets/catalog_card.dart
+++ b/lib/features/catalog/widgets/catalog_card.dart
@@ -100,7 +100,7 @@ class _CatalogCardState extends State<CatalogCard> {
                       widget.entry.title,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w600,
                         color: kTextPrimary,
@@ -111,7 +111,7 @@ class _CatalogCardState extends State<CatalogCard> {
                       Text(
                         _fmt(widget.entry.date!),
                         style:
-                            const TextStyle(fontSize: 11, color: kTextMuted),
+                            TextStyle(fontSize: 11, color: kTextMuted),
                       ),
                     ],
                     if (widget.entry.genres.isNotEmpty) ...[
@@ -326,7 +326,7 @@ class CatalogCardExpandedState extends ConsumerState<CatalogCardExpanded> {
                       Expanded(
                         child: Text(
                           entry.title,
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w700,
                             color: kTextPrimary,
@@ -402,7 +402,7 @@ class CatalogCardExpandedState extends ConsumerState<CatalogCardExpanded> {
                               entry.stars.join(' · '),
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(
+                              style: TextStyle(
                                   fontSize: 11, color: kTextMuted),
                             ),
                           ],
@@ -410,7 +410,7 @@ class CatalogCardExpandedState extends ConsumerState<CatalogCardExpanded> {
                             const SizedBox(height: 12),
                             Text(
                               entry.plot,
-                              style: const TextStyle(
+                              style: TextStyle(
                                 fontSize: 12,
                                 color: kTextSecondary,
                                 height: 1.55,
@@ -878,7 +878,7 @@ class _ThumbnailState extends State<_Thumbnail> {
 
   Widget _placeholder() => Container(
         color: kSurface2Color,
-        child: const Icon(Icons.movie_rounded, color: kTextMuted, size: 32),
+        child: Icon(Icons.movie_rounded, color: kTextMuted, size: 32),
       );
 }
 

--- a/lib/features/catalog/widgets/catalog_card.dart
+++ b/lib/features/catalog/widgets/catalog_card.dart
@@ -512,7 +512,7 @@ class _EntryActionButton extends ConsumerWidget {
 
     final style = FilledButton.styleFrom(
       backgroundColor: palette.primary,
-      foregroundColor: Colors.black,
+      foregroundColor: onAccentColor(palette.primary),
       padding: const EdgeInsets.symmetric(vertical: 12),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
     );

--- a/lib/features/catalog/widgets/catalog_detail_panel.dart
+++ b/lib/features/catalog/widgets/catalog_detail_panel.dart
@@ -98,7 +98,7 @@ class CatalogDetailPanel extends StatelessWidget {
                       label: const Text('View & Download'),
                       style: FilledButton.styleFrom(
                         backgroundColor: palette.primary,
-                        foregroundColor: Colors.black,
+                        foregroundColor: onAccentColor(palette.primary),
                         padding: const EdgeInsets.symmetric(vertical: 12),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(8),

--- a/lib/features/catalog/widgets/series_card.dart
+++ b/lib/features/catalog/widgets/series_card.dart
@@ -33,7 +33,7 @@ class _SeriesCardState extends State<SeriesCard> {
 
   @override
   Widget build(BuildContext context) {
-    const palette = kSeriesPalette;
+    final palette = kSeriesPalette;
     final e = widget.entry;
     final seasonCount  = e.seasons.length;
     final episodeCount = e.totalEpisodes;
@@ -87,7 +87,7 @@ class _SeriesCardState extends State<SeriesCard> {
                       e.title,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w600,
                         color: kTextPrimary,
@@ -96,7 +96,7 @@ class _SeriesCardState extends State<SeriesCard> {
                     const SizedBox(height: 3),
                     Text(
                       _countLabel(seasonCount, episodeCount),
-                      style: const TextStyle(fontSize: 11, color: kTextMuted),
+                      style: TextStyle(fontSize: 11, color: kTextMuted),
                     ),
                     if (e.genres.isNotEmpty) ...[
                       const SizedBox(height: 6),
@@ -170,7 +170,7 @@ class SeriesCardExpandedState extends State<SeriesCardExpanded> {
 
   @override
   Widget build(BuildContext context) {
-    const palette = kSeriesPalette;
+    final palette = kSeriesPalette;
     final e = widget.entry;
 
     return Container(
@@ -219,7 +219,7 @@ class SeriesCardExpandedState extends State<SeriesCardExpanded> {
                       Expanded(
                         child: Text(
                           e.title,
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w700,
                             color: kTextPrimary,
@@ -300,7 +300,7 @@ class SeriesCardExpandedState extends State<SeriesCardExpanded> {
                             const SizedBox(height: 12),
                             Text(
                               e.plot,
-                              style: const TextStyle(
+                              style: TextStyle(
                                 fontSize: 12,
                                 color: kTextSecondary,
                                 height: 1.55,
@@ -375,7 +375,7 @@ class _SeasonSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const palette = kSeriesPalette;
+    final palette = kSeriesPalette;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -405,7 +405,7 @@ class _SeasonSection extends StatelessWidget {
                 const SizedBox(width: 8),
                 Text(
                   '${season.episodes.length} episodes',
-                  style: const TextStyle(fontSize: 11, color: kTextMuted),
+                  style: TextStyle(fontSize: 11, color: kTextMuted),
                 ),
               ],
             ),
@@ -452,7 +452,7 @@ class _EpisodeRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const palette = kSeriesPalette;
+    final palette = kSeriesPalette;
     final ep = episode;
 
     return Padding(
@@ -468,7 +468,7 @@ class _EpisodeRow extends StatelessWidget {
               children: [
                 Text(
                   'E${ep.episodeNumber.toString().padLeft(2, '0')}',
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 11,
                     fontWeight: FontWeight.w600,
                     color: kTextMuted,
@@ -496,25 +496,25 @@ class _EpisodeRow extends StatelessWidget {
                   ep.displayTitle,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(fontSize: 12, color: kTextPrimary),
+                  style: TextStyle(fontSize: 12, color: kTextPrimary),
                 ),
                 if (ep.plot.isNotEmpty)
                   Text(
                     ep.plot,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
+                    style: TextStyle(
                         fontSize: 10, color: kTextMuted, height: 1.4),
                   )
                 else if (ep.airDate != null)
                   Text(
                     _fmtDate(ep.airDate!),
-                    style: const TextStyle(fontSize: 10, color: kTextMuted),
+                    style: TextStyle(fontSize: 10, color: kTextMuted),
                   ),
                 if (ep.plot.isNotEmpty && ep.airDate != null)
                   Text(
                     _fmtDate(ep.airDate!),
-                    style: const TextStyle(fontSize: 10, color: kTextMuted),
+                    style: TextStyle(fontSize: 10, color: kTextMuted),
                   ),
               ],
             ),
@@ -672,7 +672,7 @@ class _SeriesThumbnail extends StatelessWidget {
 
   Widget _placeholder() => Container(
         color: kSurface2Color,
-        child: const Icon(Icons.live_tv_rounded,
+        child: Icon(Icons.live_tv_rounded,
             color: kTextMuted, size: 32),
       );
 }
@@ -748,7 +748,7 @@ class _Tag extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const palette = kSeriesPalette;
+    final palette = kSeriesPalette;
     final color = muted ? kTextMuted : palette.primary;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),

--- a/lib/features/decode/decode_screen.dart
+++ b/lib/features/decode/decode_screen.dart
@@ -419,7 +419,7 @@ class _DecodeDoneBanner extends StatelessWidget {
                     style: TextStyle(
                         fontWeight: FontWeight.w600, color: accentColor)),
                 Text(outputDir,
-                    style: const TextStyle(
+                    style: TextStyle(
                         fontSize: 12, color: kTextSecondary),
                     overflow: TextOverflow.ellipsis),
               ],

--- a/lib/features/decode/widgets/extracted_files_list.dart
+++ b/lib/features/decode/widgets/extracted_files_list.dart
@@ -27,7 +27,7 @@ class ExtractedFilesList extends StatelessWidget {
       children: [
         Text(
           'Extracted files (${files.length})',
-          style: const TextStyle(
+          style: TextStyle(
               fontSize: 13,
               fontWeight: FontWeight.w600,
               color: kTextSecondary),
@@ -111,12 +111,12 @@ class _FileRow extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(name,
-                    style: const TextStyle(fontSize: 13, color: kTextPrimary),
+                    style: TextStyle(fontSize: 13, color: kTextPrimary),
                     overflow: TextOverflow.ellipsis),
                 if (size.isNotEmpty)
                   Text(size,
                       style:
-                          const TextStyle(fontSize: 11, color: kTextMuted)),
+                          TextStyle(fontSize: 11, color: kTextMuted)),
               ],
             ),
           ),

--- a/lib/features/encode/encode_screen.dart
+++ b/lib/features/encode/encode_screen.dart
@@ -470,7 +470,7 @@ class _Field extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
-      style: const TextStyle(fontSize: 14, color: kTextPrimary),
+      style: TextStyle(fontSize: 14, color: kTextPrimary),
       decoration: InputDecoration(
         labelText: label,
         hintText: hint,
@@ -595,7 +595,7 @@ class _DoneBanner extends StatelessWidget {
                     style: TextStyle(
                         fontWeight: FontWeight.w600, color: accentColor)),
                 Text(outputPath,
-                    style: const TextStyle(
+                    style: TextStyle(
                         fontSize: 12, color: kTextSecondary),
                     overflow: TextOverflow.ellipsis),
               ],

--- a/lib/features/encode/widgets/drop_zone.dart
+++ b/lib/features/encode/widgets/drop_zone.dart
@@ -167,10 +167,10 @@ class _FileDropZoneState extends State<FileDropZone> {
                       hasFile
                           ? (sizeLabel.isNotEmpty ? sizeLabel : 'Click to change')
                           : widget.hint,
-                      style: const TextStyle(fontSize: 12, color: kTextMuted),
+                      style: TextStyle(fontSize: 12, color: kTextMuted),
                     ),
                     if (hasFile && sizeLabel.isNotEmpty)
-                      const Text(
+                      Text(
                         'Click to change',
                         style: TextStyle(fontSize: 11, color: kTextMuted),
                       ),
@@ -198,7 +198,7 @@ class _FileDropZoneState extends State<FileDropZone> {
                   color: kSurface2Color,
                   border: Border.all(color: kBorderColor),
                 ),
-                child: const Icon(Icons.close_rounded,
+                child: Icon(Icons.close_rounded,
                     size: 13, color: kTextMuted),
               ),
             ),

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -622,7 +622,7 @@ class _CcButton extends StatelessWidget {
                 color: activeSubtitle == null ? accent : kTextMuted,
               ),
               const SizedBox(width: 8),
-              const Text('None', style: TextStyle(fontSize: 13, color: kTextPrimary)),
+              Text('None', style: TextStyle(fontSize: 13, color: kTextPrimary)),
             ],
           ),
         ),
@@ -639,7 +639,7 @@ class _CcButton extends StatelessWidget {
                 const SizedBox(width: 8),
                 Text(
                   p.basename(sub),
-                  style: const TextStyle(fontSize: 13, color: kTextPrimary),
+                  style: TextStyle(fontSize: 13, color: kTextPrimary),
                 ),
               ],
             ),
@@ -836,7 +836,7 @@ class _PlayerPlaceholderState extends State<_PlayerPlaceholder> {
                     ),
                   ),
                   const SizedBox(height: 4),
-                  const Text(
+                  Text(
                     'MP4 · MKV · MOV · AVI · WebM',
                     style: TextStyle(fontSize: 12, color: kTextMuted),
                   ),
@@ -892,14 +892,14 @@ class _FilenameBar extends StatelessWidget {
           Expanded(
             child: Text(
               p.basename(path),
-              style: const TextStyle(fontSize: 13, color: kTextPrimary),
+              style: TextStyle(fontSize: 13, color: kTextPrimary),
               overflow: TextOverflow.ellipsis,
             ),
           ),
           const SizedBox(width: 12),
           Text(
             p.dirname(path),
-            style: const TextStyle(fontSize: 11, color: kTextMuted),
+            style: TextStyle(fontSize: 11, color: kTextMuted),
             overflow: TextOverflow.ellipsis,
           ),
         ],
@@ -1178,7 +1178,7 @@ class _SyncplaySection extends StatelessWidget {
                     Icon(Icons.settings_ethernet_rounded,
                         size: 15, color: kTextMuted),
                     const SizedBox(width: 8),
-                    const Text('Port',
+                    Text('Port',
                         style:
                             TextStyle(fontSize: 13, color: kTextSecondary)),
                     const SizedBox(width: 12),
@@ -1298,16 +1298,16 @@ class _SyncplayField extends StatelessWidget {
           child: TextField(
             controller: controller,
             onChanged: onChanged,
-            style: const TextStyle(fontSize: 13, color: kTextPrimary),
+            style: TextStyle(fontSize: 13, color: kTextPrimary),
             decoration: InputDecoration(
               hintText: hint,
-              hintStyle: const TextStyle(fontSize: 13, color: kTextMuted),
+              hintStyle: TextStyle(fontSize: 13, color: kTextMuted),
               isDense: true,
               contentPadding:
                   const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(8),
-                borderSide: const BorderSide(color: kBorderColor),
+                borderSide: BorderSide(color: kBorderColor),
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(8),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -10,6 +10,7 @@ import '../../core/models/settings_model.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
+import '../../core/theme/theme_spec.dart';
 import '../catalog/catalog_notifier.dart';
 import '../catalog/imdb_service.dart';
 import '../catalog/widgets/catalog_card.dart';
@@ -35,8 +36,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   @override
   void initState() {
     super.initState();
-    _passwordCtrl =
-        TextEditingController(text: ref.read(settingsProvider).password);
+    _passwordCtrl = TextEditingController(
+      text: ref.read(settingsProvider).password,
+    );
     PackageInfo.fromPlatform().then((info) {
       if (mounted) setState(() => _appVersion = info.version);
     });
@@ -58,30 +60,54 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         title: Text(
           "What's new in v${info.version}",
-          style: const TextStyle(color: kTextPrimary, fontSize: 16),
+          style: TextStyle(color: kTextPrimary, fontSize: 16),
         ),
         content: SizedBox(
           width: 480,
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxHeight: 300),
             child: Markdown(
-              data: info.releaseNotes.isNotEmpty ? info.releaseNotes : '_No release notes available._',
+              data: info.releaseNotes.isNotEmpty
+                  ? info.releaseNotes
+                  : '_No release notes available._',
               shrinkWrap: true,
               padding: const EdgeInsets.only(top: 4),
               styleSheet: MarkdownStyleSheet(
-                p: const TextStyle(fontSize: 12, color: kTextSecondary, height: 1.6),
-                h1: TextStyle(fontSize: 15, fontWeight: FontWeight.w700, color: accent),
-                h2: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: accent),
-                h3: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: kTextPrimary),
-                strong: const TextStyle(fontWeight: FontWeight.w600, color: kTextPrimary),
-                em: const TextStyle(fontStyle: FontStyle.italic, color: kTextSecondary),
-                code: const TextStyle(fontSize: 11, color: kTextPrimary, fontFamily: 'monospace'),
+                p: TextStyle(fontSize: 12, color: kTextSecondary, height: 1.6),
+                h1: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w700,
+                  color: accent,
+                ),
+                h2: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: accent,
+                ),
+                h3: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: kTextPrimary,
+                ),
+                strong: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: kTextPrimary,
+                ),
+                em: TextStyle(
+                  fontStyle: FontStyle.italic,
+                  color: kTextSecondary,
+                ),
+                code: TextStyle(
+                  fontSize: 11,
+                  color: kTextPrimary,
+                  fontFamily: 'monospace',
+                ),
                 codeblockDecoration: BoxDecoration(
                   color: kSurface2Color,
                   borderRadius: BorderRadius.circular(6),
                 ),
-                listBullet: const TextStyle(fontSize: 12, color: kTextSecondary),
-                horizontalRuleDecoration: const BoxDecoration(
+                listBullet: TextStyle(fontSize: 12, color: kTextSecondary),
+                horizontalRuleDecoration: BoxDecoration(
                   border: Border(top: BorderSide(color: kBorderColor)),
                 ),
               ),
@@ -105,14 +131,18 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
     switch (updateState.status) {
       case UpdateStatus.checking:
-        return Text('$version  ·  Checking for updates…',
-            style: const TextStyle(fontSize: 12, color: kTextSecondary));
+        return Text(
+          '$version  ·  Checking for updates…',
+          style: TextStyle(fontSize: 12, color: kTextSecondary),
+        );
       case UpdateStatus.upToDate:
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text('$version  ·  Already up to date  ·',
-                style: const TextStyle(fontSize: 12, color: kTextSecondary)),
+            Text(
+              '$version  ·  Already up to date  ·',
+              style: TextStyle(fontSize: 12, color: kTextSecondary),
+            ),
             if (info?.releaseNotes.isNotEmpty == true) ...[
               const SizedBox(width: 8),
               GestureDetector(
@@ -134,8 +164,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text('Update available  ·',
-                style: TextStyle(fontSize: 12, color: accent)),
+            Text(
+              'Update available  ·',
+              style: TextStyle(fontSize: 12, color: accent),
+            ),
             const SizedBox(width: 8),
             GestureDetector(
               onTap: info?.releaseNotes.isNotEmpty == true
@@ -154,17 +186,25 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ],
         );
       case UpdateStatus.downloading:
-        return Text('$version  ·  Downloading update…',
-            style: const TextStyle(fontSize: 12, color: kTextSecondary));
+        return Text(
+          '$version  ·  Downloading update…',
+          style: TextStyle(fontSize: 12, color: kTextSecondary),
+        );
       case UpdateStatus.readyToInstall:
-        return Text('$version  ·  Ready to install',
-            style: TextStyle(fontSize: 12, color: accent));
+        return Text(
+          '$version  ·  Ready to install',
+          style: TextStyle(fontSize: 12, color: accent),
+        );
       case UpdateStatus.error:
-        return Text('$version  ·  ${updateState.errorMessage ?? 'Check failed'}',
-            style: const TextStyle(fontSize: 12, color: kDanger));
+        return Text(
+          '$version  ·  ${updateState.errorMessage ?? 'Check failed'}',
+          style: const TextStyle(fontSize: 12, color: kDanger),
+        );
       case UpdateStatus.idle:
-        return Text('$version  ·  Currently installed',
-            style: const TextStyle(fontSize: 12, color: kTextSecondary));
+        return Text(
+          '$version  ·  Currently installed',
+          style: TextStyle(fontSize: 12, color: kTextSecondary),
+        );
     }
   }
 
@@ -262,17 +302,18 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       builder: (ctx) => AlertDialog(
         backgroundColor: kSurfaceColor,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: const Text('Clear all caches?',
-            style: TextStyle(color: kTextPrimary, fontSize: 16)),
-        content: const Text(
+        title: Text(
+          'Clear all caches?',
+          style: TextStyle(color: kTextPrimary, fontSize: 16),
+        ),
+        content: Text(
           'IMDB metadata, image URLs, catalog CSV, and cached poster images will be deleted. App settings are not affected.',
           style: TextStyle(color: kTextSecondary, fontSize: 13),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: Text('Cancel',
-                style: TextStyle(color: _palette.primary)),
+            child: Text('Cancel', style: TextStyle(color: _palette.primary)),
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
@@ -298,13 +339,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   }
 
   static (IconData, String) _tabInfo(AppTab tab) => switch (tab) {
-        AppTab.encode   => (Icons.upload_rounded,        'Encode'),
-        AppTab.decode   => (Icons.download_rounded,      'Decode'),
-        AppTab.player   => (Icons.play_circle_rounded,   'Player'),
-        AppTab.catalog  => (Icons.photo_library_rounded, 'Catalog'),
-        AppTab.settings => (Icons.settings_rounded,      'Settings'),
-        AppTab.admin    => (Icons.admin_panel_settings_rounded, 'Admin'),
-      };
+    AppTab.encode => (Icons.upload_rounded, 'Encode'),
+    AppTab.decode => (Icons.download_rounded, 'Decode'),
+    AppTab.player => (Icons.play_circle_rounded, 'Player'),
+    AppTab.catalog => (Icons.photo_library_rounded, 'Catalog'),
+    AppTab.settings => (Icons.settings_rounded, 'Settings'),
+    AppTab.admin => (Icons.admin_panel_settings_rounded, 'Admin'),
+  };
 
   static List<int> _effectiveOrder(AppSettings settings, String? sheetUrl) {
     if (settings.tabOrder != null) return settings.tabOrder!;
@@ -326,7 +367,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     ];
   }
 
-  Widget _buildLayoutSection(AppSettings settings, Color accent, String? sheetUrl) {
+  Widget _buildLayoutSection(
+    AppSettings settings,
+    Color accent,
+    String? sheetUrl,
+  ) {
     final order = _effectiveOrder(settings, sheetUrl);
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
@@ -341,14 +386,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Text('Page Order',
-                        style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                            color: kTextPrimary)),
+                    Text(
+                      'Page Order',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: kTextPrimary,
+                      ),
+                    ),
                     const SizedBox(height: 2),
-                    const Text('Drag to reorder sidebar pages.',
-                        style: TextStyle(fontSize: 12, color: kTextSecondary)),
+                    Text(
+                      'Drag to reorder sidebar pages.',
+                      style: TextStyle(fontSize: 12, color: kTextSecondary),
+                    ),
                   ],
                 ),
               ),
@@ -356,7 +406,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 _ActionButton(
                   label: 'Reset',
                   accent: accent,
-                  onTap: () => ref.read(settingsProvider.notifier).resetTabOrder(),
+                  onTap: () =>
+                      ref.read(settingsProvider.notifier).resetTabOrder(),
                 ),
             ],
           ),
@@ -387,26 +438,34 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     key: ValueKey(order[index]),
                     height: 44,
                     decoration: index < order.length - 1
-                        ? const BoxDecoration(
+                        ? BoxDecoration(
                             border: Border(
-                                bottom: BorderSide(color: kBorderColor)))
+                              bottom: BorderSide(color: kBorderColor),
+                            ),
+                          )
                         : null,
                     child: Row(
                       children: [
                         ReorderableDragStartListener(
                           index: index,
-                          child: const Padding(
+                          child: Padding(
                             padding: EdgeInsets.symmetric(
-                                horizontal: 12, vertical: 12),
-                            child: Icon(Icons.drag_handle_rounded,
-                                color: kTextMuted, size: 18),
+                              horizontal: 12,
+                              vertical: 12,
+                            ),
+                            child: Icon(
+                              Icons.drag_handle_rounded,
+                              color: kTextMuted,
+                              size: 18,
+                            ),
                           ),
                         ),
                         Icon(icon, color: accent, size: 16),
                         const SizedBox(width: 10),
-                        Text(label,
-                            style: const TextStyle(
-                                fontSize: 13, color: kTextPrimary)),
+                        Text(
+                          label,
+                          style: TextStyle(fontSize: 13, color: kTextPrimary),
+                        ),
                       ],
                     ),
                   );
@@ -425,17 +484,18 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       builder: (ctx) => AlertDialog(
         backgroundColor: kSurfaceColor,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: const Text('Reset all settings?',
-            style: TextStyle(color: kTextPrimary, fontSize: 16)),
-        content: const Text(
+        title: Text(
+          'Reset all settings?',
+          style: TextStyle(color: kTextPrimary, fontSize: 16),
+        ),
+        content: Text(
           'Password, output directories, encode options and Syncplay config will all be cleared.',
           style: TextStyle(color: kTextSecondary, fontSize: 13),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: Text('Cancel',
-                style: TextStyle(color: _palette.primary)),
+            child: Text('Cancel', style: TextStyle(color: _palette.primary)),
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
@@ -471,6 +531,39 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ),
           const SizedBox(height: 32),
 
+          // ── Appearance ───────────────────────────────────────────────────
+          _SettingsGroup(
+            label: 'Appearance',
+            accent: accent,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(2, 2, 2, 6),
+                child: Text(
+                  'Theme — re-skins the whole app instantly',
+                  style: TextStyle(fontSize: 12, color: kTextSecondary),
+                ),
+              ),
+              Wrap(
+                spacing: 10,
+                runSpacing: 10,
+                children: themeSpecs.values
+                    .map(
+                      (spec) => _ThemeSwatchCard(
+                        spec: spec,
+                        selected: spec.id.id == settings.themeId,
+                        accent: accent,
+                        onTap: () => ref
+                            .read(settingsProvider.notifier)
+                            .setThemeId(spec.id),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+          ).animate().fadeIn(duration: 300.ms, delay: 20.ms),
+
+          const SizedBox(height: 20),
+
           // ── Updates ──────────────────────────────────────────────────────
           _SettingsGroup(
             label: 'Updates',
@@ -505,21 +598,20 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   child: TextField(
                     controller: _passwordCtrl,
                     obscureText: !_showPassword,
-                    style:
-                        const TextStyle(fontSize: 13, color: kTextPrimary),
+                    style: TextStyle(fontSize: 13, color: kTextPrimary),
                     onChanged: (v) =>
                         ref.read(settingsProvider.notifier).setPassword(v),
                     decoration: InputDecoration(
                       hintText: 'No password',
-                      hintStyle: const TextStyle(
-                          fontSize: 13, color: kTextMuted),
+                      hintStyle: TextStyle(fontSize: 13, color: kTextMuted),
                       isDense: true,
                       contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 10),
+                        horizontal: 12,
+                        vertical: 10,
+                      ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(10),
-                        borderSide:
-                            const BorderSide(color: kBorderColor),
+                        borderSide: BorderSide(color: kBorderColor),
                       ),
                       focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(10),
@@ -576,14 +668,15 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 onClear: settings.encodeOutputDirectory.isEmpty
                     ? null
                     : () => ref
-                        .read(settingsProvider.notifier)
-                        .setEncodeOutputDirectory(''),
+                          .read(settingsProvider.notifier)
+                          .setEncodeOutputDirectory(''),
                 placeholder: 'Default: Videos\\mStorage\\Encoded',
               ),
               _DirSettingRow(
                 icon: Icons.download_rounded,
                 title: 'Decode Output',
-                subtitle: 'Where extracted files from decoded videos are saved.',
+                subtitle:
+                    'Where extracted files from decoded videos are saved.',
                 accent: accent,
                 dir: settings.decodeOutputDirectory,
                 onPick: () async {
@@ -597,8 +690,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 onClear: settings.decodeOutputDirectory.isEmpty
                     ? null
                     : () => ref
-                        .read(settingsProvider.notifier)
-                        .setDecodeOutputDirectory(''),
+                          .read(settingsProvider.notifier)
+                          .setDecodeOutputDirectory(''),
                 placeholder: 'Default: Videos\\mStorage\\Decoded',
               ),
               _DirSettingRow(
@@ -618,8 +711,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 onClear: settings.catalogDownloadDirectory.isEmpty
                     ? null
                     : () => ref
-                        .read(settingsProvider.notifier)
-                        .setCatalogDownloadDirectory(''),
+                          .read(settingsProvider.notifier)
+                          .setCatalogDownloadDirectory(''),
                 placeholder: 'Default: Videos\\mStorage\\Downloaded',
               ),
             ],
@@ -731,7 +824,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ? const SizedBox.shrink()
                 : Container(
                     margin: const EdgeInsets.only(top: 12),
-                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 10,
+                    ),
                     decoration: BoxDecoration(
                       color: accent.withValues(alpha: 0.08),
                       borderRadius: BorderRadius.circular(8),
@@ -739,7 +835,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     ),
                     child: Row(
                       children: [
-                        Icon(Icons.check_circle_outline_rounded, size: 15, color: accent),
+                        Icon(
+                          Icons.check_circle_outline_rounded,
+                          size: 15,
+                          color: accent,
+                        ),
                         const SizedBox(width: 10),
                         Expanded(
                           child: Text(
@@ -752,7 +852,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                             _cacheMessageTimer?.cancel();
                             setState(() => _cacheMessage = null);
                           },
-                          child: Icon(Icons.close_rounded, size: 14, color: accent),
+                          child: Icon(
+                            Icons.close_rounded,
+                            size: 14,
+                            color: accent,
+                          ),
                         ),
                       ],
                     ),
@@ -772,10 +876,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 subtitle:
                     'Clear password, output directories, and Syncplay config.',
                 accent: kDanger,
-                control: _DangerButton(
-                  label: 'Reset',
-                  onTap: _confirmReset,
-                ),
+                control: _DangerButton(label: 'Reset', onTap: _confirmReset),
               ),
             ],
           ).animate().fadeIn(duration: 300.ms, delay: 260.ms),
@@ -790,13 +891,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 const SizedBox(height: 16),
                 Text(
                   'mStorage  v${_appVersion ?? '...'}',
-                  style: const TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      color: kTextMuted),
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: kTextMuted,
+                  ),
                 ),
                 const SizedBox(height: 2),
-                const Text(
+                Text(
                   'Seshu Tarapatla  ·  Flutter · Windows',
                   style: TextStyle(fontSize: 11, color: kTextMuted),
                 ),
@@ -907,16 +1009,20 @@ class _SettingRowState extends State<_SettingRow> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(widget.title,
-                        style: const TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                            color: kTextPrimary)),
+                    Text(
+                      widget.title,
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: kTextPrimary,
+                      ),
+                    ),
                     const SizedBox(height: 2),
                     widget.subtitleWidget ??
-                        Text(widget.subtitle,
-                            style: const TextStyle(
-                                fontSize: 12, color: kTextSecondary)),
+                        Text(
+                          widget.subtitle,
+                          style: TextStyle(fontSize: 12, color: kTextSecondary),
+                        ),
                   ],
                 ),
               ),
@@ -968,15 +1074,19 @@ class _DirSettingRow extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(title,
-                        style: const TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                            color: kTextPrimary)),
+                    Text(
+                      title,
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: kTextPrimary,
+                      ),
+                    ),
                     const SizedBox(height: 2),
-                    Text(subtitle,
-                        style: const TextStyle(
-                            fontSize: 12, color: kTextSecondary)),
+                    Text(
+                      subtitle,
+                      style: TextStyle(fontSize: 12, color: kTextSecondary),
+                    ),
                   ],
                 ),
               ),
@@ -1063,8 +1173,7 @@ class _DangerButtonState extends State<_DangerButton> {
         onTap: widget.onTap,
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 150),
-          padding:
-              const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           decoration: BoxDecoration(
             color: _hovered
                 ? kDanger.withValues(alpha: 0.15)
@@ -1139,6 +1248,124 @@ class _ActionButtonState extends State<_ActionButton> {
               fontWeight: FontWeight.w600,
               color: c,
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Self-previewing theme card. The mini preview uses the candidate theme's own
+// colours (spec.*) while the card chrome uses the active theme (k* getters).
+
+class _ThemeSwatchCard extends StatelessWidget {
+  final ThemeSpec spec;
+  final bool selected;
+  final Color accent;
+  final VoidCallback onTap;
+
+  const _ThemeSwatchCard({
+    required this.spec,
+    required this.selected,
+    required this.accent,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: 172,
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: kSurface2Color,
+            borderRadius: BorderRadius.circular(kRadius + 2),
+            border: Border.all(
+              color: selected ? accent : kBorderColor,
+              width: selected ? 2 : 1,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Mini app preview in the candidate theme's palette.
+              Container(
+                height: 48,
+                decoration: BoxDecoration(
+                  color: spec.bg,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: spec.border),
+                ),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 22,
+                      margin: const EdgeInsets.all(6),
+                      decoration: BoxDecoration(
+                        color: spec.surface,
+                        borderRadius: BorderRadius.circular(4),
+                        border: Border.all(color: spec.border),
+                      ),
+                    ),
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            height: 6,
+                            width: 64,
+                            decoration: BoxDecoration(
+                              color: spec.textPrimary.withValues(alpha: 0.75),
+                              borderRadius: BorderRadius.circular(3),
+                            ),
+                          ),
+                          const SizedBox(height: 5),
+                          Container(
+                            height: 6,
+                            width: 38,
+                            decoration: BoxDecoration(
+                              color: spec.brandAccent,
+                              borderRadius: BorderRadius.circular(3),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      spec.name,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: kTextPrimary,
+                      ),
+                    ),
+                  ),
+                  if (selected)
+                    Icon(Icons.check_circle_rounded, size: 16, color: accent),
+                ],
+              ),
+              const SizedBox(height: 2),
+              Text(
+                spec.tagline,
+                style: TextStyle(fontSize: 10.5, color: kTextSecondary),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/shell/app_shell.dart
+++ b/lib/features/shell/app_shell.dart
@@ -9,6 +9,7 @@ import '../../core/services/gh_auth_service.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
+import '../../core/theme/theme_spec.dart';
 import '../updater/update_model.dart';
 import '../updater/update_notifier.dart';
 import '../admin/admin_screen.dart';
@@ -27,13 +28,17 @@ import '../settings/settings_screen.dart';
 final activeTabProvider = StateProvider<AppTab>((ref) {
   final settings = ref.read(settingsProvider);
   if (settings.tabOrder != null && settings.tabOrder!.isNotEmpty) {
-    return AppTab.values[settings.tabOrder!.first.clamp(0, AppTab.settings.index)];
+    return AppTab.values[settings.tabOrder!.first.clamp(
+      0,
+      AppTab.settings.index,
+    )];
   }
   return AppTab.catalog;
 });
 
 final ghAuthProvider = FutureProvider<bool>(
-    (ref) => GhAuthService().isAuthorized());
+  (ref) => GhAuthService().isAuthorized(),
+);
 
 class AppShell extends ConsumerStatefulWidget {
   const AppShell({super.key});
@@ -66,7 +71,7 @@ class _AppShellState extends ConsumerState<AppShell>
     )..value = 1.0;
 
     final curved = CurvedAnimation(parent: _ctrl, curve: Curves.easeOut);
-    _enterFade  = curved;
+    _enterFade = curved;
     _enterSlide = Tween<Offset>(
       begin: const Offset(0, 0.055),
       end: Offset.zero,
@@ -103,7 +108,9 @@ class _AppShellState extends ConsumerState<AppShell>
   void dispose() {
     windowManager.removeListener(this);
     _ctrl.dispose();
-    for (final t in _toasts) { t.timer.cancel(); }
+    for (final t in _toasts) {
+      t.timer.cancel();
+    }
     super.dispose();
   }
 
@@ -117,24 +124,42 @@ class _AppShellState extends ConsumerState<AppShell>
 
   // ── WindowListener no-ops ───────────────────────────────────────────────
 
-  @override void onWindowResize() {}
-  @override void onWindowResized() {}
-  @override void onWindowMove() {}
-  @override void onWindowMoved() {}
-  @override void onWindowEvent(String eventName) {}
-  @override void onWindowFocus() {}
-  @override void onWindowBlur() {}
-  @override void onWindowMinimize() {}
-  @override void onWindowRestore() {}
-  @override void onWindowEnterFullScreen() {}
-  @override void onWindowLeaveFullScreen() {}
-  @override void onWindowClose() {}
-  @override void onWindowDocked() {}
-  @override void onWindowUndocked() {}
+  @override
+  void onWindowResize() {}
+  @override
+  void onWindowResized() {}
+  @override
+  void onWindowMove() {}
+  @override
+  void onWindowMoved() {}
+  @override
+  void onWindowEvent(String eventName) {}
+  @override
+  void onWindowFocus() {}
+  @override
+  void onWindowBlur() {}
+  @override
+  void onWindowMinimize() {}
+  @override
+  void onWindowRestore() {}
+  @override
+  void onWindowEnterFullScreen() {}
+  @override
+  void onWindowLeaveFullScreen() {}
+  @override
+  void onWindowClose() {}
+  @override
+  void onWindowDocked() {}
+  @override
+  void onWindowUndocked() {}
 
   // ── Dialog & styles ─────────────────────────────────────────────────────
 
-  void _showUpdateDialog(BuildContext context, UpdateInfo info, TabPalette palette) {
+  void _showUpdateDialog(
+    BuildContext context,
+    UpdateInfo info,
+    TabPalette palette,
+  ) {
     showDialog(
       context: context,
       barrierDismissible: false,
@@ -149,16 +174,32 @@ class _AppShellState extends ConsumerState<AppShell>
                 color: palette.primary.withValues(alpha: 0.12),
                 borderRadius: BorderRadius.circular(10),
               ),
-              child: Icon(Icons.system_update_rounded, color: palette.primary, size: 20),
+              child: Icon(
+                Icons.system_update_rounded,
+                color: palette.primary,
+                size: 20,
+              ),
             ),
             const SizedBox(width: 12),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text('Update available',
-                    style: TextStyle(color: kTextPrimary, fontSize: 15, fontWeight: FontWeight.w600)),
-                Text('v${info.version} is ready to download',
-                    style: const TextStyle(color: kTextSecondary, fontSize: 12, fontWeight: FontWeight.normal)),
+                Text(
+                  'Update available',
+                  style: TextStyle(
+                    color: kTextPrimary,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Text(
+                  'v${info.version} is ready to download',
+                  style: TextStyle(
+                    color: kTextSecondary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.normal,
+                  ),
+                ),
               ],
             ),
           ],
@@ -170,8 +211,15 @@ class _AppShellState extends ConsumerState<AppShell>
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text("What's new",
-                        style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: palette.primary, letterSpacing: 0.8)),
+                    Text(
+                      "What's new",
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        color: palette.primary,
+                        letterSpacing: 0.8,
+                      ),
+                    ),
                     const SizedBox(height: 8),
                     ConstrainedBox(
                       constraints: const BoxConstraints(maxHeight: 200),
@@ -192,7 +240,7 @@ class _AppShellState extends ConsumerState<AppShell>
               Navigator.pop(ctx);
               ref.read(updateProvider.notifier).dismiss();
             },
-            child: const Text('Later', style: TextStyle(color: kTextMuted)),
+            child: Text('Later', style: TextStyle(color: kTextMuted)),
           ),
           TextButton(
             onPressed: () {
@@ -201,8 +249,13 @@ class _AppShellState extends ConsumerState<AppShell>
               ref.read(updateProvider.notifier).downloadUpdate();
             },
             style: TextButton.styleFrom(foregroundColor: palette.primary),
-            child: Text('Update Now',
-                style: TextStyle(color: palette.primary, fontWeight: FontWeight.w600)),
+            child: Text(
+              'Update Now',
+              style: TextStyle(
+                color: palette.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ),
         ],
       ),
@@ -210,33 +263,45 @@ class _AppShellState extends ConsumerState<AppShell>
   }
 
   MarkdownStyleSheet _mdStyle(TabPalette palette) => MarkdownStyleSheet(
-        p: const TextStyle(fontSize: 12, color: kTextSecondary, height: 1.6),
-        h1: TextStyle(fontSize: 15, fontWeight: FontWeight.w700, color: palette.primary),
-        h2: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: palette.primary),
-        h3: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: kTextPrimary),
-        strong: const TextStyle(fontWeight: FontWeight.w600, color: kTextPrimary),
-        em: const TextStyle(fontStyle: FontStyle.italic, color: kTextSecondary),
-        code: const TextStyle(fontSize: 11, color: kTextPrimary, fontFamily: 'monospace'),
-        codeblockDecoration: BoxDecoration(
-          color: kSurface2Color,
-          borderRadius: BorderRadius.circular(6),
-        ),
-        blockquoteDecoration: BoxDecoration(
-          border: Border(left: BorderSide(color: palette.primary, width: 3)),
-        ),
-        listBullet: const TextStyle(fontSize: 12, color: kTextSecondary),
-        horizontalRuleDecoration: const BoxDecoration(
-          border: Border(top: BorderSide(color: kBorderColor)),
-        ),
-      );
+    p: TextStyle(fontSize: 12, color: kTextSecondary, height: 1.6),
+    h1: TextStyle(
+      fontSize: 15,
+      fontWeight: FontWeight.w700,
+      color: palette.primary,
+    ),
+    h2: TextStyle(
+      fontSize: 13,
+      fontWeight: FontWeight.w600,
+      color: palette.primary,
+    ),
+    h3: TextStyle(
+      fontSize: 12,
+      fontWeight: FontWeight.w600,
+      color: kTextPrimary,
+    ),
+    strong: TextStyle(fontWeight: FontWeight.w600, color: kTextPrimary),
+    em: TextStyle(fontStyle: FontStyle.italic, color: kTextSecondary),
+    code: TextStyle(fontSize: 11, color: kTextPrimary, fontFamily: 'monospace'),
+    codeblockDecoration: BoxDecoration(
+      color: kSurface2Color,
+      borderRadius: BorderRadius.circular(6),
+    ),
+    blockquoteDecoration: BoxDecoration(
+      border: Border(left: BorderSide(color: palette.primary, width: 3)),
+    ),
+    listBullet: TextStyle(fontSize: 12, color: kTextSecondary),
+    horizontalRuleDecoration: BoxDecoration(
+      border: Border(top: BorderSide(color: kBorderColor)),
+    ),
+  );
 
   Widget _screenFor(AppTab tab) => switch (tab) {
-    AppTab.encode   => const EncodeScreen(),
-    AppTab.decode   => const DecodeScreen(),
-    AppTab.player   => const PlayerScreen(),
-    AppTab.catalog  => const CatalogScreen(),
+    AppTab.encode => const EncodeScreen(),
+    AppTab.decode => const DecodeScreen(),
+    AppTab.player => const PlayerScreen(),
+    AppTab.catalog => const CatalogScreen(),
     AppTab.settings => const SettingsScreen(),
-    AppTab.admin    => const AdminScreen(),
+    AppTab.admin => const AdminScreen(),
   };
 
   @override
@@ -283,7 +348,11 @@ class _AppShellState extends ConsumerState<AppShell>
     ref.listen(downloadProvider, (prev, next) {
       if (prev is! DownloadDone && next is DownloadDone) {
         if (ref.read(activeTabProvider) != AppTab.catalog) {
-          _addToast('Download complete', AppTab.catalog.palette, AppTab.catalog);
+          _addToast(
+            'Download complete',
+            AppTab.catalog.palette,
+            AppTab.catalog,
+          );
         }
       }
     });
@@ -309,55 +378,75 @@ class _AppShellState extends ConsumerState<AppShell>
                       if (!isFullscreen)
                         _Sidebar(activeTab: activeTab, palette: palette),
                       Expanded(
-                        child: AnimatedContainer(
-                          duration: const Duration(milliseconds: 300),
-                          color: palette.surface,
-                          child: Stack(
-                            fit: StackFit.expand,
-                            children: AppTab.values.map((tab) {
-                              final isActive  = tab == activeTab;
-                              final isExiting = tab == _exitingTab;
+                        child: Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            AnimatedContainer(
+                              duration: const Duration(milliseconds: 300),
+                              decoration: BoxDecoration(
+                                color: activeSpec.gradientBg == null
+                                    ? palette.surface
+                                    : null,
+                                gradient: activeSpec.gradientBg == null
+                                    ? null
+                                    : LinearGradient(
+                                        begin: Alignment.topLeft,
+                                        end: Alignment.bottomRight,
+                                        colors: activeSpec.gradientBg!,
+                                      ),
+                              ),
+                              child: Stack(
+                                fit: StackFit.expand,
+                                children: AppTab.values.map((tab) {
+                                  final isActive = tab == activeTab;
+                                  final isExiting = tab == _exitingTab;
 
-                              if (!isActive && !isExiting) {
-                                // Player keeps tickers so audio continues off-tab;
-                                // all other tabs are fully frozen.
-                                return Offstage(
-                                  offstage: true,
-                                  child: tab == AppTab.player
-                                      ? _screenFor(tab)
-                                      : TickerMode(
-                                          enabled: false,
-                                          child: _screenFor(tab),
+                                  if (!isActive && !isExiting) {
+                                    // Player keeps tickers so audio continues off-tab;
+                                    // all other tabs are fully frozen.
+                                    return Offstage(
+                                      offstage: true,
+                                      child: tab == AppTab.player
+                                          ? _screenFor(tab)
+                                          : TickerMode(
+                                              enabled: false,
+                                              child: _screenFor(tab),
+                                            ),
+                                    );
+                                  }
+
+                                  if (isActive) {
+                                    return AnimatedBuilder(
+                                      animation: _ctrl,
+                                      builder: (_, child) => FadeTransition(
+                                        opacity: _enterFade,
+                                        child: SlideTransition(
+                                          position: _enterSlide,
+                                          child: child,
                                         ),
-                                );
-                              }
+                                      ),
+                                      child: _screenFor(tab),
+                                    );
+                                  }
 
-                              if (isActive) {
-                                return AnimatedBuilder(
-                                  animation: _ctrl,
-                                  builder: (_, child) => FadeTransition(
-                                    opacity: _enterFade,
-                                    child: SlideTransition(
-                                      position: _enterSlide,
-                                      child: child,
+                                  return IgnorePointer(
+                                    child: AnimatedBuilder(
+                                      animation: _ctrl,
+                                      builder: (_, child) => FadeTransition(
+                                        opacity: _exitFade,
+                                        child: child,
+                                      ),
+                                      child: _screenFor(tab),
                                     ),
-                                  ),
-                                  child: _screenFor(tab),
-                                );
-                              }
-
-                              return IgnorePointer(
-                                child: AnimatedBuilder(
-                                  animation: _ctrl,
-                                  builder: (_, child) => FadeTransition(
-                                    opacity: _exitFade,
-                                    child: child,
-                                  ),
-                                  child: _screenFor(tab),
-                                ),
-                              );
-                            }).toList(),
-                          ),
+                                  );
+                                }).toList(),
+                              ),
+                            ),
+                            if (activeSpec.scanlines)
+                              const Positioned.fill(
+                                child: IgnorePointer(child: _ScanlineOverlay()),
+                              ),
+                          ],
                         ),
                       ),
                     ],
@@ -371,18 +460,27 @@ class _AppShellState extends ConsumerState<AppShell>
                 right: 16,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.end,
-                  children: _toasts.map((t) => _ToastCard(
-                    toast: t,
-                    onTap: () {
-                      t.timer.cancel();
-                      setState(() => _toasts.removeWhere((e) => e.id == t.id));
-                      ref.read(activeTabProvider.notifier).state = t.target;
-                    },
-                    onDismiss: () {
-                      t.timer.cancel();
-                      setState(() => _toasts.removeWhere((e) => e.id == t.id));
-                    },
-                  )).toList(),
+                  children: _toasts
+                      .map(
+                        (t) => _ToastCard(
+                          toast: t,
+                          onTap: () {
+                            t.timer.cancel();
+                            setState(
+                              () => _toasts.removeWhere((e) => e.id == t.id),
+                            );
+                            ref.read(activeTabProvider.notifier).state =
+                                t.target;
+                          },
+                          onDismiss: () {
+                            t.timer.cancel();
+                            setState(
+                              () => _toasts.removeWhere((e) => e.id == t.id),
+                            );
+                          },
+                        ),
+                      )
+                      .toList(),
                 ),
               ),
           ],
@@ -431,9 +529,7 @@ class _TitleBar extends ConsumerWidget {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 color: palette.primary,
-                boxShadow: [
-                  BoxShadow(color: palette.glow, blurRadius: 8),
-                ],
+                boxShadow: [BoxShadow(color: palette.glow, blurRadius: 8)],
               ),
             ),
             const SizedBox(width: 10),
@@ -515,31 +611,36 @@ class _WindowButtonState extends State<_WindowButton> {
       preferBelow: true,
       waitDuration: const Duration(milliseconds: 600),
       child: MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() { _hovered = false; _pressed = false; }),
-      child: GestureDetector(
-        onTap: widget.onTap,
-        onTapDown: (_) => setState(() => _pressed = true),
-        onTapUp: (_) => setState(() => _pressed = false),
-        onTapCancel: () => setState(() => _pressed = false),
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 100),
-          width: 46,
-          height: 48,
-          color: _hovered
-              ? (widget.isClose
-                  ? const Color(0xFFE81123).withValues(alpha: _pressed ? 1.0 : 0.85)
-                  : kSurface2Color)
-              : Colors.transparent,
-          child: AnimatedScale(
-            scale: _pressed ? 0.88 : 1.0,
-            duration: const Duration(milliseconds: 80),
-            child: Icon(widget.icon, size: 16, color: kTextSecondary),
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setState(() => _hovered = true),
+        onExit: (_) => setState(() {
+          _hovered = false;
+          _pressed = false;
+        }),
+        child: GestureDetector(
+          onTap: widget.onTap,
+          onTapDown: (_) => setState(() => _pressed = true),
+          onTapUp: (_) => setState(() => _pressed = false),
+          onTapCancel: () => setState(() => _pressed = false),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 100),
+            width: 46,
+            height: 48,
+            color: _hovered
+                ? (widget.isClose
+                      ? const Color(
+                          0xFFE81123,
+                        ).withValues(alpha: _pressed ? 1.0 : 0.85)
+                      : kSurface2Color)
+                : Colors.transparent,
+            child: AnimatedScale(
+              scale: _pressed ? 0.88 : 1.0,
+              duration: const Duration(milliseconds: 80),
+              child: Icon(widget.icon, size: 16, color: kTextSecondary),
+            ),
           ),
         ),
       ),
-    ),
     );
   }
 }
@@ -565,8 +666,11 @@ class _SidebarState extends ConsumerState<_Sidebar> {
     (AppTab.settings, Icons.settings_rounded, 'Settings'),
   ];
 
-  static const _adminItem =
-      (AppTab.admin, Icons.admin_panel_settings_rounded, 'Admin');
+  static const _adminItem = (
+    AppTab.admin,
+    Icons.admin_panel_settings_rounded,
+    'Admin',
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -616,18 +720,20 @@ class _SidebarState extends ConsumerState<_Sidebar> {
               label: item.$3,
               isActive: widget.activeTab == item.$1,
               isHovered: _hovered == item.$1,
-              isRunning: (item.$1 == AppTab.encode && encodeRunning) ||
+              isRunning:
+                  (item.$1 == AppTab.encode && encodeRunning) ||
                   (item.$1 == AppTab.decode && decodeRunning) ||
                   (item.$1 == AppTab.player && playerPlaying),
-              hasBadge: item.$1 == AppTab.settings &&
+              hasBadge:
+                  item.$1 == AppTab.settings &&
                   (updateStatus == UpdateStatus.available ||
-                   updateStatus == UpdateStatus.downloading ||
-                   updateStatus == UpdateStatus.readyToInstall),
-              palette: widget.activeTab == item.$1 ? widget.palette : item.$1.palette,
-              onTap: () =>
-                  ref.read(activeTabProvider.notifier).state = item.$1,
-              onHover: (v) =>
-                  setState(() => _hovered = v ? item.$1 : null),
+                      updateStatus == UpdateStatus.downloading ||
+                      updateStatus == UpdateStatus.readyToInstall),
+              palette: widget.activeTab == item.$1
+                  ? widget.palette
+                  : item.$1.palette,
+              onTap: () => ref.read(activeTabProvider.notifier).state = item.$1,
+              onHover: (v) => setState(() => _hovered = v ? item.$1 : null),
             ),
         ],
       ),
@@ -665,96 +771,99 @@ class _SidebarItem extends StatelessWidget {
     final color = isActive
         ? palette.primary
         : isHovered
-            ? palette.primary.withValues(alpha: 0.7)
-            : kTextMuted;
+        ? palette.primary.withValues(alpha: 0.7)
+        : kTextMuted;
 
     return Tooltip(
       message: label,
       preferBelow: false,
       waitDuration: const Duration(milliseconds: 800),
       child: MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => onHover(true),
-      onExit: (_) => onHover(false),
-      child: GestureDetector(
-        onTap: onTap,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          width: 72,
-          height: 72,
-          decoration: BoxDecoration(
-            color: isActive
-                ? palette.primary.withValues(alpha: 0.1)
-                : Colors.transparent,
-            border: Border(
-              left: BorderSide(
-                color: isActive ? palette.primary : Colors.transparent,
-                width: 3,
-              ),
-            ),
-          ),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  AnimatedContainer(
-                    duration: const Duration(milliseconds: 200),
-                    padding: const EdgeInsets.all(6),
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      boxShadow: isActive
-                          ? [BoxShadow(color: palette.glow, blurRadius: 10)]
-                          : [],
-                    ),
-                    child: Icon(icon, color: color, size: 22),
-                  ),
-                  if (isRunning)
-                    Positioned(
-                      top: 2,
-                      right: 2,
-                      child: Container(
-                        width: 8,
-                        height: 8,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: palette.primary,
-                          boxShadow: [
-                            BoxShadow(color: palette.glow, blurRadius: 4)
-                          ],
-                        ),
-                      )
-                          .animate(onPlay: (c) => c.repeat(reverse: true))
-                          .fade(begin: 0.3, end: 1.0, duration: 600.ms),
-                    ),
-                  if (hasBadge)
-                    Positioned(
-                      top: -1,
-                      right: -1,
-                      child: Icon(
-                        Icons.download_rounded,
-                        size: 15,
-                        color: palette.primary,
-                      ),
-                    ),
-                ],
-              ),
-              const SizedBox(height: 4),
-              Text(
-                label,
-                style: TextStyle(
-                  fontSize: 10,
-                  color: color,
-                  fontWeight:
-                      isActive ? FontWeight.w600 : FontWeight.normal,
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => onHover(true),
+        onExit: (_) => onHover(false),
+        child: GestureDetector(
+          onTap: onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            width: 72,
+            height: 72,
+            decoration: BoxDecoration(
+              color: isActive
+                  ? palette.primary.withValues(alpha: 0.1)
+                  : Colors.transparent,
+              border: Border(
+                left: BorderSide(
+                  color: isActive ? palette.primary : Colors.transparent,
+                  width: 3,
                 ),
               ),
-            ],
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      padding: const EdgeInsets.all(6),
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        boxShadow: isActive
+                            ? [BoxShadow(color: palette.glow, blurRadius: 10)]
+                            : [],
+                      ),
+                      child: Icon(icon, color: color, size: 22),
+                    ),
+                    if (isRunning)
+                      Positioned(
+                        top: 2,
+                        right: 2,
+                        child:
+                            Container(
+                                  width: 8,
+                                  height: 8,
+                                  decoration: BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    color: palette.primary,
+                                    boxShadow: [
+                                      BoxShadow(
+                                        color: palette.glow,
+                                        blurRadius: 4,
+                                      ),
+                                    ],
+                                  ),
+                                )
+                                .animate(onPlay: (c) => c.repeat(reverse: true))
+                                .fade(begin: 0.3, end: 1.0, duration: 600.ms),
+                      ),
+                    if (hasBadge)
+                      Positioned(
+                        top: -1,
+                        right: -1,
+                        child: Icon(
+                          Icons.download_rounded,
+                          size: 15,
+                          color: palette.primary,
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: color,
+                    fontWeight: isActive ? FontWeight.w600 : FontWeight.normal,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
-    ),
     );
   }
 }
@@ -793,60 +902,101 @@ class _ToastCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          onTap: onTap,
-          child: Container(
-            width: 240,
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-            decoration: BoxDecoration(
-              color: kSurfaceColor,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                  color: toast.palette.primary.withValues(alpha: 0.4)),
-              boxShadow: [
-                BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.35),
-                    blurRadius: 14,
-                    offset: const Offset(0, 4)),
-              ],
-            ),
-            child: Row(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(6),
-                  decoration: BoxDecoration(
-                    color: toast.palette.primary.withValues(alpha: 0.15),
-                    shape: BoxShape.circle,
-                  ),
-                  child: Icon(Icons.check_rounded,
-                      color: toast.palette.primary, size: 14),
+          padding: const EdgeInsets.only(bottom: 8),
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              onTap: onTap,
+              child: Container(
+                width: 240,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
                 ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    toast.message,
-                    style: const TextStyle(
-                        fontSize: 12,
-                        color: kTextPrimary,
-                        fontWeight: FontWeight.w500),
+                decoration: BoxDecoration(
+                  color: kSurfaceColor,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: toast.palette.primary.withValues(alpha: 0.4),
                   ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.35),
+                      blurRadius: 14,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
                 ),
-                GestureDetector(
-                  behavior: HitTestBehavior.opaque,
-                  onTap: onDismiss,
-                  child: const Padding(
-                    padding: EdgeInsets.all(4),
-                    child: Icon(Icons.close_rounded, color: kTextMuted, size: 14),
-                  ),
+                child: Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(6),
+                      decoration: BoxDecoration(
+                        color: toast.palette.primary.withValues(alpha: 0.15),
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(
+                        Icons.check_rounded,
+                        color: toast.palette.primary,
+                        size: 14,
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        toast.message,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: kTextPrimary,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                    GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: onDismiss,
+                      child: Padding(
+                        padding: EdgeInsets.all(4),
+                        child: Icon(
+                          Icons.close_rounded,
+                          color: kTextMuted,
+                          size: 14,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
-        ),
-      ),
-    ).animate().fadeIn(duration: 180.ms).slideX(begin: 0.25, end: 0, duration: 180.ms);
+        )
+        .animate()
+        .fadeIn(duration: 180.ms)
+        .slideX(begin: 0.25, end: 0, duration: 180.ms);
   }
+}
+
+// ── Scanline overlay (Phosphor / CRT themes) ────────────────────────────────
+
+class _ScanlineOverlay extends StatelessWidget {
+  const _ScanlineOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(painter: _ScanlinePainter());
+  }
+}
+
+class _ScanlinePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = Colors.black.withValues(alpha: 0.16);
+    const gap = 3.0;
+    for (double y = 0; y < size.height; y += gap) {
+      canvas.drawRect(Rect.fromLTWH(0, y, size.width, 1), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/lib/features/shell/widgets/shared_widgets.dart
+++ b/lib/features/shell/widgets/shared_widgets.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/theme/theme_spec.dart';
 
 class SectionHeader extends StatelessWidget {
   final IconData icon;
@@ -23,10 +25,15 @@ class SectionHeader extends StatelessWidget {
           padding: const EdgeInsets.all(10),
           decoration: BoxDecoration(
             color: color.withValues(alpha: 0.12),
-            borderRadius: BorderRadius.circular(12),
-            boxShadow: [
-              BoxShadow(color: color.withValues(alpha: 0.2), blurRadius: 16)
-            ],
+            borderRadius: BorderRadius.circular(kRadius + 2),
+            boxShadow: activeSpec.hasGlow
+                ? [
+                    BoxShadow(
+                      color: color.withValues(alpha: 0.2),
+                      blurRadius: 16,
+                    ),
+                  ]
+                : null,
           ),
           child: Icon(icon, color: color, size: 24),
         ),
@@ -34,14 +41,19 @@ class SectionHeader extends StatelessWidget {
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(title,
-                style: const TextStyle(
-                    fontSize: 22,
-                    fontWeight: FontWeight.w700,
-                    color: kTextPrimary)),
-            Text(subtitle,
-                style:
-                    const TextStyle(fontSize: 13, color: kTextSecondary)),
+            Text(
+              title,
+              style: GoogleFonts.getFont(
+                activeSpec.headingFont,
+                fontSize: 22,
+                fontWeight: FontWeight.w700,
+                color: kTextPrimary,
+              ),
+            ),
+            Text(
+              subtitle,
+              style: TextStyle(fontSize: 13, color: kTextSecondary),
+            ),
           ],
         ),
       ],
@@ -71,10 +83,8 @@ class SmallButton extends StatelessWidget {
       label: Text(label, style: TextStyle(color: color, fontSize: 13)),
       style: TextButton.styleFrom(
         backgroundColor: color.withValues(alpha: 0.1),
-        padding:
-            const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
-        shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10)),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       ),
     );
   }
@@ -96,13 +106,17 @@ class ErrorBanner extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const Icon(Icons.error_outline_rounded,
-              color: Color(0xFFF87171), size: 18),
+          const Icon(
+            Icons.error_outline_rounded,
+            color: Color(0xFFF87171),
+            size: 18,
+          ),
           const SizedBox(width: 10),
           Expanded(
-            child: Text(message,
-                style: const TextStyle(
-                    fontSize: 13, color: Color(0xFFFCA5A5))),
+            child: Text(
+              message,
+              style: const TextStyle(fontSize: 13, color: Color(0xFFFCA5A5)),
+            ),
           ),
         ],
       ),
@@ -193,14 +207,13 @@ class OutDirRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isCustom = onClear != null;  // user-picked dir, not auto-computed
+    final isCustom = onClear != null; // user-picked dir, not auto-computed
     final hasContent = dir.isNotEmpty;
     return Row(
       children: [
         Expanded(
           child: Container(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
             decoration: BoxDecoration(
               color: kSurface2Color,
               borderRadius: BorderRadius.circular(10),
@@ -212,8 +225,11 @@ class OutDirRow extends StatelessWidget {
             ),
             child: Row(
               children: [
-                Icon(Icons.folder_outlined,
-                    color: isCustom ? accentColor : kTextMuted, size: 18),
+                Icon(
+                  Icons.folder_outlined,
+                  color: isCustom ? accentColor : kTextMuted,
+                  size: 18,
+                ),
                 const SizedBox(width: 10),
                 Expanded(
                   child: Text(
@@ -230,10 +246,13 @@ class OutDirRow extends StatelessWidget {
                     cursor: SystemMouseCursors.click,
                     child: GestureDetector(
                       onTap: onClear,
-                      child: const Padding(
+                      child: Padding(
                         padding: EdgeInsets.only(left: 8),
-                        child: Icon(Icons.close_rounded,
-                            size: 15, color: kTextMuted),
+                        child: Icon(
+                          Icons.close_rounded,
+                          size: 15,
+                          color: kTextMuted,
+                        ),
                       ),
                     ),
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:media_kit/media_kit.dart';
 import 'package:window_manager/window_manager.dart';
 import 'core/services/settings_service.dart';
 import 'core/theme/app_theme.dart';
+import 'core/theme/theme_spec.dart';
 import 'features/shell/app_shell.dart';
 import 'features/updater/update_notifier.dart';
 
@@ -31,7 +32,9 @@ void main() async {
     },
   );
 
-  runApp(UncontrolledProviderScope(container: container, child: const MStorageApp()));
+  runApp(
+    UncontrolledProviderScope(container: container, child: const MStorageApp()),
+  );
 
   // Background update check after first frame — single HTTP call, non-blocking.
   WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -44,11 +47,20 @@ class MStorageApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Re-skin the whole app when the selected theme changes. Keeping the active
+    // spec in sync here (idempotent) guarantees the getter-backed `k*` tokens
+    // and `tabPalettes` resolve correctly before the subtree rebuilds.
+    final themeId = ref.watch(settingsProvider.select((s) => s.themeId));
+    applyThemeGlobals(appThemeIdFromString(themeId));
+
     return MaterialApp(
       title: 'mStorage',
       debugShowCheckedModeBanner: false,
       theme: buildAppTheme(),
-      home: const AppShell(),
+      // The ValueKey forces a clean remount on theme switch so every widget
+      // re-reads the new tokens. Feature state survives (Riverpod providers and
+      // the module-level media_kit player are not tied to the widget tree).
+      home: KeyedSubtree(key: ValueKey(themeId), child: const AppShell()),
     );
   }
 }


### PR DESCRIPTION
## Summary

- **Theme system**: New `ThemeSpec` model with 7 named themes (Spectrum, Monolith, Aurora, Manuscript, Phosphor, Clay, Halcyon) — each with distinct colors, fonts, radius, elevation style, and optional effects
- **Runtime switcher**: Settings → Appearance section with live-preview swatch cards; selection persists via `shared_preferences` and survives app restart
- **Zero call-site rewrites**: `k*` color constants and `tabPalettes` converted to getters so ~1000 existing usages stay unchanged
- **Bug fixes**: Aurora catalog black bar, admin panel always-cyan, series accent mismatch in mono themes, unreadable button text on dark accents (`onAccentColor` helper)

## Test plan

- [ ] Launch app — Spectrum theme loads by default
- [ ] Settings → Appearance — all 7 swatch cards visible with mini previews
- [ ] Tap each theme — full app re-skins without navigation loss or playback interruption
- [ ] Restart app — last selected theme persists
- [ ] Aurora theme: catalog bottom bar matches page background (no black bar)
- [ ] Admin panel accent matches active theme accent (not always cyan)
- [ ] Monolith/Manuscript "View & Download" button has readable text
- [ ] Series section accent matches page accent in single-color themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)