### PR TITLE
feat: v1.6.2 — drag-and-drop fix and today-date encode guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,25 +20,23 @@ Before touching any code, produce a written plan of the changes described in QUE
 ### 4. Implement and iterate
 Apply the changes. The user will review and give feedback. Go back and forth until the user explicitly says they are satisfied and ready to release.
 
-### 5. Raise a PR
-When the user confirms readiness, open a GitHub PR from `feat/vX.Y.Z` → `main`.
-
-### 6. Merge
-
-### 7. Bump version numbers and build the installer
-**Both** of the following must be updated to X.Y.Z before building — missing either one causes the installed app to misreport its version and the update checker to fire on every launch:
+### 5. Bump version numbers on the feature branch
+Once the user is satisfied, bump **both** of the following to X.Y.Z **before raising the PR** — do this on `feat/vX.Y.Z`, not on `main`. Missing either one causes the installed app to misreport its version and the update checker to fire on every launch:
 
 | File | Field | Example |
 |---|---|---|
-| `pubspec.yaml` | `version: X.Y.Z+N` — increment build number N by 1 each release | `1.4.1+11` |
-| `installer.iss` | `#define AppVersion "X.Y.Z"` | `"1.4.1"` |
+| `pubspec.yaml` | `version: X.Y.Z+N` — increment build number N by 1 each release | `1.6.2+17` |
+| `installer.iss` | `#define AppVersion "X.Y.Z"` | `"1.6.2"` |
 
-After updating both files, build:
+### 6. Raise a PR
+Open a GitHub PR from `feat/vX.Y.Z` → `main`.
+
+### 7. Merge and build the installer
+After merging, build:
 ```
 flutter build windows --release
 iscc installer.iss
 ```
-Commit both file changes to `main` with message `chore: bump version to X.Y.Z`.
 
 ### 8. Tag and release on GitHub
 Create a GitHub release using the tag `vX.Y.Z`. Write release notes following the rules in `.github/RELEASE_TEMPLATE.md`:

--- a/installer.iss
+++ b/installer.iss
@@ -7,7 +7,7 @@
 ; Output: installer\mStorage_Setup.exe
 
 #define AppName        "mStorage"
-#define AppVersion     "1.6.1"
+#define AppVersion     "1.6.2"
 #define AppPublisher   "Seshu Tarapatla"
 #define AppURL         "https://github.com/SeshuTarapatla/mStorage"
 #define AppExeName     "m_storage.exe"

--- a/lib/features/decode/decode_screen.dart
+++ b/lib/features/decode/decode_screen.dart
@@ -1,6 +1,7 @@
+import 'dart:async';
 import 'dart:io';
-import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -128,9 +129,24 @@ class _DecodeScreenState extends ConsumerState<DecodeScreen> {
       return const {'mp4', 'mkv', 'avi', 'mov', 'webm'}.contains(ext);
     }).firstOrNull;
 
-    return DropTarget(
-      onDragDone: (details) {
-        final path = details.files.first.path;
+    return DropRegion(
+      formats: const [Formats.fileUri],
+      hitTestBehavior: HitTestBehavior.opaque,
+      onDropOver: (event) =>
+          event.session.allowedOperations.contains(DropOperation.copy)
+              ? DropOperation.copy
+              : DropOperation.none,
+      onPerformDrop: (event) async {
+        final item = event.session.items.firstOrNull;
+        if (item == null) return;
+        final reader = item.dataReader;
+        if (reader == null || !reader.canProvide(Formats.fileUri)) return;
+        final c = Completer<String?>();
+        reader.getValue<Uri>(Formats.fileUri,
+            (uri) => c.complete(uri?.toFilePath()),
+            onError: (_) => c.complete(null));
+        final path = await c.future;
+        if (path == null) return;
         final ext = path.split('.').last.toLowerCase();
         if (ext == 'mp4') _onVideoDropped(path);
       },

--- a/lib/features/encode/encode_screen.dart
+++ b/lib/features/encode/encode_screen.dart
@@ -1,6 +1,7 @@
+import 'dart:async';
 import 'dart:io';
-import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -183,6 +184,38 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
 
   Future<void> _runEncode() async {
     if (_videoPath == null) return;
+
+    final enteredDate = DateTime.tryParse(_dateCtrl.text.trim());
+    if (enteredDate != null) {
+      final today = DateTime.now();
+      if (enteredDate.year == today.year &&
+          enteredDate.month == today.month &&
+          enteredDate.day == today.day) {
+        final proceed = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text("Date is set to today"),
+            content: const Text(
+              "The encode date matches today's date. Did you forget to update it?\n\n"
+              "Tap \"Encode anyway\" to continue, or go back and set the correct date.",
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Go back'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Encode anyway'),
+              ),
+            ],
+          ),
+        );
+        if (proceed != true) return;
+      }
+    }
+    if (!mounted) return;
+
     final settings = ref.read(settingsProvider);
     final title = _titleCtrl.text.trim().isEmpty
         ? p.basenameWithoutExtension(_videoPath!)
@@ -240,9 +273,27 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
 
     final anyFieldSet = _videoPath != null || _posterPath != null || _srtPath != null;
 
-    return DropTarget(
-      onDragDone: (details) =>
-          _routeFiles(details.files.map((f) => f.path).toList()),
+    return DropRegion(
+      formats: const [Formats.fileUri],
+      hitTestBehavior: HitTestBehavior.opaque,
+      onDropOver: (event) =>
+          event.session.allowedOperations.contains(DropOperation.copy)
+              ? DropOperation.copy
+              : DropOperation.none,
+      onPerformDrop: (event) async {
+        final paths = <String>[];
+        for (final item in event.session.items) {
+          final reader = item.dataReader;
+          if (reader == null || !reader.canProvide(Formats.fileUri)) continue;
+          final c = Completer<String?>();
+          reader.getValue<Uri>(Formats.fileUri,
+              (uri) => c.complete(uri?.toFilePath()),
+              onError: (_) => c.complete(null));
+          final path = await c.future;
+          if (path != null) paths.add(path);
+        }
+        if (paths.isNotEmpty) _routeFiles(paths);
+      },
       child: SingleChildScrollView(
             padding: const EdgeInsets.all(28),
             child: Column(

--- a/lib/features/encode/widgets/drop_zone.dart
+++ b/lib/features/encode/widgets/drop_zone.dart
@@ -1,6 +1,7 @@
+import 'dart:async';
 import 'dart:io';
-import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
+import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../../../core/theme/app_theme.dart';
 
@@ -68,18 +69,34 @@ class _FileDropZoneState extends State<FileDropZone> {
 
     return Stack(
       children: [
-        DropTarget(
-          onDragEntered: (_) => setState(() => _isDragging = true),
-          onDragExited: (_) => setState(() => _isDragging = false),
-          onDragDone: (details) {
+        DropRegion(
+          formats: const [Formats.fileUri],
+          hitTestBehavior: HitTestBehavior.opaque,
+          onDropOver: (event) =>
+              event.session.allowedOperations.contains(DropOperation.copy)
+                  ? DropOperation.copy
+                  : DropOperation.none,
+          onDropEnter: (_) => setState(() => _isDragging = true),
+          onDropLeave: (_) => setState(() => _isDragging = false),
+          onPerformDrop: (event) async {
             setState(() => _isDragging = false);
-            final files = details.files;
-            if (files.isEmpty) return;
-            if (files.length > 1 && widget.onMultiFileDrop != null) {
-              widget.onMultiFileDrop!(files.map((f) => f.path).toList());
+            final paths = <String>[];
+            for (final item in event.session.items) {
+              final reader = item.dataReader;
+              if (reader == null || !reader.canProvide(Formats.fileUri)) continue;
+              final c = Completer<String?>();
+              reader.getValue<Uri>(Formats.fileUri,
+                  (uri) => c.complete(uri?.toFilePath()),
+                  onError: (_) => c.complete(null));
+              final path = await c.future;
+              if (path != null) paths.add(path);
+            }
+            if (paths.isEmpty) return;
+            if (paths.length > 1 && widget.onMultiFileDrop != null) {
+              widget.onMultiFileDrop!(paths);
               return;
             }
-            final path = files.first.path;
+            final path = paths.first;
             final ext = path.split('.').last.toLowerCase();
             if (widget.allowedExtensions.isEmpty ||
                 widget.allowedExtensions.contains(ext)) {

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
@@ -436,10 +436,24 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     }
 
     // ── Normal mode ───────────────────────────────────────────────────────
-    return DropTarget(
-      onDragDone: (details) {
-        final path = details.files.first.path;
-        if (_isVideoFile(path)) _openVideo(path);
+    return DropRegion(
+      formats: const [Formats.fileUri],
+      hitTestBehavior: HitTestBehavior.opaque,
+      onDropOver: (event) =>
+          event.session.allowedOperations.contains(DropOperation.copy)
+              ? DropOperation.copy
+              : DropOperation.none,
+      onPerformDrop: (event) async {
+        final item = event.session.items.firstOrNull;
+        if (item == null) return;
+        final reader = item.dataReader;
+        if (reader == null || !reader.canProvide(Formats.fileUri)) return;
+        final c = Completer<String?>();
+        reader.getValue<Uri>(Formats.fileUri,
+            (uri) => c.complete(uri?.toFilePath()),
+            onError: (_) => c.complete(null));
+        final path = await c.future;
+        if (path != null && _isVideoFile(path)) _openVideo(path);
       },
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -695,13 +709,27 @@ class _VideoAreaState extends State<_VideoArea> {
 
   @override
   Widget build(BuildContext context) {
-    return DropTarget(
-      onDragEntered: (_) => setState(() => _isDragging = true),
-      onDragExited: (_) => setState(() => _isDragging = false),
-      onDragDone: (details) {
+    return DropRegion(
+      formats: const [Formats.fileUri],
+      hitTestBehavior: HitTestBehavior.opaque,
+      onDropOver: (event) =>
+          event.session.allowedOperations.contains(DropOperation.copy)
+              ? DropOperation.copy
+              : DropOperation.none,
+      onDropEnter: (_) => setState(() => _isDragging = true),
+      onDropLeave: (_) => setState(() => _isDragging = false),
+      onPerformDrop: (event) async {
         setState(() => _isDragging = false);
-        final path = details.files.first.path;
-        if (_isVideoFile(path)) widget.onDrop(path);
+        final item = event.session.items.firstOrNull;
+        if (item == null) return;
+        final reader = item.dataReader;
+        if (reader == null || !reader.canProvide(Formats.fileUri)) return;
+        final c = Completer<String?>();
+        reader.getValue<Uri>(Formats.fileUri,
+            (uri) => c.complete(uri?.toFilePath()),
+            onError: (_) => c.complete(null));
+        final path = await c.future;
+        if (path != null && _isVideoFile(path)) widget.onDrop(path);
       },
       child: GestureDetector(
         onDoubleTap: widget.onDoubleTap,
@@ -791,13 +819,27 @@ class _PlayerPlaceholderState extends State<_PlayerPlaceholder> {
 
   @override
   Widget build(BuildContext context) {
-    return DropTarget(
-      onDragEntered: (_) => setState(() => _isDragging = true),
-      onDragExited: (_) => setState(() => _isDragging = false),
-      onDragDone: (details) {
+    return DropRegion(
+      formats: const [Formats.fileUri],
+      hitTestBehavior: HitTestBehavior.opaque,
+      onDropOver: (event) =>
+          event.session.allowedOperations.contains(DropOperation.copy)
+              ? DropOperation.copy
+              : DropOperation.none,
+      onDropEnter: (_) => setState(() => _isDragging = true),
+      onDropLeave: (_) => setState(() => _isDragging = false),
+      onPerformDrop: (event) async {
         setState(() => _isDragging = false);
-        final path = details.files.first.path;
-        if (_isVideoFile(path)) widget.onDrop(path);
+        final item = event.session.items.firstOrNull;
+        if (item == null) return;
+        final reader = item.dataReader;
+        if (reader == null || !reader.canProvide(Formats.fileUri)) return;
+        final c = Completer<String?>();
+        reader.getValue<Uri>(Formats.fileUri,
+            (uri) => c.complete(uri?.toFilePath()),
+            onError: (_) => c.complete(null));
+        final path = await c.future;
+        if (path != null && _isVideoFile(path)) widget.onDrop(path);
       },
       child: MouseRegion(
         onEnter: (_) => setState(() => _hovered = true),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.6.1+16
+version: 1.6.2+17
 
 environment:
   sdk: ^3.11.5
@@ -15,7 +15,6 @@ dependencies:
 
   # File picking & drag-drop
   file_picker: ^8.1.4
-  desktop_drop: ^0.4.4
 
   # Video playback (Windows-native via libmpv)
   media_kit: ^1.1.11
@@ -61,6 +60,7 @@ dependencies:
 
   # Icons
   cupertino_icons: ^1.0.8
+  super_drag_and_drop: ^0.9.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- **Fix drag-and-drop on all pages** — migrated from `desktop_drop` to `super_drag_and_drop`. Root cause: `desktop_drop` calls `RegisterDragDrop` directly on the window HWND, but Flutter 3.3+ already registers its own OLE `IDropTarget` there, causing a silent `DRAGDROP_E_ALREADYREGISTERED` failure. `super_drag_and_drop` hooks into Flutter's internal event system instead, avoiding the conflict entirely.
- **Today-date encode guard** — when the user presses Encode with the date field still at today's default, a confirmation dialog appears asking if they forgot to update it. Accepting proceeds normally; declining lets them edit the date first.
- **Version bumped to 1.6.2+17** on the feature branch (pubspec.yaml + installer.iss)
- **CLAUDE.md updated** — version bump step now explicitly happens on the feature branch before raising the PR

## Test plan
- [ ] Drag a video file onto the Encode page video drop zone → file populates
- [ ] Drag a JPG and SRT onto the Encode page poster/subtitle zones → fields populate
- [ ] Drag an MP4 onto the Decode page drop zone → file populates
- [ ] Drag a video onto the Player page → playback starts
- [ ] Encode with date = today → confirmation dialog appears; "Go back" aborts, "Encode anyway" proceeds
- [ ] Encode with date = any past date → no dialog, proceeds immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)