### PR TITLE
feat: v1.6.1 — Syncplay exe picker and theme font preloading

### DIFF
--- a/lib/core/models/settings_model.dart
+++ b/lib/core/models/settings_model.dart
@@ -13,6 +13,7 @@ class AppSettings {
   final bool deleteAfterDecode;
   final double playerVolume;
   final String themeId;
+  final String syncplayPath;
 
   const AppSettings({
     this.password = '',
@@ -29,6 +30,7 @@ class AppSettings {
     this.deleteAfterDecode = false,
     this.playerVolume = 100.0,
     this.themeId = 'spectrum',
+    this.syncplayPath = '',
   });
 
   AppSettings copyWith({
@@ -46,6 +48,7 @@ class AppSettings {
     bool? deleteAfterDecode,
     double? playerVolume,
     String? themeId,
+    String? syncplayPath,
   }) {
     return AppSettings(
       password: password ?? this.password,
@@ -65,6 +68,7 @@ class AppSettings {
       deleteAfterDecode: deleteAfterDecode ?? this.deleteAfterDecode,
       playerVolume: playerVolume ?? this.playerVolume,
       themeId: themeId ?? this.themeId,
+      syncplayPath: syncplayPath ?? this.syncplayPath,
     );
   }
 }

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -31,6 +31,7 @@ const _kTabOrder = 'tab_order';
 const _kDeleteAfterDecode = 'setting_delete_after_decode';
 const _kPlayerVolume = 'player_volume';
 const _kThemeId = 'setting_theme_id';
+const _kSyncplayPath = 'syncplay_exe_path';
 
 class SettingsNotifier extends Notifier<AppSettings> {
   late SharedPreferences _prefs;
@@ -59,8 +60,14 @@ class SettingsNotifier extends Notifier<AppSettings> {
       deleteAfterDecode: _prefs.getBool(_kDeleteAfterDecode) ?? false,
       playerVolume: _prefs.getDouble(_kPlayerVolume) ?? 100.0,
       themeId: _prefs.getString(_kThemeId) ?? 'spectrum',
+      syncplayPath: _prefs.getString(_kSyncplayPath) ?? '',
     );
     applyThemeGlobals(appThemeIdFromString(state.themeId));
+  }
+
+  Future<void> setSyncplayPath(String value) async {
+    state = state.copyWith(syncplayPath: value);
+    await _prefs.setString(_kSyncplayPath, value);
   }
 
   Future<void> setThemeId(AppThemeId id) async {
@@ -151,6 +158,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
       deleteAfterDecode: state.deleteAfterDecode,
       playerVolume: state.playerVolume,
       themeId: state.themeId,
+      syncplayPath: state.syncplayPath,
     );
   }
 

--- a/lib/core/theme/theme_fonts.dart
+++ b/lib/core/theme/theme_fonts.dart
@@ -1,0 +1,16 @@
+import 'package:google_fonts/google_fonts.dart';
+
+/// Eagerly loads all font families used across the 7 bundled themes so that
+/// theme switching never triggers an async font-load + relayout.  Call once
+/// (non-blocking) after settings are initialised in main().
+Future<void> preloadThemeFonts() async {
+  // Touch one style per family — enough to trigger the cache fetch.
+  GoogleFonts.spaceGrotesk();   // Spectrum + Halcyon body fallback
+  GoogleFonts.archivo();        // Monolith headings
+  GoogleFonts.inter();          // Aurora + Halcyon
+  GoogleFonts.fraunces();       // Manuscript headings
+  GoogleFonts.sourceSans3();    // Manuscript body
+  GoogleFonts.jetBrainsMono();  // Phosphor
+  GoogleFonts.nunito();         // Clay
+  await GoogleFonts.pendingFonts();
+}

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -176,7 +176,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     return false;
   }
 
-  void _checkSyncplay() {
+  void _checkSyncplay({String? userPath}) {
+    // User-chosen path takes priority over all auto-detect locations.
+    final custom = userPath ?? ref.read(settingsProvider).syncplayPath;
+    if (custom.isNotEmpty && File(custom).existsSync()) {
+      setState(() { _syncplayFound = true; _syncplayPath = custom; });
+      return;
+    }
     final appDir = p.dirname(Platform.resolvedExecutable);
     final paths = [
       p.join(appDir, 'syncplay', 'SyncplayConsole.exe'),
@@ -189,6 +195,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         return;
       }
     }
+    setState(() { _syncplayFound = false; _syncplayPath = null; });
   }
 
   void _checkVlc() {
@@ -378,6 +385,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         _openVideo(path);
       }
     });
+
+
+    // Re-run detection when the user picks or clears a custom Syncplay path.
+    ref.listen<String>(
+      settingsProvider.select((s) => s.syncplayPath),
+      (_, path) => _checkSyncplay(userPath: path),
+    );
 
     // Pause automatically when leaving the Player tab.
     ref.listen<AppTab>(activeTabProvider, (prev, next) {

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -720,6 +720,44 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           const SizedBox(height: 20),
 
+          // ── Syncplay ─────────────────────────────────────────────────────
+          _SettingsGroup(
+            label: 'Syncplay',
+            accent: accent,
+            children: [
+              _DirSettingRow(
+                icon: Icons.sync_rounded,
+                title: 'Syncplay Executable',
+                subtitle:
+                    'Pick SyncplayConsole.exe if Syncplay isn\'t installed in Program Files.',
+                accent: accent,
+                dir: settings.syncplayPath,
+                leadingIcon: Icons.terminal_rounded,
+                onPick: () async {
+                  final result = await FilePicker.platform.pickFiles(
+                    type: FileType.custom,
+                    allowedExtensions: ['exe'],
+                    dialogTitle: 'Select SyncplayConsole.exe',
+                  );
+                  final path = result?.files.single.path;
+                  if (path != null) {
+                    ref
+                        .read(settingsProvider.notifier)
+                        .setSyncplayPath(path);
+                  }
+                },
+                onClear: settings.syncplayPath.isEmpty
+                    ? null
+                    : () => ref
+                          .read(settingsProvider.notifier)
+                          .setSyncplayPath(''),
+                placeholder: 'Auto-detect from Program Files',
+              ),
+            ],
+          ).animate().fadeIn(duration: 300.ms, delay: 140.ms),
+
+          const SizedBox(height: 20),
+
           // ── Encode Options ───────────────────────────────────────────────
           _SettingsGroup(
             label: 'Encode Options',
@@ -1047,6 +1085,7 @@ class _DirSettingRow extends StatelessWidget {
   final VoidCallback onPick;
   final VoidCallback? onClear;
   final String placeholder;
+  final IconData leadingIcon;
 
   const _DirSettingRow({
     required this.icon,
@@ -1057,6 +1096,7 @@ class _DirSettingRow extends StatelessWidget {
     required this.onPick,
     required this.onClear,
     required this.placeholder,
+    this.leadingIcon = Icons.folder_outlined,
   });
 
   @override
@@ -1099,6 +1139,7 @@ class _DirSettingRow extends StatelessWidget {
             onPick: onPick,
             onClear: onClear,
             placeholder: placeholder,
+            leadingIcon: leadingIcon,
           ),
         ],
       ),

--- a/lib/features/shell/widgets/shared_widgets.dart
+++ b/lib/features/shell/widgets/shared_widgets.dart
@@ -195,6 +195,7 @@ class OutDirRow extends StatelessWidget {
   final VoidCallback onPick;
   final VoidCallback? onClear;
   final String placeholder;
+  final IconData leadingIcon;
 
   const OutDirRow({
     super.key,
@@ -203,6 +204,7 @@ class OutDirRow extends StatelessWidget {
     required this.onPick,
     this.onClear,
     this.placeholder = 'Default: <video folder>/output/',
+    this.leadingIcon = Icons.folder_outlined,
   });
 
   @override
@@ -226,7 +228,7 @@ class OutDirRow extends StatelessWidget {
             child: Row(
               children: [
                 Icon(
-                  Icons.folder_outlined,
+                  leadingIcon,
                   color: isCustom ? accentColor : kTextMuted,
                   size: 18,
                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:media_kit/media_kit.dart';
 import 'package:window_manager/window_manager.dart';
 import 'core/services/settings_service.dart';
 import 'core/theme/app_theme.dart';
+import 'core/theme/theme_fonts.dart';
 import 'core/theme/theme_spec.dart';
 import 'features/shell/app_shell.dart';
 import 'features/updater/update_notifier.dart';
@@ -15,6 +16,10 @@ void main() async {
   // Load settings before building UI so activeTabProvider can read startupTab.
   final container = ProviderContainer();
   await container.read(settingsProvider.notifier).load();
+
+  // Preload all theme font families so switching never triggers an async
+  // font-load + relayout.  Non-blocking — first paint isn't delayed.
+  unawaited(preloadThemeFonts());
 
   await windowManager.ensureInitialized();
   await windowManager.waitUntilReadyToShow(


### PR DESCRIPTION
## Summary

- **Syncplay executable picker** — new Settings group lets users browse to `SyncplayConsole.exe` when Syncplay isn't installed in Program Files; path is persisted and re-detected live in the Player tab without restarting the app
- **Theme font preloading** — all 7 theme font families are loaded at startup so switching themes no longer triggers an async font-load relayout

## Test plan

- [ ] Pick a custom `SyncplayConsole.exe` in Settings → Syncplay; verify Player tab shows Syncplay as found without restarting
- [ ] Clear the custom path; verify Player falls back to auto-detection
- [ ] Switch between all 7 themes and confirm no font relayout glitch
- [ ] Verify font preload is non-blocking (app first paint is not delayed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)