### PR TITLE
feat: v1.7.0 — migrate to new IMDB API with sheet-first metadata

### DIFF
--- a/MIGRATION_ANALYSIS_v1.7.0.md
+++ b/MIGRATION_ANALYSIS_v1.7.0.md
@@ -1,0 +1,398 @@
+# v1.7.0 — IMDB API Migration Analysis
+
+**Status: APPROVED — implementation in progress on `feat/v1.7.0`.**
+
+`api.imdbapi.dev` (the current metadata source) appears to be dead. Candidate
+replacement: `https://api.balloonerismm.workers.dev` (unofficial Cloudflare
+Worker proxy in front of IMDb's internal GraphQL API — same category of
+service as the one that just died: **not** an official/licensed API, no
+auth, no published SLA or rate limit, could disappear the same way). That
+risk doesn't block the migration (we have no better option right now) but
+it's worth going in with eyes open, and probably worth designing the
+service layer so a *third* swap someday is cheap (see §6).
+
+Everything below is grounded in the actual code (`lib/features/catalog/imdb_service.dart`,
+`lib/features/catalog/models/imdb_data.dart`, the three sheet-schema files, and
+`admin_screen.dart`) and in live test calls to the new API (`tt1375666` /
+Inception, `tt0944947` / Game of Thrones, `tt0944947` S1E1) — not just the
+OpenAPI spec.
+
+---
+
+## 1. Where this touches the app
+
+One file makes all HTTP calls: `ImdbService` (`lib/features/catalog/imdb_service.dart`).
+Everything else — `catalog_notifier.dart`, `series_notifier.dart`,
+`request_notifier.dart`, `admin_screen.dart`, `catalog_card.dart`,
+`settings_screen.dart` — goes through it. That's good: the migration is
+contained to `imdb_service.dart` + `models/imdb_data.dart`, nothing else
+needs to change *structurally*. But the internal shape of `ImdbService`
+needs a real rewrite, not a find-and-replace of the base URL — see §3.
+
+## 2. What doesn't change
+
+- **IDs are compatible.** Both APIs use IMDb's native `tt########` scheme
+  (and the new API's own validation pattern is literally `^tt\d+$`). Every
+  ID already stored in the Sheets (`imdb_id`, `series_imdb_id`,
+  `episode_imdb_id`) stays valid. No ID-mapping/backfill needed.
+- **No auth.** New API has no security scheme — same as today, no key to
+  provision or store.
+- **Existing sheet columns don't need to change.** Per your direction we're
+  now *adding* columns (append-only, backward-compatible) rather than just
+  swapping the data source behind the same ones — see §5.
+- **Poster/image URLs are still full HTTPS URLs** (`m.media-amazon.com`),
+  not relative paths needing a base-URL prefix — confirmed against a live
+  response, not just the schema description.
+
+## 3. What breaks / needs real rework in `ImdbService`
+
+### 3a. No batch endpoint — this is the biggest structural change
+Today, `resolve(ids)` fetches up to 5 IDs per request, 4 requests
+concurrently (`titles:batchGet?titleIds=...`). The new API has **no
+multi-ID endpoint at all** — every title is `GET /movie/{id}` or
+`GET /tv/{id}` individually. A catalog load that today issues, say, 8 batch
+requests for 40 titles would issue **40 individual requests**. `resolve()`
+needs to be rewritten around per-ID fetches with its own concurrency cap
+(and probably a smaller one, to be polite to an unauthenticated free
+Worker) — this is the part of the migration I'd want to load-test against
+the real catalog size before calling it done, since neither API publishes
+a rate limit.
+
+### 3b. The API is no longer type-agnostic — movie vs TV must be known up front
+The old `:batchGet` endpoint took a flat list of IDs and figured out
+movie/series/episode from the response shape (`ImdbData.fromApi` still has
+this logic — parentId/seasonNumber/endYear sniffing). The new API requires
+you to already know the type:
+- Movies-tab IDs → `/movie/{id}`
+- Series-tab IDs → `/tv/{id}`
+- Episode-tab rows → `/tv/{series_imdb_id}/season/{season}/episode/{episode}`
+  (**not** a lookup by the episode's own `tt` id — more below)
+
+The good news: **for every existing bulk-load path this is a non-issue**,
+because the sheet tab you're reading from already tells you the type
+(Movies sheet = movie, Series sheet = series, Episodes sheet = episode row
+with `series_imdb_id`/`season`/`episode` columns already present). No sheet
+schema change needed for this.
+
+The one place it *is* a real gap: **`request_notifier.dart`**'s "paste an
+IMDb URL to request a title" flow. Today it doesn't know or care what type
+the pasted ID is — one `:batchGet` call and `_inferType()` sniffs the
+answer from whatever comes back. With the new API we try `/movie/{id}`,
+fall back to `/tv/{id}` on 404 (2 requests instead of 1, worst case), and
+if a user pastes a link to a **specific episode**
+(`imdb.com/title/tt1480055` — an episode's own page), **neither endpoint
+will resolve it** — the new API only reaches episode data via
+`/tv/{series}/season/{n}/episode/{n}`, which requires already knowing the
+parent series + season + episode number, none of which is recoverable from
+a bare episode `tt` id.
+
+**Decided:** rather than silently falling back to "raw ID as title, type
+guessed as Movie" (today's behavior for *any* unresolvable ID — which
+would be actively misleading here, since it'd tag a real episode link as
+a Movie submission with no warning), a double-404 gets a specific message:
+*"Couldn't find this on IMDb as a movie or TV series — if this links to a
+specific episode, please submit the show's main IMDb page instead."* This
+also covers genuinely invalid/mistyped links with the same honest framing.
+Side benefit: `_inferType()`'s heuristic sniffing (`endYear`/`runtimeSeconds`/
+`parentId` guessing) goes away entirely — type is now known for certain
+from *which* endpoint returned 200, not inferred from response shape.
+
+### 3c. Admin screen's episode-fetch path actually gets *more correct*
+`admin_screen.dart`'s episode mode already collects series ID, season
+number, and episode number as separate form fields (`_seriesImdbCtrl`,
+`_seasonCtrl`, `_episodeCtrl`) — it just doesn't use season/episode in the
+fetch today because the old API didn't need them. Switching
+`_fetchEpisode` to call `/tv/{seriesId}/season/{s}/episode/{e}` is a
+straightforward swap, and is arguably more correct than today's "guess
+from a flat ID lookup" approach. Bonus: the new episode response includes
+the episode's own `id` (confirmed live: `tt1480055` for GoT S1E1), so the
+`episode_imdb_id` sheet field could be auto-filled from the response
+instead of hand-typed — optional, not required.
+
+### 3d. "Stars" (top cast) requires a second call per title — resolved by §5's sheet-first redesign
+The old batch response embedded `stars[].displayName` directly. The new
+`MovieDetail`/`TVDetail` responses **do not include cast** — it's a
+separate `GET /movie/{id}/credits` (confirmed live: 87 cast + 163 crew for
+Inception) or `/tv/{id}/credits` call. `stars` is shown on every catalog
+card, not just in admin (`catalog_card.dart:399-402`), so if every catalog
+load still resolved every title live, this would mean doubling request
+volume for that field alone.
+
+**Superseded by §5.** Per your direction, we're persisting `rating`,
+`runtime`, `certificate`, and `stars` straight into the Sheet at
+admin-entry time instead of re-fetching them on every catalog load. Under
+that model, the `/credits` call happens **once**, when the admin adds the
+title — not once per catalog load per device. See §5 for the full design;
+this subsection is kept for the historical reasoning.
+
+### 3e. Runtime units are inconsistent *within* the new API itself
+Confirmed against live data — this is the one silent-corruption risk if
+missed:
+- `MovieDetail.runtime` is in **minutes** (Inception → `148`, correct as
+  minutes; would be nonsense as seconds).
+- `TVEpisode.runtime` (from the season/episode endpoint) is in **seconds**
+  (GoT S1E1 → `3720` = 62 minutes, correct as seconds; nonsense as
+  minutes).
+- `TVDetail.episode_run_time` (array, typical episode length) is almost
+  certainly minutes like the movie field, not confirmed live.
+
+The app's internal field is named `runtimeSeconds` everywhere
+(`ImdbData`, `CatalogEntry`, `EpisodeEntry`) and is currently populated
+directly from a seconds value. Migration code must convert movie/series
+runtime *×60* but leave episode runtime as-is — easy to get backwards,
+worth an explicit unit test per entity type rather than trusting review
+alone.
+
+### 3f. Field renames / reshapes (mechanical, but exhaustive — see §4)
+`plot`→`overview`, `primaryTitle`→`title` (movies) / `name` (TV),
+`primaryImage.url`→`poster_path`, `rating.aggregateRating`→`vote_average`,
+`rating.voteCount`→`vote_count`, `genres[]` (strings)→`genres[].name`
+(objects, but `id == name` in this API so no lookup table needed),
+`releaseDate.{year,month,day}`/`startYear` (two shapes)→`release_date`
+(single ISO date string, actually simpler), `certificates[]` (list,
+picks `country=='US'`)→`certificate` (single object `{rating, body}`,
+already US-equivalent — confirmed live: Inception → `{"rating":"PG-13","body":"MPAA"}`,
+so the country-preference loop goes away entirely), `endYear`
+(direct field, movies/series)→**not present**; must be derived as
+`in_production ? null : year(last_air_date)` for series, N/A for movies.
+
+### 3g. Image fetching loses pagination, gains categorization
+Old: `/titles/{id}/images?pageSize=&pageToken=` — flat list, paginated,
+used by both the catalog-card carousel (`fetchImages`, 4 images, cached)
+and admin's "load more" tool (`fetchImagesUncached`, paginated).
+New: `/movie/{id}/images` (or `/tv/{id}/images`) — returns **everything in
+one response**, split into `posters[]` / `backdrops[]` / `logos[]` /
+`stills[]` (confirmed live: 1 poster + 46 stills for Inception in a single
+call; movie images has no backdrops/logos populated per the API's own
+description — "IMDb doesn't separate backdrops or logos as distinct
+categories — all non-poster art is returned in stills"). This actually
+simplifies the cached `fetchImages` path (one call, no pagination to
+manage) but the admin "load more" button and `nextPageToken` plumbing in
+`fetchImagesUncached` becomes dead code — the equivalent new behavior is
+"fetch once, client-side-paginate through the array you already have."
+
+## 4. Field mapping reference
+
+| Current (`ImdbData` / old API) | New API field | Notes |
+|---|---|---|
+| `id` | `id` | unchanged, same `tt` scheme |
+| `title` (`primaryTitle`) | `title` (movie) / `name` (TV) | key rename, differs by type |
+| `plot` | `overview` | rename |
+| `genres[]` (string) | `genres[].name` | object now, but `id==name`, so `.map((g) => g.name)` is a drop-in |
+| `posterUrl` (`primaryImage.url`) | `poster_path` | still a full HTTPS URL |
+| `releaseDate` (object or bare year) | `release_date` (movie) / `first_air_date` (TV) | now a single ISO date string — simpler |
+| `rating` (`rating.aggregateRating`) | `vote_average` | rename |
+| `voteCount` (`rating.voteCount`) | `vote_count` | rename |
+| `runtimeSeconds` | `runtime` (movie, **minutes** — ×60) / episode `runtime` (**seconds**, direct) | unit mismatch, see §3e |
+| `stars[]` | not in detail response — `GET /{type}/{id}/credits` → `cast[].name` (ordered by `order`) | extra call, see §3d |
+| `certificate` (loop over `certificates[]` for `country=='US'`) | `certificate.rating` | now a single object, no loop needed |
+| `endYear` | not present — derive from `!in_production ? null : year(last_air_date)` | TV only |
+| `seasonNumber` / `episodeNumber` | `season_number` / `episode_number` (from the season/episode endpoint response) | only reachable via the nested episode endpoint |
+| `parentId` | not returned — already known from the request path (`series_imdb_id`) | no longer needs sniffing |
+
+## 5. Google Sheets impact — revised: sheet-first, API-once
+
+**Direction from you:** push as much IMDB-derived data as possible into
+the Sheet itself at admin-entry time, so the live app calls the API as
+close to zero times as possible during normal catalog browsing. This
+changes the plan from "same columns, new source" to "new columns +
+new merge behavior," so I'm laying it out in full for review.
+
+### 5a. Why this works, and what it doesn't fix
+
+Two things line up in our favor:
+
+1. **The merge pattern already exists — it's just not applied consistently.**
+   `CatalogEntry.mergeImdb()` already does "sheet value wins if present,
+   API only fills what's blank" for `title`/`date`/`genres`/`plot`/`thumbnailUrl`
+   (`catalog_entry.dart:127-145`). It just currently makes an exception for
+   `rating`/`voteCount`/`runtimeSeconds`/`stars`/`certificate` — those five
+   are unconditionally overwritten by the API every load because there's
+   nowhere to read a sheet value from today. Adding sheet columns for them
+   and applying the *same* pattern is a small, consistent change, not a new
+   pattern.
+2. **Two of the three sheets already half-did this and it got lost.**
+   `series_sheet_schema.dart` already has a `rating` column (idx 6) —
+   but `series_notifier.dart`'s `_buildEntries()` never reads it back
+   (no `sc(row, ['rating'])` call anywhere in that method), so it's
+   currently a dead column: written by admin, ignored on load, silently
+   clobbered by the live API value in `withImdb()`. Same story for
+   Episodes' `rating` (idx 8) — it *is* read into `EpisodeEntry.imdbRating`
+   at parse time (`series_notifier.dart:240,255`), but then unconditionally
+   overwritten a few lines later in the enrichment step (`:331`) regardless
+   of whether the sheet already had a value. Both are existing bugs this
+   change fixes as a side effect.
+
+What this **doesn't** eliminate: the admin "add new title" flow still
+needs to call the API at least once per title (that's the one-time cost
+you're asking for), the "request new title" validation flow still needs a
+lookup to show a preview, and any row where the admin leaves an optional
+column blank still falls back to a live fetch, same safety net as today.
+It also doesn't change §3g (images) — `slide_images` already persists a
+curated set of poster/still URLs to the sheet and always has; no change
+needed there.
+
+### 5b. Proposed new columns
+
+Appended at the **end** of each tab, not inserted in the middle — the TSV
+schemas are strictly positional (`parseTsv`/`buildTsv` in each
+`*_sheet_schema.dart`), and inserting mid-row would require you to
+manually reorder columns in the live Google Sheet to match. Appending is
+purely additive: `parseTsv` already pads short rows with `''` up to
+`columnCount`, so existing rows read fine with the new columns simply
+blank until backfilled, and the read path (`CatalogEntry.fromRow`, and
+`series_notifier.dart`'s header-alias lookups) matches by **header name**,
+not position, so column order in your actual spreadsheet doesn't need to
+match the moment you add the header text.
+
+**⚠️ You'll need to manually add the new header names to row 1 of your
+live Sheet(s)** — the app reads a published CSV export, it can't create
+columns for you.
+
+**Movies** (`sheet_schema.dart`) — currently 13 columns, would become 17:
+
+| New column | Source (new API) | Format | Example |
+|---|---|---|---|
+| `rating` | `vote_average` | 1dp decimal | `8.8` |
+| `runtime_min` | `runtime` (movie endpoint — already minutes) | integer | `148` |
+| `certificate` | `certificate.rating` | string | `PG-13` |
+| `stars` | `GET /movie/{id}/credits` → `cast[].name`, top 3 by `order` | comma-space joined | `Leonardo DiCaprio, Joseph Gordon-Levitt, Elliot Page` |
+
+**Series** (`series_sheet_schema.dart`) — `rating` already exists (fix the
+dead-read bug, no new column); currently 10 columns, would become 12:
+
+| Column | Status | Source | Format |
+|---|---|---|---|
+| `rating` | *existing, currently unread* | `vote_average` | 1dp decimal |
+| `certificate` | new | `certificate.rating` | string |
+| `stars` | new | `GET /tv/{id}/credits` → `cast[].name`, top 3 | comma-space joined |
+
+**Episodes** (`episode_sheet_schema.dart`) — `rating` already exists (fix
+the clobber bug, no new column); currently 14 columns, would become 15:
+
+| Column | Status | Source | Format |
+|---|---|---|---|
+| `rating` | *existing, currently clobbered* | `vote_average` | 1dp decimal |
+| `runtime_min` | new | episode `runtime` (**seconds** — ÷60 at write time) | integer |
+
+**Decided:** `vote_count` stays out entirely (unused in UI today, would be
+dead weight). Series/Episodes' `certificate`/`stars` will get matching UI
+additions — `series_card.dart` and the series/episode detail screens gain
+the same certificate/stars display Movies' `catalog_card.dart` already
+has, once the columns exist. `stars` still not proposed for Episodes by
+default — guest cast varies per-episode and is a weaker signal than
+movie/series leads; easy to add later if wanted.
+
+### 5c. Merge-logic change
+
+Extend the existing "sheet wins, API fills blanks" pattern
+(`catalog_entry.dart:127-145`) to the five previously-API-only fields, and
+fix the two dead/clobbered `rating` reads in `series_notifier.dart`. In
+`catalog_notifier.dart`/`series_notifier.dart`, the `resolve()` call
+becomes conditional: only IDs whose sheet row is **missing one of the new
+columns** get queued for a live fetch; a fully-backfilled row skips the
+network entirely. This is incremental, not a one-time migration — old rows
+keep working exactly as they do today (live-fetched) until you re-save
+them through the admin screen with the new fields populated; there's no
+bulk backfill step required to ship this.
+
+Net effect once most rows are backfilled: normal catalog/series browsing
+on any device makes **zero** IMDB API calls for existing entries. The API
+is only touched when: (a) the admin adds a brand-new title, (b) a sheet
+row is missing one of these fields and the fallback kicks in, or (c) a
+user pastes an IMDb URL into "Request new title" for validation/preview.
+
+### 5d. Effect on §3a's concurrency/rate-limit concern
+
+Substantially de-risked. §3a's worry was every device issuing N individual
+requests on every cold catalog load. Under the sheet-first model, that
+only happens for genuinely incomplete rows — a normal load of a fully
+backfilled catalog issues **zero** metadata requests, only image URLs
+already sitting in `slide_images`/`poster_url`/`thumbnail_url`. The
+per-ID concurrency cap from §3a is still needed (for the admin flow, the
+fallback path, and the initial backfill period), just no longer sized for
+"the whole catalog, every load."
+
+## 6. Error handling / resilience
+
+Today: every failure (timeout, non-200, exception) is silently swallowed
+in `ImdbService`, no retries, cache-first with a 30-day TTL, callers
+degrade gracefully to sheet-only data. That pattern carries over cleanly,
+and §5 makes it matter less in practice — a live-fetch failure now only
+affects rows that haven't been backfilled yet, not the whole catalog.
+Still worth adding:
+- A concurrency cap tuned for "many individual requests" rather than
+  reusing the old "batches of 5, 4 at once" constant, which no longer
+  means anything.
+- Since this is an unofficial proxy with a documented `502` response for
+  "Upstream IMDb GraphQL error" (i.e., it has its own upstream fragility
+  baked into the spec), the existing swallow-and-degrade behavior is
+  probably still the right call rather than adding retry logic — but it
+  does mean transient 502s will look identical to "this title doesn't
+  exist" from the app's point of view, same as today.
+
+## 7. No tests currently cover this
+
+`test/core_test.dart` only tests CSV row parsing (`CatalogEntry.fromRow`),
+never `ImdbService` or `ImdbData.fromApi`. No HTTP mocking exists in the
+project. Recommend adding a couple of focused unit tests for
+`ImdbData.fromApi` against fixed fixtures (using the live samples pulled
+during this analysis) specifically covering §3e's unit conversion, since
+that's the one change that fails silently (wrong number, not a crash) if
+gotten wrong — everything else in a migration like this tends to fail
+loudly (null/type errors) and gets caught in manual testing.
+
+## 8. Suggested scope for this release
+
+1. Rewrite `ImdbService` internals: per-ID fetch with concurrency cap,
+   type-aware endpoint selection (movie/tv/tv-episode), drop the
+   batch/pageToken plumbing.
+2. Rewrite `ImdbData.fromApi` for the new field names + unit conversions
+   (§4), keep `fromJson`/`toJson` (disk cache format) unchanged so
+   existing caches don't need a version bump — new fetches just repopulate
+   the same on-disk shape.
+3. Add the `stars` field to `ImdbData` sourced from `/credits`, fetched
+   once by the admin screen when building a row (§5b/§5c) — no longer a
+   per-catalog-load concern.
+4. Add the new columns from §5b to `sheet_schema.dart`,
+   `series_sheet_schema.dart`, `episode_sheet_schema.dart` (append-only,
+   bump each `columnCount`); update `admin_screen.dart`'s
+   `_rowValues`/`_seriesRowValues`/`_episodeRowValues` to populate them;
+   add `certificate`/`stars` display to `series_card.dart` and the
+   series/episode detail screens, matching `catalog_card.dart`'s existing
+   pills.
+5. Fix the two dead/clobbered `rating` reads in `series_notifier.dart`
+   and extend the "sheet wins, API fills blanks" pattern
+   (`catalog_entry.dart:127-145`) to `rating`/`runtime`/`certificate`/`stars`
+   everywhere; make `resolve()` calls conditional on missing fields (§5c).
+6. Update `admin_screen.dart`'s episode fetch to use
+   `series + season + episode` instead of a flat episode-ID lookup (§3c);
+   simplify/remove the "load more images" pagination UI (§3g).
+7. Update `request_notifier.dart`'s type inference to try
+   `/movie/{id}` → `/tv/{id}` and decide how to message unresolvable
+   episode-URL submissions (§3b).
+8. Add the unit tests from §7, at minimum for runtime conversion and the
+   new sheet-wins merge behavior.
+9. Manually re-test the full golden path per `CLAUDE.md`'s UI-testing
+   requirement: catalog load (movies + series + episodes) with a
+   backfilled row (should make no API call) and a non-backfilled row
+   (should fall back correctly), admin fetch/paste flow for all three
+   modes, "request new title" for a movie, a series, and (to confirm the
+   documented gap) an episode URL.
+
+**Sheet schema changes required** (opt-in, backward-compatible, append-only
+— see §5b for exact columns).
+
+---
+
+**Resolved:**
+- Series/Episodes get matching `certificate`/`stars` UI, not just storage.
+- `vote_count` stays out of the schema entirely.
+- §3b: double-404 (movie + tv) gets an explicit "couldn't find this as a
+  movie or TV series — if it's an episode link, submit the series page
+  instead" message rather than a silent guessed-type fallback.
+- No fallback data source for now — accepted risk of depending on a
+  single unofficial proxy; service layer will still be reasonably
+  contained to `imdb_service.dart` if a future swap is ever needed.
+
+**Status: plan approved — starting implementation on `feat/v1.7.0`.**

--- a/columns.txt
+++ b/columns.txt
@@ -1,0 +1,35 @@
+New columns for v1.7.0 — paste into the first empty cell after your last
+existing header (columns are append-only, don't reorder existing ones).
+
+=============================================================================
+Movies tab — existing headers end at column M (slide_images).
+Click cell N1 and paste this row:
+=============================================================================
+rating	runtime_min	certificate	stars
+
+=============================================================================
+Series tab — existing headers end at column J (show).
+(rating already exists at column G — nothing to do there, just add these two.)
+Click cell K1 and paste this row:
+=============================================================================
+certificate	stars
+
+=============================================================================
+Episodes tab — existing headers end at column N (show).
+(rating already exists at column I — nothing to do there.)
+Click cell O1 and paste this row:
+=============================================================================
+runtime_min
+
+-----------------------------------------------------------------------------
+Full header rows, for reference / if you're setting up a tab from scratch:
+-----------------------------------------------------------------------------
+
+Movies
+title	imdb_id	date	video_url	poster_url	size_mb	language	plot	genres	tags	encoded	show	slide_images	rating	runtime_min	certificate	stars
+
+Series
+series_imdb_id	title	start_year	end_year	poster_url	plot	rating	genres	tags	show	certificate	stars
+
+Episodes
+episode_imdb_id	series_imdb_id	season	episode	title	air_date	thumbnail_url	plot	rating	video_url	size_mb	language	encoded	show	runtime_min

--- a/docs/sheet_schema.txt
+++ b/docs/sheet_schema.txt
@@ -1,8 +1,8 @@
 Movies
-title	imdb_id	date	video_url	poster_url	size_mb	language	plot	genres	tags	encoded	show	slide_images
+title	imdb_id	date	video_url	poster_url	size_mb	language	plot	genres	tags	encoded	show	slide_images	rating	runtime_min	certificate	stars
 
 Series
-series_imdb_id	title	start_year	end_year	poster_url	plot	rating	genres	tags	show
+series_imdb_id	title	start_year	end_year	poster_url	plot	rating	genres	tags	show	certificate	stars
 
 Episodes
-episode_imdb_id	series_imdb_id	season	episode	title	air_date	thumbnail_url	plot	rating	video_url	size_mb	language	encoded	show
+episode_imdb_id	series_imdb_id	season	episode	title	air_date	thumbnail_url	plot	rating	video_url	size_mb	language	encoded	show	runtime_min

--- a/installer.iss
+++ b/installer.iss
@@ -7,7 +7,7 @@
 ; Output: installer\mStorage_Setup.exe
 
 #define AppName        "mStorage"
-#define AppVersion     "1.6.3"
+#define AppVersion     "1.7.0"
 #define AppPublisher   "Seshu Tarapatla"
 #define AppURL         "https://github.com/SeshuTarapatla/mStorage"
 #define AppExeName     "m_storage.exe"

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -75,9 +75,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
   // Positions 0-3 are slide_images (amber star); 4+ are cyan border.
   List<String> _selected = [];
 
-  // Cursor for the next images page; null = no more pages available.
-  String? _nextPageToken;
-  // True while a "Load more" or paste-enrichment API call is in flight.
+  // True while a paste-enrichment API call is in flight.
   bool _loadingMore = false;
 
   // Brief highlight on pool image tap; auto-clears after 200 ms.
@@ -206,16 +204,13 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
     _imdbIdCtrl.text = imdbId;
     setState(() { _fetching = true; _error = null; _data = null; });
 
-    final results = await ImdbService().resolve([imdbId]);
+    // Type is unknown ahead of time for a pasted request — resolve tries
+    // /movie then /tv and tells us definitively which one matched.
+    final results = await ImdbService().resolveUnknown([imdbId]);
     if (!mounted) return;
 
     final data = results[imdbId];
-    // Detect series: ended series have endYear; ongoing series typically lack
-    // runtimeSeconds (episodes have per-ep runtime, not a single feature length).
-    final isSeries = data != null &&
-        data.parentId == null &&
-        data.seasonNumber == null &&
-        (data.endYear != null || data.runtimeSeconds == null);
+    final isSeries = data?.kind == ImdbKind.tv;
 
     _setMode(isSeries ? _AdminMode.series : _AdminMode.movie);
     _imdbIdCtrl.text = imdbId;
@@ -246,21 +241,20 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       _encoded = true; _show = true;
     });
     try {
-      final results = await ImdbService().resolve([id]);
+      final results = await ImdbService().resolve([id], ImdbKind.movie);
       final data = results[id];
       if (!mounted) return;
       if (data == null) {
         setState(() { _error = 'No data found for "$id".'; _fetching = false; });
         return;
       }
-      final page1 = await ImdbService().fetchImagesUncached(id);
+      final images = await ImdbService().fetchAllImages(id, ImdbKind.movie);
       if (!mounted) return;
       setState(() {
         _data = data;
         _genres = List<String>.from(data.genres);
-        _allImages = page1.images;
-        _selected = page1.images.take(4).toList();
-        _nextPageToken = page1.nextPageToken;
+        _allImages = images;
+        _selected = images.take(4).toList();
         _selectedYear  = data.releaseDate?.year;
         _selectedMonth = data.releaseDate?.month ?? 1;
         _selectedDay   = data.releaseDate?.day   ?? 1;
@@ -277,7 +271,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       _genres = []; _tags = [];
     });
     try {
-      final results = await ImdbService().resolve([id]);
+      final results = await ImdbService().resolve([id], ImdbKind.tv);
       if (!mounted) return;
       final data = results[id];
       if (data == null) {
@@ -299,30 +293,50 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       setState(() => _error = 'Series IMDB ID is required.');
       return;
     }
+    final season  = int.tryParse(_seasonCtrl.text.trim());
+    final episode = int.tryParse(_episodeCtrl.text.trim());
+    if (season == null || episode == null) {
+      setState(() => _error = 'Season and episode number are required.');
+      return;
+    }
     setState(() {
       _fetching = true; _error = null; _data = null; _episodeData = null;
       _videoUrlCtrl.clear(); _languageCtrl.clear(); _sizeMbCtrl.clear();
       _encoded = true; _show = true;
     });
     try {
-      final ids = <String>[seriesId];
-      if (episodeId.isNotEmpty) ids.add(episodeId);
-      final results = await ImdbService().resolve(ids);
+      final results = await Future.wait([
+        ImdbService().resolve([seriesId], ImdbKind.tv),
+        ImdbService().resolveEpisode(
+          episodeImdbId: episodeId,
+          seriesId: seriesId,
+          season: season,
+          episode: episode,
+        ),
+      ]);
       if (!mounted) return;
-      final seriesData = results[seriesId];
+      final seriesData = (results[0] as Map<String, ImdbData>)[seriesId];
       if (seriesData == null) {
         setState(() { _error = 'No series data for "$seriesId".'; _fetching = false; });
         return;
       }
-      final epData = episodeId.isNotEmpty ? results[episodeId] : null;
-      if (episodeId.isNotEmpty && epData == null) {
-        setState(() { _error = 'No episode data for "$episodeId".'; _fetching = false; });
+      final epData = results[1] as ImdbData?;
+      if (epData == null) {
+        setState(() {
+          _error = 'No episode data for S${season}E$episode of "$seriesId".';
+          _fetching = false;
+        });
         return;
       }
       setState(() {
         _data        = seriesData;
         _episodeData = epData;
-        _selectedYear  = epData?.releaseDate?.year;
+        // The episode's own tt id is exposed in the response — auto-fill it
+        // if the admin hasn't already typed one in.
+        if (episodeId.isEmpty && epData.id.isNotEmpty) {
+          _imdbIdCtrl.text = epData.id;
+        }
+        _selectedYear  = epData.releaseDate?.year;
         _selectedMonth = 1;
         _selectedDay   = 1;
         _fetching = false;
@@ -331,27 +345,6 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       if (mounted) setState(() { _error = e.toString(); _fetching = false; });
     }
   }
-
-  Future<void> _loadMoreImages() async {
-    final id = _imdbIdCtrl.text.trim();
-    if (id.isEmpty || _loadingMore || _nextPageToken == null) return;
-    final token = _nextPageToken!;
-    setState(() => _loadingMore = true);
-    try {
-      final next = await ImdbService().fetchImagesUncached(id, pageToken: token);
-      if (!mounted) return;
-      final existing = _allImages.toSet();
-      final fresh = next.images.where((u) => !existing.contains(u)).toList();
-      setState(() {
-        _allImages = [..._allImages, ...fresh];
-        _nextPageToken = next.nextPageToken;
-        _loadingMore = false;
-      });
-    } catch (_) {
-      if (mounted) setState(() => _loadingMore = false);
-    }
-  }
-
 
   // ── Clipboard paste ───────────────────────────────────────────────────────
 
@@ -377,15 +370,18 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
 
     final tabCols = text.split('\t');
 
-    // Case 2a: Series TSV (10 cols) in series mode.
+    // Case 2a: Series TSV in series mode.
     if (_mode == _AdminMode.series && tabCols.length >= SeriesSheetSchema.columnCount) {
       final sc = SeriesSheetSchema.parseTsv(text);
       final genresRaw = sc[SeriesSheetSchema.iGenres];
       final tagsRaw   = sc[SeriesSheetSchema.iTags];
+      final starsRaw  = sc[SeriesSheetSchema.iStars];
       final genres = genresRaw.isEmpty ? <String>[] : genresRaw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
       final tags   = tagsRaw.isEmpty   ? <String>[] : tagsRaw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+      final stars  = starsRaw.isEmpty  ? <String>[] : starsRaw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
       final startYear = int.tryParse(sc[SeriesSheetSchema.iStartYear]);
       final seriesId  = sc[SeriesSheetSchema.iSeriesImdbId];
+      final certRaw   = sc[SeriesSheetSchema.iCertificate];
 
       setState(() {
         _imdbIdCtrl.text = seriesId;
@@ -400,7 +396,9 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
           releaseDate: startYear != null ? DateTime(startYear) : null,
           posterUrl: sc[SeriesSheetSchema.iPosterUrl],
           rating: double.tryParse(sc[SeriesSheetSchema.iRating]),
-          voteCount: null, runtimeSeconds: null, stars: const [], certificate: null,
+          voteCount: null, runtimeSeconds: null,
+          stars: stars,
+          certificate: certRaw.isEmpty ? null : certRaw,
           endYear: int.tryParse(sc[SeriesSheetSchema.iEndYear]),
         );
         _loadingMore = seriesId.isNotEmpty;
@@ -408,10 +406,10 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
         _error       = null;
       });
 
-      // Enrich from API in background
+      // Enrich from API in background — pasted values win, API fills gaps.
       if (seriesId.isEmpty) return;
       try {
-        final results = await ImdbService().resolve([seriesId]);
+        final results = await ImdbService().resolve([seriesId], ImdbKind.tv);
         if (!mounted) return;
         final meta = results[seriesId];
         if (meta == null) { setState(() => _loadingMore = false); return; }
@@ -424,9 +422,11 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
             genres: pasted.genres.isNotEmpty ? pasted.genres : List<String>.from(meta.genres),
             releaseDate: meta.releaseDate ?? pasted.releaseDate,
             posterUrl: pasted.posterUrl.isNotEmpty ? pasted.posterUrl : meta.posterUrl,
-            rating: meta.rating, voteCount: meta.voteCount,
+            rating: pasted.rating ?? meta.rating,
+            voteCount: meta.voteCount,
             runtimeSeconds: meta.runtimeSeconds,
-            stars: meta.stars, certificate: meta.certificate,
+            stars: pasted.stars.isNotEmpty ? pasted.stars : meta.stars,
+            certificate: pasted.certificate ?? meta.certificate,
             endYear: meta.endYear ?? pasted.endYear,
           );
           _genres      = _data!.genres;
@@ -438,11 +438,12 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       return;
     }
 
-    // Case 2b: Episode TSV (14 cols) in episode mode.
+    // Case 2b: Episode TSV in episode mode.
     if (_mode == _AdminMode.episode && tabCols.length >= EpisodeSheetSchema.columnCount) {
       final ec     = EpisodeSheetSchema.parseTsv(text);
       final epDate = DateTime.tryParse(ec[EpisodeSheetSchema.iAirDate]);
       final seriesId = ec[EpisodeSheetSchema.iSeriesImdbId];
+      final runtimeMin = int.tryParse(ec[EpisodeSheetSchema.iRuntimeMin]);
 
       setState(() {
         _imdbIdCtrl.text     = ec[EpisodeSheetSchema.iEpisodeImdbId];
@@ -466,7 +467,9 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                 releaseDate: epDate,
                 posterUrl: ec[EpisodeSheetSchema.iThumbnailUrl],
                 rating: double.tryParse(ec[EpisodeSheetSchema.iRating]),
-                voteCount: null, runtimeSeconds: null, stars: const [], certificate: null,
+                voteCount: null,
+                runtimeSeconds: runtimeMin != null ? runtimeMin * 60 : null,
+                stars: const [], certificate: null,
               )
             : null;
         // Minimal series placeholder so form renders; enriched below.
@@ -475,7 +478,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
           releaseDate: null, posterUrl: '', rating: null,
           voteCount: null, runtimeSeconds: null, stars: const [], certificate: null,
         );
-        _allImages = []; _selected = []; _nextPageToken = null;
+        _allImages = []; _selected = [];
         _loadingMore = seriesId.isNotEmpty;
         _fetching    = false;
         _error       = null;
@@ -484,7 +487,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       // Enrich series context from API in background
       if (seriesId.isEmpty) return;
       try {
-        final results = await ImdbService().resolve([seriesId]);
+        final results = await ImdbService().resolve([seriesId], ImdbKind.tv);
         if (!mounted) return;
         final meta = results[seriesId];
         if (meta == null) { setState(() => _loadingMore = false); return; }
@@ -511,6 +514,10 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
     final encodedRaw = cols[SheetSchema.iEncoded].toLowerCase();
     final showRaw    = cols[SheetSchema.iShow].toLowerCase();
     final slidesRaw  = cols[SheetSchema.iSlideImages];
+    final ratingRaw  = cols[SheetSchema.iRating];
+    final runtimeMin = int.tryParse(cols[SheetSchema.iRuntimeMin]);
+    final certRaw    = cols[SheetSchema.iCertificate];
+    final starsRaw   = cols[SheetSchema.iStars];
 
     final genres = genresRaw.isEmpty
         ? <String>[]
@@ -518,6 +525,9 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
     final tags = tagsRaw.isEmpty
         ? <String>[]
         : tagsRaw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+    final stars = starsRaw.isEmpty
+        ? <String>[]
+        : starsRaw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
     // sheet order (pos 1 first); queue needs newest-first so reverse later
     final slideImages = slidesRaw.isEmpty
         ? <String>[]
@@ -541,12 +551,13 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       _data   = ImdbData(
         id: imdbId, title: title, plot: plot, genres: genres,
         releaseDate: date, posterUrl: posterUrl,
-        rating: null, voteCount: null, runtimeSeconds: null,
-        stars: const [], certificate: null,
+        rating: double.tryParse(ratingRaw), voteCount: null,
+        runtimeSeconds: runtimeMin != null ? runtimeMin * 60 : null,
+        stars: stars,
+        certificate: certRaw.isEmpty ? null : certRaw,
       );
       _allImages     = List<String>.from(slideImages);
       _selected      = List<String>.from(slideImages);
-      _nextPageToken = null;
       // _loadingMore spinner shows while we enrich from API below
       _loadingMore   = imdbId.isNotEmpty;
       _fetching     = false;
@@ -558,14 +569,13 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
     // Enrich: fetch metadata + fresh images in parallel; clipboard wins on conflicts.
     try {
       final results = await Future.wait([
-        ImdbService().resolve([imdbId]),
-        ImdbService().fetchImagesUncached(imdbId),
+        ImdbService().resolve([imdbId], ImdbKind.movie),
+        ImdbService().fetchAllImages(imdbId, ImdbKind.movie),
       ]);
       if (!mounted) return;
 
       final meta    = (results[0] as Map<String, ImdbData>)[imdbId];
-      final page1   = results[1] as ({List<String> images, String? nextPageToken});
-      final apiImgs = page1.images;
+      final apiImgs = results[1] as List<String>;
 
       // Clipboard values take priority; API fills any gaps.
       final mergedPosterUrl = posterUrl.isNotEmpty ? posterUrl : (meta?.posterUrl ?? '');
@@ -573,6 +583,8 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       final mergedGenres    = genres.isNotEmpty    ? genres    : List<String>.from(meta?.genres ?? []);
       final mergedDate      = date ?? meta?.releaseDate;
       final mergedTitle     = title.isNotEmpty     ? title     : (meta?.title ?? '');
+      final pastedRating    = double.tryParse(ratingRaw);
+      final pastedRuntimeSeconds = runtimeMin != null ? runtimeMin * 60 : null;
 
       // Image pool: API images first, then any pasted slides not already in pool.
       final apiSet     = apiImgs.toSet();
@@ -583,9 +595,10 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
         _data = ImdbData(
           id: imdbId, title: mergedTitle, plot: mergedPlot,
           genres: mergedGenres, releaseDate: mergedDate, posterUrl: mergedPosterUrl,
-          rating: meta?.rating, voteCount: meta?.voteCount,
-          runtimeSeconds: meta?.runtimeSeconds,
-          stars: meta?.stars ?? const [], certificate: meta?.certificate,
+          rating: pastedRating ?? meta?.rating, voteCount: meta?.voteCount,
+          runtimeSeconds: pastedRuntimeSeconds ?? meta?.runtimeSeconds,
+          stars: stars.isNotEmpty ? stars : (meta?.stars ?? const []),
+          certificate: certRaw.isNotEmpty ? certRaw : meta?.certificate,
         );
         _genres        = mergedGenres;
         _selectedYear  = mergedDate?.year  ?? _selectedYear;
@@ -593,7 +606,6 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
         _selectedDay   = mergedDate?.day   ?? _selectedDay;
         _allImages     = mergedImages;
         _selected      = List<String>.from(slideImages);
-        _nextPageToken = page1.nextPageToken;
         _loadingMore   = false;
       });
     } catch (_) {
@@ -1535,35 +1547,21 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                         delay: Duration(milliseconds: min(poolIdx, 8) * 25))
                     .slideY(begin: 0.05, duration: 250.ms, curve: Curves.easeOut);
               }),
-              // Load more
-              if (_nextPageToken != null || _loadingMore)
-                GestureDetector(
-                  onTap: _loadingMore ? null : _loadMoreImages,
-                  child: MouseRegion(
-                    cursor: _loadingMore ? SystemMouseCursors.basic : SystemMouseCursors.click,
-                    child: AnimatedContainer(
-                      duration: const Duration(milliseconds: 150),
-                      width: 110, height: 82,
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(7),
-                        border: Border.all(color: kBorderColor),
-                        color: kSurface2Color,
-                      ),
-                      child: _loadingMore
-                          ? Center(child: SizedBox(
-                              width: 20, height: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2, color: _adminPalette.primary),
-                            ))
-                          : Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Icon(Icons.add_circle_outline_rounded, size: 22, color: kTextSecondary),
-                                const SizedBox(height: 4),
-                                Text('Load more', style: TextStyle(fontSize: 10, color: kTextSecondary)),
-                              ],
-                            ),
-                    ),
+              // Enrichment in progress (paste flow fetches metadata + the
+              // full image set in the background) — the API returns every
+              // image in one response now, so there's no "load more" step.
+              if (_loadingMore)
+                Container(
+                  width: 110, height: 82,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(7),
+                    border: Border.all(color: kBorderColor),
+                    color: kSurface2Color,
                   ),
+                  child: Center(child: SizedBox(
+                    width: 20, height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2, color: _adminPalette.primary),
+                  )),
                 ),
             ],
           ),
@@ -1644,10 +1642,16 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                               fontSize: 11, color: kTextSecondary),
                         ),
                       ],
-                      if (_episodeData!.rating != null) ...[
+                      if (_episodeData!.rating != null ||
+                          _episodeData!.runtimeSeconds != null) ...[
                         const SizedBox(height: 2),
                         Text(
-                          '★ ${_episodeData!.rating!.toStringAsFixed(1)}',
+                          [
+                            if (_episodeData!.rating != null)
+                              '★ ${_episodeData!.rating!.toStringAsFixed(1)}',
+                            if (_episodeData!.runtimeSeconds != null)
+                              _fmtRuntime(_episodeData!.runtimeSeconds!),
+                          ].join('   '),
                           style: const TextStyle(
                               fontSize: 11, color: Color(0xFFF5C518)),
                         ),
@@ -1682,6 +1686,8 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       _genres.join(', '),                         // genres
       _tags.join(', '),                           // tags
       _show ? 'TRUE' : 'FALSE',                   // show
+      d.certificate ?? '',                        // certificate
+      d.stars.join(', '),                         // stars
     ];
   }
 
@@ -1702,6 +1708,9 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       _languageCtrl.text.trim(),                  // language
       _encoded ? 'TRUE' : 'FALSE',                // encoded
       _show    ? 'TRUE' : 'FALSE',                // show
+      ep.runtimeSeconds != null
+          ? (ep.runtimeSeconds! ~/ 60).toString()
+          : '',                                    // runtime_min
     ];
   }
 
@@ -1863,6 +1872,12 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
       _encoded ? 'TRUE' : 'FALSE',
       _show    ? 'TRUE' : 'FALSE',
       _selected.take(4).join(', '),
+      data.rating?.toStringAsFixed(1) ?? '',
+      data.runtimeSeconds != null
+          ? (data.runtimeSeconds! ~/ 60).toString()
+          : '',
+      data.certificate ?? '',
+      data.stars.join(', '),
     ];
   }
 
@@ -2472,11 +2487,8 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
       RegExp(r'/spreadsheets/d/([a-zA-Z0-9_-]+)');
 
   static String _inferType(ImdbData? data) {
-    if (data == null) return 'Movie';
-    if (data.parentId != null || data.seasonNumber != null) return 'Episode';
-    if (data.endYear != null) return 'Series';
-    if (data.runtimeSeconds == null) return 'Series';
-    return 'Movie';
+    if (data == null) return 'Unknown';
+    return data.kind == ImdbKind.tv ? 'Series' : 'Movie';
   }
 
   @override
@@ -2554,7 +2566,7 @@ class _AdminRequestsPanelState extends ConsumerState<_AdminRequestsPanel> {
       final ids = rawRows.map((r) => r.imdbId).toSet().toList();
       final imdbMap = ids.isEmpty
           ? <String, ImdbData>{}
-          : await ImdbService().resolve(ids);
+          : await ImdbService().resolveUnknown(ids);
 
       final parsed = rawRows.map((r) {
         final data = imdbMap[r.imdbId];

--- a/lib/features/catalog/catalog_notifier.dart
+++ b/lib/features/catalog/catalog_notifier.dart
@@ -11,6 +11,7 @@ import '../../core/services/catalog_cache_manager.dart';
 import '../../core/services/settings_service.dart';
 import 'imdb_service.dart';
 import 'models/catalog_entry.dart';
+import 'models/imdb_data.dart';
 
 const _prefKey = 'catalog_sheet_url';
 
@@ -168,16 +169,19 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
         .toList();
   }
 
-  /// Merges IMDB metadata into [raw] entries. Makes network calls for uncached IDs.
+  /// Merges IMDB metadata into [raw] entries. Only rows still missing one
+  /// of the sheet-persisted IMDB fields (rating/runtime/certificate/stars/
+  /// etc.) trigger a network call — a fully backfilled row never touches
+  /// the API.
   Future<List<CatalogEntry>> _mergeImdb(List<CatalogEntry> raw) async {
     final imdbIds = raw
-        .where((e) => e.imdbId.isNotEmpty)
+        .where((e) => e.imdbId.isNotEmpty && e.needsImdbFetch)
         .map((e) => e.imdbId)
         .toList();
 
     final imdbMap = imdbIds.isNotEmpty
-        ? await ImdbService().resolve(imdbIds)
-        : <String, dynamic>{};
+        ? await ImdbService().resolve(imdbIds, ImdbKind.movie)
+        : <String, ImdbData>{};
 
     return raw.map((e) {
       final data = imdbMap[e.imdbId];

--- a/lib/features/catalog/imdb_service.dart
+++ b/lib/features/catalog/imdb_service.dart
@@ -7,10 +7,22 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'models/imdb_data.dart';
 
+/// A single episode lookup request: which series/season/episode to fetch,
+/// keyed for caching by the episode's own `tt` id (already known from the
+/// Episodes sheet — the new API has no way to resolve an episode except via
+/// its parent series + season + episode number).
+typedef EpisodeRequest = ({
+  String episodeImdbId,
+  String seriesId,
+  int season,
+  int episode,
+});
+
 class ImdbService {
-  static const _baseUrl = 'https://api.imdbapi.dev';
+  static const _baseUrl = 'https://api.balloonerismm.workers.dev';
   static const _ttl = Duration(days: 30);
-  static const _batchSize = 5;
+  static const _concurrency = 6;
+  static const _headers = {'Accept': 'application/json'};
 
   // Singleton — one instance shares the in-memory cache across all callers.
   static final ImdbService _instance = ImdbService._();
@@ -102,7 +114,29 @@ class ImdbService {
     } catch (_) {}
   }
 
-  // ── Public API ─────────────────────────────────────────────────────────────
+  // ── Low-level HTTP helper ───────────────────────────────────────────────────
+
+  /// GETs `$_baseUrl$path`. Returns null on any failure (timeout, network
+  /// error, etc.) rather than throwing — every caller treats "no data" as
+  /// the normal not-found/unavailable case, same as the rest of this service.
+  Future<http.Response?> _get(String path,
+      {Duration timeout = const Duration(seconds: 15)}) async {
+    try {
+      return await http
+          .get(Uri.parse('$_baseUrl$path'), headers: _headers)
+          .timeout(timeout);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Runs [tasks] with at most [_concurrency] in flight at once.
+  Future<void> _runInBatches(List<Future<void> Function()> tasks) async {
+    for (var i = 0; i < tasks.length; i += _concurrency) {
+      final window = tasks.sublist(i, min(i + _concurrency, tasks.length));
+      await Future.wait(window.map((t) => t()));
+    }
+  }
 
   bool _isFresh(String id) {
     if (!_cache.containsKey(id)) return false;
@@ -110,9 +144,67 @@ class ImdbService {
     return t != null && DateTime.now().difference(t) < _ttl;
   }
 
-  /// Returns IMDB metadata for every ID in [ids].
-  /// Hits the disk cache first; only fetches IDs that are missing or stale.
-  Future<Map<String, ImdbData>> resolve(List<String> ids) async {
+  // ── Single-title fetches ────────────────────────────────────────────────────
+
+  Future<ImdbData?> _fetchMovie(String id) async {
+    final results = await Future.wait([
+      _get('/movie/$id'),
+      _get('/movie/$id/credits'),
+    ]);
+    final detailResp = results[0];
+    if (detailResp == null || detailResp.statusCode != 200) return null;
+    try {
+      final detail = jsonDecode(detailResp.body) as Map<String, dynamic>;
+      final creditsResp = results[1];
+      final credits = (creditsResp != null && creditsResp.statusCode == 200)
+          ? jsonDecode(creditsResp.body) as Map<String, dynamic>
+          : null;
+      final data = ImdbData.fromMovieApi(detail, credits);
+      return data.id.isEmpty ? null : data;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<ImdbData?> _fetchTv(String id) async {
+    final results = await Future.wait([
+      _get('/tv/$id'),
+      _get('/tv/$id/credits'),
+    ]);
+    final detailResp = results[0];
+    if (detailResp == null || detailResp.statusCode != 200) return null;
+    try {
+      final detail = jsonDecode(detailResp.body) as Map<String, dynamic>;
+      final creditsResp = results[1];
+      final credits = (creditsResp != null && creditsResp.statusCode == 200)
+          ? jsonDecode(creditsResp.body) as Map<String, dynamic>
+          : null;
+      final data = ImdbData.fromTvApi(detail, credits);
+      return data.id.isEmpty ? null : data;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<ImdbData?> _fetchEpisode(
+      String seriesId, int season, int episode) async {
+    final resp = await _get('/tv/$seriesId/season/$season/episode/$episode');
+    if (resp == null || resp.statusCode != 200) return null;
+    try {
+      final json = jsonDecode(resp.body) as Map<String, dynamic>;
+      final data = ImdbData.fromEpisodeApi(json, parentId: seriesId);
+      return data.id.isEmpty ? null : data;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /// Resolves movie or TV-series metadata for every ID in [ids] — all of
+  /// [kind]. Hits the disk cache first; only fetches IDs that are missing
+  /// or stale.
+  Future<Map<String, ImdbData>> resolve(List<String> ids, ImdbKind kind) async {
     await _ensureLoaded();
 
     final result = <String, ImdbData>{};
@@ -127,27 +219,138 @@ class ImdbService {
     }
 
     if (toFetch.isNotEmpty) {
-      // Split into batches of _batchSize, fetch up to 4 concurrently.
-      final batches = <List<String>>[];
-      for (var i = 0; i < toFetch.length; i += _batchSize) {
-        batches.add(toFetch.sublist(i, min(i + _batchSize, toFetch.length)));
-      }
-      for (var i = 0; i < batches.length; i += 4) {
-        final window = batches.sublist(i, min(i + 4, batches.length));
-        await Future.wait(window.map((b) => _fetchBatch(b, result)));
-      }
+      await _runInBatches(toFetch.map((id) => () async {
+            final data = kind == ImdbKind.movie
+                ? await _fetchMovie(id)
+                : await _fetchTv(id);
+            if (data != null) {
+              _cache[id] = data;
+              _fetchedAt[id] = DateTime.now();
+              result[id] = data;
+            }
+          }).toList());
       await _persist();
     }
 
     return result;
   }
 
-  /// Returns up to 4 extra image URLs for [imdbId].
-  /// Results are persisted to disk with a 30-day TTL.
-  Future<List<String>> fetchImages(String imdbId) async {
+  /// Resolves IDs of unknown type — tries the movie endpoint, then falls
+  /// back to TV. Used where a pasted IMDb ID could be either (the request
+  /// form, the admin requests queue). IDs that 404 on both are omitted
+  /// from the result rather than guessed at.
+  Future<Map<String, ImdbData>> resolveUnknown(List<String> ids) async {
+    await _ensureLoaded();
+
+    final result = <String, ImdbData>{};
+    final toFetch = <String>[];
+
+    for (final id in ids) {
+      if (_isFresh(id)) {
+        result[id] = _cache[id]!;
+      } else {
+        toFetch.add(id);
+      }
+    }
+
+    if (toFetch.isNotEmpty) {
+      await _runInBatches(toFetch.map((id) => () async {
+            final data = await _fetchMovie(id) ?? await _fetchTv(id);
+            if (data != null) {
+              _cache[id] = data;
+              _fetchedAt[id] = DateTime.now();
+              result[id] = data;
+            }
+          }).toList());
+      await _persist();
+    }
+
+    return result;
+  }
+
+  /// Resolves a single TV episode via its series ID + season + episode
+  /// number. [episodeImdbId] (from the Episodes sheet) is used as the
+  /// cache key — the new API has no way to look an episode up by that ID
+  /// alone.
+  Future<ImdbData?> resolveEpisode({
+    required String episodeImdbId,
+    required String seriesId,
+    required int season,
+    required int episode,
+  }) async {
+    await _ensureLoaded();
+    if (episodeImdbId.isNotEmpty && _isFresh(episodeImdbId)) {
+      return _cache[episodeImdbId];
+    }
+    final data = await _fetchEpisode(seriesId, season, episode);
+    if (data != null) {
+      final key = episodeImdbId.isNotEmpty ? episodeImdbId : data.id;
+      _cache[key] = data;
+      _fetchedAt[key] = DateTime.now();
+      unawaited(_persist());
+    }
+    return data;
+  }
+
+  /// Bulk version of [resolveEpisode], concurrency-capped like [resolve].
+  /// Returns a map keyed by each request's `episodeImdbId`.
+  Future<Map<String, ImdbData>> resolveEpisodes(
+      List<EpisodeRequest> requests) async {
+    await _ensureLoaded();
+
+    final result = <String, ImdbData>{};
+    final toFetch = <EpisodeRequest>[];
+
+    for (final r in requests) {
+      if (r.episodeImdbId.isNotEmpty && _isFresh(r.episodeImdbId)) {
+        result[r.episodeImdbId] = _cache[r.episodeImdbId]!;
+      } else {
+        toFetch.add(r);
+      }
+    }
+
+    if (toFetch.isNotEmpty) {
+      await _runInBatches(toFetch.map((r) => () async {
+            final data = await _fetchEpisode(r.seriesId, r.season, r.episode);
+            if (data != null) {
+              final key = r.episodeImdbId.isNotEmpty ? r.episodeImdbId : data.id;
+              _cache[key] = data;
+              _fetchedAt[key] = DateTime.now();
+              result[key] = data;
+            }
+          }).toList());
+      await _persist();
+    }
+
+    return result;
+  }
+
+  Future<List<String>?> _fetchAllImageUrls(String imdbId, ImdbKind kind) async {
+    final path =
+        kind == ImdbKind.movie ? '/movie/$imdbId/images' : '/tv/$imdbId/images';
+    final resp = await _get(path, timeout: const Duration(seconds: 10));
+    if (resp == null || resp.statusCode != 200) return null;
+    try {
+      final body = jsonDecode(resp.body) as Map<String, dynamic>;
+      final urls = <String>[];
+      for (final key in const ['posters', 'backdrops', 'logos', 'stills']) {
+        final list = body[key] as List<dynamic>? ?? const [];
+        for (final item in list) {
+          final url = (item as Map<String, dynamic>)['file_path']?.toString();
+          if (url != null && url.isNotEmpty) urls.add(url);
+        }
+      }
+      return urls;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Returns up to 8 image URLs for [imdbId] (poster + stills, cached with
+  /// a 30-day TTL). Used for on-demand extra images (e.g. card hover).
+  Future<List<String>> fetchImages(String imdbId, ImdbKind kind) async {
     await _ensureImagesLoaded();
 
-    // Return from disk/memory cache if still fresh.
     if (_imagesCache.containsKey(imdbId)) {
       final at = _imagesFetchedAt[imdbId];
       if (at != null && DateTime.now().difference(at) < _ttl) {
@@ -155,80 +358,22 @@ class ImdbService {
       }
     }
 
-    try {
-      final resp = await http
-          .get(Uri.parse('$_baseUrl/titles/$imdbId/images?pageSize=4'),
-              headers: {'Accept': 'application/json'})
-          .timeout(const Duration(seconds: 10));
-      if (resp.statusCode != 200) {
-        return _imagesCache[imdbId] ?? [];
-      }
-      final body = jsonDecode(resp.body);
-      final list = body is List
-          ? body
-          : (body['images'] as List<dynamic>? ?? []);
-      final urls = list
-          .map((item) => item is String
-              ? item
-              : (item as Map<String, dynamic>)['url']?.toString() ?? '')
-          .where((u) => u.isNotEmpty)
-          .toList();
-      _imagesCache[imdbId] = urls;
-      _imagesFetchedAt[imdbId] = DateTime.now();
-      unawaited(_persistImages());
-      return urls;
-    } catch (_) {
-      return _imagesCache[imdbId] ?? [];
-    }
+    final urls = await _fetchAllImageUrls(imdbId, kind);
+    if (urls == null) return _imagesCache[imdbId] ?? [];
+
+    final capped = urls.take(8).toList();
+    _imagesCache[imdbId] = capped;
+    _imagesFetchedAt[imdbId] = DateTime.now();
+    unawaited(_persistImages());
+    return capped;
   }
 
-  Future<void> _fetchBatch(List<String> ids, Map<String, ImdbData> out) async {
-    final qs = ids.map((id) => 'titleIds=$id').join('&');
-    try {
-      final resp = await http
-          .get(Uri.parse('$_baseUrl/titles:batchGet?$qs'),
-              headers: {'Accept': 'application/json'})
-          .timeout(const Duration(seconds: 15));
-      if (resp.statusCode != 200) return;
-      final body = jsonDecode(resp.body);
-      final list = body is List
-          ? body
-          : (body['titles'] as List<dynamic>? ?? []);
-      for (final item in list) {
-        final data = ImdbData.fromApi(item as Map<String, dynamic>);
-        if (data.id.isEmpty) continue;
-        _cache[data.id] = data;
-        _fetchedAt[data.id] = DateTime.now();
-        out[data.id] = data;
-      }
-    } catch (_) {}
-  }
-
-  /// Fetches a page of image URLs for [imdbId].
-  /// Pass [pageToken] from a previous response to get the next page.
-  /// Returns images and the next page token (null = no more pages).
-  Future<({List<String> images, String? nextPageToken})> fetchImagesUncached(
-      String imdbId, {int pageSize = 20, String? pageToken}) async {
-    try {
-      var url = '$_baseUrl/titles/$imdbId/images?pageSize=$pageSize';
-      if (pageToken != null) url += '&pageToken=${Uri.encodeQueryComponent(pageToken)}';
-      final resp = await http
-          .get(Uri.parse(url), headers: {'Accept': 'application/json'})
-          .timeout(const Duration(seconds: 10));
-      if (resp.statusCode != 200) return (images: <String>[], nextPageToken: null);
-      final body = jsonDecode(resp.body) as Map<String, dynamic>;
-      final list = (body['images'] as List<dynamic>? ?? []);
-      final images = list
-          .map((item) => item is String
-              ? item
-              : (item as Map<String, dynamic>)['url']?.toString() ?? '')
-          .where((u) => u.isNotEmpty)
-          .toList();
-      final next = body['nextPageToken'] as String?;
-      return (images: images, nextPageToken: next?.isEmpty == true ? null : next);
-    } catch (_) {
-      return (images: <String>[], nextPageToken: null);
-    }
+  /// Returns every image URL for [imdbId], uncached — used by the admin
+  /// gallery, where the admin picks a handful to keep. The API returns all
+  /// images in one response (no pagination), unlike the old source.
+  Future<List<String>> fetchAllImages(String imdbId, ImdbKind kind) async {
+    final urls = await _fetchAllImageUrls(imdbId, kind);
+    return urls ?? [];
   }
 
   Future<void> clearCache() async {

--- a/lib/features/catalog/models/catalog_entry.dart
+++ b/lib/features/catalog/models/catalog_entry.dart
@@ -71,6 +71,10 @@ class CatalogEntry {
                                'poster', 'image', 'imageurl', 'cover'];
   static const _hSlides    = ['slideimages', 'slides', 'extraimages',
                                'slideshow', 'galleryimages'];
+  static const _hRating    = ['rating', 'imdbrating'];
+  static const _hRuntime   = ['runtimemin', 'runtime', 'runtimeminutes'];
+  static const _hCert      = ['certificate', 'cert', 'rated'];
+  static const _hStars     = ['stars', 'cast'];
 
   /// Parses a data row using the normalized header map produced by
   /// [CatalogNotifier] (keys are lowercase with separators stripped).
@@ -99,6 +103,10 @@ class CatalogEntry {
     final plot      = get(_hPlot);
     final thumbRaw  = get(_hThumb);
     final slidesRaw = get(_hSlides);
+    final ratingRaw = get(_hRating);
+    final runtimeMin = int.tryParse(get(_hRuntime));
+    final certRaw   = get(_hCert);
+    final starsRaw  = get(_hStars);
 
     return CatalogEntry(
       imdbId:       imdbId,
@@ -119,8 +127,29 @@ class CatalogEntry {
       slideImages:  slidesRaw.isEmpty
                       ? const []
                       : slidesRaw.split(',').map((u) => u.trim()).where((u) => u.isNotEmpty).toList(),
+      imdbRating:   double.tryParse(ratingRaw),
+      runtimeSeconds: runtimeMin != null ? runtimeMin * 60 : null,
+      certificate:  certRaw.isEmpty ? null : certRaw,
+      stars:        starsRaw.isEmpty
+                      ? const []
+                      : starsRaw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList(),
     );
   }
+
+  /// True if any of the fields the IMDB API can fill are still blank —
+  /// i.e. this row hasn't been backfilled with the new columns yet and a
+  /// live API call is worth making. `voteCount` is excluded: it isn't
+  /// persisted to the sheet at all, so its absence never triggers a fetch.
+  bool get needsImdbFetch =>
+      title.isEmpty ||
+      date == null ||
+      genres.isEmpty ||
+      plot.isEmpty ||
+      thumbnailUrl.isEmpty ||
+      imdbRating == null ||
+      runtimeSeconds == null ||
+      certificate == null ||
+      stars.isEmpty;
 
   /// Returns a new entry with IMDB metadata merged in.
   /// Sheet values always win when present; API fills in only what the sheet left blank.
@@ -135,11 +164,11 @@ class CatalogEntry {
         videoUrl:     videoUrl,
         sizeMb:       sizeMb,
         encoded:      encoded,
-        imdbRating:   data.rating,
+        imdbRating:   imdbRating ?? data.rating,
         voteCount:    data.voteCount,
-        runtimeSeconds: data.runtimeSeconds,
-        stars:        data.stars,
-        certificate:  data.certificate,
+        runtimeSeconds: runtimeSeconds ?? data.runtimeSeconds,
+        stars:        stars.isNotEmpty ? stars : data.stars,
+        certificate:  certificate ?? data.certificate,
         language:     language,
         slideImages:  slideImages,
       );

--- a/lib/features/catalog/models/episode_sheet_schema.dart
+++ b/lib/features/catalog/models/episode_sheet_schema.dart
@@ -19,6 +19,7 @@ class EpisodeSheetSchema {
     'language',         // 11
     'encoded',          // 12 — TRUE / FALSE
     'show',             // 13 — TRUE / FALSE
+    'runtime_min',      // 14 — episode runtime in minutes
   ];
 
   static const int iEpisodeImdbId = 0;
@@ -35,8 +36,9 @@ class EpisodeSheetSchema {
   static const int iLanguage      = 11;
   static const int iEncoded       = 12;
   static const int iShow          = 13;
+  static const int iRuntimeMin    = 14;
 
-  static const int columnCount = 14;
+  static const int columnCount = 15;
 
   static String get headerTsv => columns.join('\t');
 

--- a/lib/features/catalog/models/imdb_data.dart
+++ b/lib/features/catalog/models/imdb_data.dart
@@ -1,5 +1,11 @@
+/// Which IMDB entity type a title resolved as.
+/// Set whenever the kind was determined by the fetch (movie vs tv detail
+/// endpoint that actually returned 200) rather than assumed by the caller.
+enum ImdbKind { movie, tv }
+
 class ImdbData {
   final String id;
+  final ImdbKind? kind;
   final String title;
   final String plot;
   final List<String> genres;
@@ -11,7 +17,7 @@ class ImdbData {
   final List<String> stars;
   final String? certificate;
   // TV series fields — null for movies / episodes
-  final int? endYear; // end year for tvSeries (null if ongoing or not a series)
+  final int? endYear; // end year for a series (null if ongoing or not a series)
   // TV episode fields — null for movies / series
   final int? seasonNumber;
   final int? episodeNumber;
@@ -19,6 +25,7 @@ class ImdbData {
 
   const ImdbData({
     required this.id,
+    this.kind,
     required this.title,
     required this.plot,
     required this.genres,
@@ -35,89 +42,111 @@ class ImdbData {
     this.parentId,
   });
 
-  /// Parse from the live API response.
-  factory ImdbData.fromApi(Map<String, dynamic> json) {
-    final img = json['primaryImage'] as Map<String, dynamic>?;
-    final posterUrl = img?['url'] as String? ?? '';
-
-    final genres = (json['genres'] as List<dynamic>? ?? [])
-        .map((g) => g.toString())
-        .toList();
-
-    // API uses either a releaseDate object or a bare startYear integer.
-    DateTime? releaseDate;
-    final rd = json['releaseDate'] as Map<String, dynamic>?;
-    if (rd != null) {
-      final y = rd['year'] as int?;
-      if (y != null) {
-        releaseDate = DateTime(y, rd['month'] as int? ?? 1, rd['day'] as int? ?? 1);
-      }
-    } else {
-      final y = json['startYear'] as int?;
-      if (y != null) releaseDate = DateTime(y);
-    }
-
-    final ratingObj = json['rating'] as Map<String, dynamic>?;
-    final rating = (ratingObj?['aggregateRating'] as num?)?.toDouble();
-    final voteCount = ratingObj?['voteCount'] as int?;
-
-    final stars = (json['stars'] as List<dynamic>? ?? [])
-        .take(3)
-        .map((s) => (s as Map<String, dynamic>)['displayName']?.toString() ?? '')
-        .where((s) => s.isNotEmpty)
-        .toList();
-
-    final certs = json['certificates'] as List<dynamic>? ?? [];
-    String? certificate;
-    for (final c in certs) {
-      final cm = c as Map<String, dynamic>;
-      if (cm['country'] == 'US') {
-        certificate = cm['rating']?.toString();
-        break;
-      }
-    }
-    certificate ??= certs.isNotEmpty
-        ? (certs.first as Map<String, dynamic>)['rating']?.toString()
-        : null;
-
-    final endYear = json['endYear'] as int?;
-
-    // TV episode: season / episode number and parent series ID.
-    // API may return these flat or nested under an "episode" object.
-    final epObj = json['episode'] as Map<String, dynamic>?;
-    final seasonNumber = (json['seasonNumber'] as num?)?.toInt()
-        ?? (epObj?['seasonNumber'] as num?)?.toInt();
-    final episodeNumber = (json['episodeNumber'] as num?)?.toInt()
-        ?? (epObj?['episodeNumber'] as num?)?.toInt();
-    // Parent series ID: try several common field names.
-    final seriesObj = json['series'] as Map<String, dynamic>?;
-    final parentId = json['seriesId'] as String?
-        ?? json['parentId'] as String?
-        ?? seriesObj?['id'] as String?;
+  /// Parses a `GET /movie/{id}` response, optionally merging in cast names
+  /// from a companion `GET /movie/{id}/credits` response.
+  factory ImdbData.fromMovieApi(Map<String, dynamic> detail,
+      [Map<String, dynamic>? credits]) {
+    final cert = detail['certificate'] as Map<String, dynamic>?;
+    // API runtime is in minutes; the app's internal field is seconds.
+    final runtimeMin = (detail['runtime'] as num?)?.toInt();
 
     return ImdbData(
-      id: json['id'] as String? ?? '',
-      // API field is primaryTitle, not title
-      title: json['primaryTitle'] as String? ?? json['title'] as String? ?? '',
-      plot: json['plot'] as String? ?? '',
-      genres: genres,
-      releaseDate: releaseDate,
-      posterUrl: posterUrl,
-      rating: rating,
-      voteCount: voteCount,
-      runtimeSeconds: json['runtimeSeconds'] as int?,
-      stars: stars,
-      certificate: certificate,
-      endYear: endYear,
-      seasonNumber: seasonNumber,
-      episodeNumber: episodeNumber,
-      parentId: parentId?.isNotEmpty == true ? parentId : null,
+      id: detail['id'] as String? ?? '',
+      kind: ImdbKind.movie,
+      title: detail['title'] as String? ?? '',
+      plot: detail['overview'] as String? ?? '',
+      genres: _genreNames(detail['genres']),
+      releaseDate: _parseDate(detail['release_date']),
+      posterUrl: detail['poster_path'] as String? ?? '',
+      rating: (detail['vote_average'] as num?)?.toDouble(),
+      voteCount: (detail['vote_count'] as num?)?.toInt(),
+      runtimeSeconds: runtimeMin != null ? runtimeMin * 60 : null,
+      stars: _castNames(credits),
+      certificate: cert?['rating'] as String?,
     );
+  }
+
+  /// Parses a `GET /tv/{id}` response, optionally merging in cast names
+  /// from a companion `GET /tv/{id}/credits` response.
+  factory ImdbData.fromTvApi(Map<String, dynamic> detail,
+      [Map<String, dynamic>? credits]) {
+    final cert = detail['certificate'] as Map<String, dynamic>?;
+    final inProduction = detail['in_production'] as bool? ?? false;
+    final lastAirDate = _parseDate(detail['last_air_date']);
+
+    return ImdbData(
+      id: detail['id'] as String? ?? '',
+      kind: ImdbKind.tv,
+      title: detail['name'] as String? ?? '',
+      plot: detail['overview'] as String? ?? '',
+      genres: _genreNames(detail['genres']),
+      releaseDate: _parseDate(detail['first_air_date']),
+      posterUrl: detail['poster_path'] as String? ?? '',
+      rating: (detail['vote_average'] as num?)?.toDouble(),
+      voteCount: (detail['vote_count'] as num?)?.toInt(),
+      runtimeSeconds: null, // a series has no single runtime value
+      stars: _castNames(credits),
+      certificate: cert?['rating'] as String?,
+      endYear: inProduction ? null : lastAirDate?.year,
+    );
+  }
+
+  /// Parses a `GET /tv/{seriesId}/season/{s}/episode/{e}` response.
+  /// [parentId] is the series ID used to make the request — the response
+  /// itself doesn't echo it back.
+  factory ImdbData.fromEpisodeApi(Map<String, dynamic> json,
+      {required String parentId}) {
+    return ImdbData(
+      id: json['id'] as String? ?? '',
+      kind: ImdbKind.tv,
+      title: json['name'] as String? ?? '',
+      plot: json['overview'] as String? ?? '',
+      genres: const [],
+      releaseDate: _parseDate(json['air_date']),
+      posterUrl: json['still_path'] as String? ?? '',
+      rating: (json['vote_average'] as num?)?.toDouble(),
+      voteCount: (json['vote_count'] as num?)?.toInt(),
+      // Episode runtime from this endpoint is already in seconds.
+      runtimeSeconds: (json['runtime'] as num?)?.toInt(),
+      stars: const [],
+      certificate: null,
+      seasonNumber: (json['season_number'] as num?)?.toInt(),
+      episodeNumber: (json['episode_number'] as num?)?.toInt(),
+      parentId: parentId,
+    );
+  }
+
+  static DateTime? _parseDate(dynamic raw) {
+    if (raw is! String || raw.isEmpty) return null;
+    return DateTime.tryParse(raw);
+  }
+
+  static List<String> _genreNames(dynamic raw) {
+    final list = raw as List<dynamic>? ?? const [];
+    return list
+        .map((g) => (g as Map<String, dynamic>)['name']?.toString() ?? '')
+        .where((s) => s.isNotEmpty)
+        .toList();
+  }
+
+  static List<String> _castNames(Map<String, dynamic>? credits) {
+    if (credits == null) return const [];
+    final cast = credits['cast'] as List<dynamic>? ?? const [];
+    return cast
+        .take(3)
+        .map((c) => (c as Map<String, dynamic>)['name']?.toString() ?? '')
+        .where((s) => s.isNotEmpty)
+        .toList();
   }
 
   /// Parse from the on-disk cache.
   factory ImdbData.fromJson(Map<String, dynamic> j) => ImdbData(
         id: j['id'] as String? ?? '',
+        kind: switch (j['kind'] as String?) {
+          'movie' => ImdbKind.movie,
+          'tv' => ImdbKind.tv,
+          _ => null,
+        },
         title: j['title'] as String? ?? '',
         plot: j['plot'] as String? ?? '',
         genres: (j['genres'] as List<dynamic>? ?? []).map((g) => '$g').toList(),
@@ -138,6 +167,7 @@ class ImdbData {
 
   Map<String, dynamic> toJson() => {
         'id': id,
+        if (kind != null) 'kind': kind == ImdbKind.movie ? 'movie' : 'tv',
         'title': title,
         'plot': plot,
         'genres': genres,

--- a/lib/features/catalog/models/series_entry.dart
+++ b/lib/features/catalog/models/series_entry.dart
@@ -7,6 +7,8 @@ class SeriesEntry {
   final List<String> tags;
   final String? language;
   final double? imdbRating;
+  final String? certificate;
+  final List<String> stars;
   final List<SeasonEntry> seasons;
 
   const SeriesEntry({
@@ -18,16 +20,32 @@ class SeriesEntry {
     required this.tags,
     this.language,
     this.imdbRating,
+    this.certificate,
+    this.stars = const [],
     required this.seasons,
   });
 
   int get totalEpisodes => seasons.fold(0, (s, e) => s + e.episodes.length);
 
+  /// True if any IMDB-fillable field is still blank — this row hasn't
+  /// been backfilled with the new columns yet and a live fetch is worth it.
+  bool get needsImdbFetch =>
+      posterUrl.isEmpty ||
+      plot.isEmpty ||
+      genres.isEmpty ||
+      imdbRating == null ||
+      certificate == null ||
+      stars.isEmpty;
+
+  /// Sheet values always win when present; API fills in only what the
+  /// sheet left blank.
   SeriesEntry withImdb({
     required String posterUrl,
     required String plot,
     required List<String> genres,
     required double? rating,
+    String? certificate,
+    List<String> stars = const [],
   }) =>
       SeriesEntry(
         title: title,
@@ -37,7 +55,9 @@ class SeriesEntry {
         genres: this.genres.isNotEmpty ? this.genres : genres,
         tags: tags,
         language: language,
-        imdbRating: rating,
+        imdbRating: imdbRating ?? rating,
+        certificate: this.certificate ?? certificate,
+        stars: this.stars.isNotEmpty ? this.stars : stars,
         seasons: seasons,
       );
 }
@@ -85,6 +105,17 @@ class EpisodeEntry {
     return m >= 60 ? '${m ~/ 60}h ${m % 60}m' : '${m}m';
   }
 
+  /// True if any IMDB-fillable field is still blank.
+  bool get needsImdbFetch =>
+      title.isEmpty ||
+      airDate == null ||
+      imdbRating == null ||
+      plot.isEmpty ||
+      posterUrl.isEmpty ||
+      runtimeSeconds == null;
+
+  /// Sheet values always win when present; API fills in only what the
+  /// sheet left blank.
   EpisodeEntry withImdb(
       {required String title,
       required DateTime? airDate,
@@ -100,9 +131,9 @@ class EpisodeEntry {
         videoUrl: videoUrl,
         sizeMb: sizeMb,
         encoded: encoded,
-        imdbRating: rating,
-        plot: plot,
-        posterUrl: posterUrl,
-        runtimeSeconds: runtimeSeconds,
+        imdbRating: imdbRating ?? rating,
+        plot: this.plot.isNotEmpty ? this.plot : plot,
+        posterUrl: this.posterUrl.isNotEmpty ? this.posterUrl : posterUrl,
+        runtimeSeconds: this.runtimeSeconds ?? runtimeSeconds,
       );
 }

--- a/lib/features/catalog/models/series_sheet_schema.dart
+++ b/lib/features/catalog/models/series_sheet_schema.dart
@@ -14,6 +14,8 @@ class SeriesSheetSchema {
     'genres',          // 7 — comma-separated
     'tags',            // 8 — comma-separated
     'show',            // 9 — TRUE / FALSE
+    'certificate',     // 10 — e.g. TV-MA
+    'stars',           // 11 — top 3 cast, comma-separated
   ];
 
   static const int iSeriesImdbId = 0;
@@ -26,8 +28,10 @@ class SeriesSheetSchema {
   static const int iGenres       = 7;
   static const int iTags         = 8;
   static const int iShow         = 9;
+  static const int iCertificate  = 10;
+  static const int iStars        = 11;
 
-  static const int columnCount = 10;
+  static const int columnCount = 12;
 
   static String get headerTsv => columns.join('\t');
 

--- a/lib/features/catalog/models/sheet_schema.dart
+++ b/lib/features/catalog/models/sheet_schema.dart
@@ -18,6 +18,10 @@ class SheetSchema {
     'encoded',
     'show',
     'slide_images',
+    'rating',        // 13 — IMDB rating, fetched once and persisted
+    'runtime_min',   // 14 — runtime in minutes
+    'certificate',   // 15 — e.g. PG-13
+    'stars',         // 16 — top 3 cast, comma-separated
   ];
 
   static const int iTitle       = 0;
@@ -33,8 +37,12 @@ class SheetSchema {
   static const int iEncoded     = 10;
   static const int iShow        = 11;
   static const int iSlideImages = 12;
+  static const int iRating      = 13;
+  static const int iRuntimeMin  = 14;
+  static const int iCertificate = 15;
+  static const int iStars       = 16;
 
-  static const int columnCount = 13;
+  static const int columnCount = 17;
 
   /// Tab-separated header row, ready to paste as the first row of a sheet.
   static String get headerTsv => columns.join('\t');

--- a/lib/features/catalog/request_notifier.dart
+++ b/lib/features/catalog/request_notifier.dart
@@ -101,8 +101,13 @@ class RequestNotifier extends StateNotifier<RequestState> {
       final config =
           _ref.read(sheetConfigProvider).valueOrNull ?? const SheetConfig();
 
+      // Type is unknown ahead of time for a pasted URL — resolveUnknown
+      // tries /movie then /tv and tells us definitively which one matched.
+      // (It can't resolve a link to a specific episode at all — the API has
+      // no way to look one up except via its parent series + season +
+      // episode number, none of which is recoverable from a bare ID.)
       final results = await Future.wait([
-        ImdbService().resolve([id]),
+        ImdbService().resolveUnknown([id]),
         _fetchExistingIds(config.requestResUrl),
       ]);
 
@@ -119,8 +124,17 @@ class RequestNotifier extends StateNotifier<RequestState> {
           imdbUrl: 'https://www.imdb.com/title/$id/',
           title: data?.title ?? id,
           year: data?.releaseDate?.year,
-          type: _inferType(data),
+          type: _typeLabel(data),
           posterUrl: data?.posterUrl ?? '',
+        );
+        return;
+      }
+
+      if (data == null) {
+        state = RequestError(
+          "Couldn't find this on IMDb as a movie or TV series. If this "
+          "links to a specific episode, please submit the show's main "
+          'IMDb page instead.',
         );
         return;
       }
@@ -128,23 +142,19 @@ class RequestNotifier extends StateNotifier<RequestState> {
       state = RequestReady(
         imdbId: id,
         imdbUrl: 'https://www.imdb.com/title/$id/',
-        title: data?.title ?? id,
-        year: data?.releaseDate?.year,
-        type: _inferType(data),
-        posterUrl: data?.posterUrl ?? '',
+        title: data.title,
+        year: data.releaseDate?.year,
+        type: _typeLabel(data),
+        posterUrl: data.posterUrl,
       );
     } catch (e) {
       if (mounted) state = RequestError('Could not fetch IMDB data: $e');
     }
   }
 
-  static String _inferType(ImdbData? data) {
-    if (data == null) return 'Movie';
-    if (data.parentId != null || data.seasonNumber != null) return 'Episode';
-    if (data.endYear != null) return 'Series';
-    // Ongoing series have no runtimeSeconds and no endYear — heuristic only.
-    if (data.runtimeSeconds == null) return 'Series';
-    return 'Movie';
+  static String _typeLabel(ImdbData? data) {
+    if (data == null) return 'Unknown';
+    return data.kind == ImdbKind.tv ? 'Series' : 'Movie';
   }
 
   // ── Submit ─────────────────────────────────────────────────────────────────

--- a/lib/features/catalog/screens/series_detail_screen.dart
+++ b/lib/features/catalog/screens/series_detail_screen.dart
@@ -231,6 +231,8 @@ class _LeftPanel extends StatelessWidget {
                 icon: Icons.video_library_rounded,
                 label: '${e.totalEpisodes} Episodes',
               ),
+              if (e.certificate != null)
+                _Pill(icon: Icons.verified_user_rounded, label: e.certificate!),
               if (e.language != null)
                 _Pill(icon: Icons.translate_rounded, label: e.language!),
             ],
@@ -268,6 +270,15 @@ class _LeftPanel extends StatelessWidget {
                 color: kTextSecondary,
                 height: 1.65,
               ),
+            ),
+          ],
+
+          // Stars
+          if (e.stars.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              e.stars.join(' · '),
+              style: TextStyle(fontSize: 11, color: kTextMuted),
             ),
           ],
 

--- a/lib/features/catalog/series_notifier.dart
+++ b/lib/features/catalog/series_notifier.dart
@@ -190,6 +190,17 @@ class SeriesNotifier extends StateNotifier<SeriesCatalogState> {
               meta.tags = t.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
             }
           }
+          meta.rating ??= double.tryParse(sc(row, ['rating']));
+          if (meta.certificate == null) {
+            final c = sc(row, ['certificate', 'cert', 'rated']);
+            if (c.isNotEmpty) meta.certificate = c;
+          }
+          if (meta.stars.isEmpty) {
+            final s = sc(row, ['stars', 'cast']);
+            if (s.isNotEmpty) {
+              meta.stars = s.split(',').map((x) => x.trim()).where((x) => x.isNotEmpty).toList();
+            }
+          }
         }
       }
     }
@@ -238,6 +249,7 @@ class SeriesNotifier extends StateNotifier<SeriesCatalogState> {
           final thumb   = ec(row, ['thumbnailurl', 'thumbnail', 'posterurl', 'image']);
           final plot    = ec(row, ['plot', 'description']);
           final rating  = double.tryParse(ec(row, ['rating']));
+          final runtimeMin = int.tryParse(ec(row, ['runtimemin', 'runtime', 'runtimeminutes']));
           final videoUrl = ec(row, ['videourl', 'url', 'googlephotosurl', 'albumurl', 'link']);
           final sizeMb  = int.tryParse(ec(row, ['sizemb', 'size', 'filesize']));
           final encoded = ec(row, ['encoded']).toLowerCase() == 'true';
@@ -253,6 +265,7 @@ class SeriesNotifier extends StateNotifier<SeriesCatalogState> {
             plot: plot,
             posterUrl: thumb,
             imdbRating: rating,
+            runtimeSeconds: runtimeMin != null ? runtimeMin * 60 : null,
           );
 
           episodeTree
@@ -282,18 +295,23 @@ class SeriesNotifier extends StateNotifier<SeriesCatalogState> {
         plot: meta.plot,
         genres: meta.genres,
         tags: meta.tags,
+        imdbRating: meta.rating,
+        certificate: meta.certificate,
+        stars: meta.stars,
         seasons: seasons,
       );
     }).toList();
 
-    // ── Series-level IMDB enrichment ─────────────────────────────────────────
-    final seriesImdbIds = rawEntries
-        .where((e) => e.imdbId.isNotEmpty)
+    // ── Series-level IMDB enrichment ───────────────────────────────────────
+    // Only rows still missing an IMDB-fillable field trigger a fetch — a
+    // fully backfilled sheet row never touches the API.
+    final seriesToFetch = rawEntries
+        .where((e) => e.imdbId.isNotEmpty && e.needsImdbFetch)
         .map((e) => e.imdbId)
         .toList();
 
-    final seriesImdbMap = seriesImdbIds.isNotEmpty
-        ? await ImdbService().resolve(seriesImdbIds)
+    final seriesImdbMap = seriesToFetch.isNotEmpty
+        ? await ImdbService().resolve(seriesToFetch, ImdbKind.tv)
         : <String, ImdbData>{};
 
     final seriesEnriched = rawEntries.map((e) {
@@ -304,21 +322,36 @@ class SeriesNotifier extends StateNotifier<SeriesCatalogState> {
         plot: data.plot,
         genres: data.genres,
         rating: data.rating,
+        certificate: data.certificate,
+        stars: data.stars,
       );
     }).toList();
 
-    // ── Episode-level IMDB enrichment ─────────────────────────────────────────
-    final episodeImdbIds = seriesEnriched
-        .expand((s) => s.seasons)
-        .expand((season) => season.episodes)
-        .where((ep) => ep.imdbId.isNotEmpty)
-        .map((ep) => ep.imdbId)
-        .toSet()
-        .toList();
+    // ── Episode-level IMDB enrichment ────────────────────────────────────────
+    // The new API has no way to resolve an episode by its own ID — it's
+    // reached via series ID + season + episode number, both already in the
+    // Episodes sheet.
+    final episodeRequests = <EpisodeRequest>[];
+    for (final series in seriesEnriched) {
+      if (series.imdbId.isEmpty) continue;
+      for (final season in series.seasons) {
+        for (final ep in season.episodes) {
+          if (ep.imdbId.isNotEmpty && ep.needsImdbFetch) {
+            episodeRequests.add((
+              episodeImdbId: ep.imdbId,
+              seriesId: series.imdbId,
+              season: season.number,
+              episode: ep.episodeNumber,
+            ));
+          }
+        }
+      }
+    }
 
-    if (episodeImdbIds.isEmpty) return seriesEnriched;
+    if (episodeRequests.isEmpty) return seriesEnriched;
 
-    final epImdbMap = await ImdbService().resolve(episodeImdbIds);
+    final epImdbMap = await ImdbService().resolveEpisodes(episodeRequests);
+    if (epImdbMap.isEmpty) return seriesEnriched;
 
     return seriesEnriched.map((series) {
       final enrichedSeasons = series.seasons.map((season) {
@@ -345,6 +378,8 @@ class SeriesNotifier extends StateNotifier<SeriesCatalogState> {
         tags: series.tags,
         language: series.language,
         imdbRating: series.imdbRating,
+        certificate: series.certificate,
+        stars: series.stars,
         seasons: enrichedSeasons,
       );
     }).toList();
@@ -439,4 +474,7 @@ class _SeriesFields {
   List<String> genres = [];
   List<String> tags   = [];
   String? language;
+  double? rating;
+  String? certificate;
+  List<String> stars = [];
 }

--- a/lib/features/catalog/widgets/catalog_card.dart
+++ b/lib/features/catalog/widgets/catalog_card.dart
@@ -17,6 +17,7 @@ import '../../shell/app_shell.dart';
 import '../catalog_notifier.dart';
 import '../imdb_service.dart';
 import '../models/catalog_entry.dart';
+import '../models/imdb_data.dart';
 
 class CatalogCard extends StatefulWidget {
   final CatalogEntry entry;
@@ -204,7 +205,7 @@ class CatalogCardExpandedState extends ConsumerState<CatalogCardExpanded> {
 
     final imdbId = entry.imdbId;
     if (imdbId.isEmpty) return;
-    final urls = await ImdbService().fetchImages(imdbId);
+    final urls = await ImdbService().fetchImages(imdbId, ImdbKind.movie);
     if (!mounted || urls.isEmpty) return;
     final extras = urls.where((u) => u != thumb).toList();
     setState(() {

--- a/lib/features/catalog/widgets/series_card.dart
+++ b/lib/features/catalog/widgets/series_card.dart
@@ -266,6 +266,11 @@ class SeriesCardExpandedState extends State<SeriesCardExpanded> {
                                 icon: Icons.video_library_rounded,
                                 label: '${e.totalEpisodes} Episodes',
                               ),
+                              if (e.certificate != null)
+                                _Pill(
+                                  icon: Icons.verified_user_rounded,
+                                  label: e.certificate!,
+                                ),
                               if (e.language != null)
                                 _Pill(
                                   icon: Icons.translate_rounded,
@@ -304,6 +309,19 @@ class SeriesCardExpandedState extends State<SeriesCardExpanded> {
                                 fontSize: 12,
                                 color: kTextSecondary,
                                 height: 1.55,
+                              ),
+                            ),
+                          ],
+                          // Stars
+                          if (e.stars.isNotEmpty) ...[
+                            const SizedBox(height: 8),
+                            Text(
+                              e.stars.join(' · '),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 11,
+                                color: kTextMuted,
                               ),
                             ),
                           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.6.3+18
+version: 1.7.0+19
 
 environment:
   sdk: ^3.11.5

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:m_storage/core/services/archive_service.dart';
 import 'package:m_storage/core/services/format_service.dart';
 import 'package:m_storage/features/catalog/models/catalog_entry.dart';
+import 'package:m_storage/features/catalog/models/imdb_data.dart';
 import 'package:m_storage/features/updater/update_service.dart';
 
 void main() {
@@ -243,6 +244,191 @@ void main() {
           ['X', 'https://a.com/1.jpg, https://b.com/2.jpg'], h);
       expect(entry.slideImages.length, equals(2));
       expect(entry.slideImages[0], equals('https://a.com/1.jpg'));
+    });
+
+    test('rating/runtime_min/certificate/stars parsed from sheet columns', () {
+      final h = mkHeaders(
+          ['title', 'rating', 'runtimeMin', 'certificate', 'stars']);
+      final entry = CatalogEntry.fromRow(
+          ['X', '8.8', '148', 'PG-13', 'Leonardo DiCaprio, Elliot Page'], h);
+      expect(entry.imdbRating, equals(8.8));
+      // Sheet stores runtime in minutes; the internal field is seconds.
+      expect(entry.runtimeSeconds, equals(148 * 60));
+      expect(entry.certificate, equals('PG-13'));
+      expect(entry.stars, equals(['Leonardo DiCaprio', 'Elliot Page']));
+    });
+
+    test('needsImdbFetch is false only once every fillable field is present', () {
+      final full = mkHeaders([
+        'title', 'date', 'genres', 'plot', 'posterUrl',
+        'rating', 'runtimeMin', 'certificate', 'stars',
+      ]);
+      final complete = CatalogEntry.fromRow([
+        'X', '2024-01-01', 'Action', 'A plot.', 'https://example.com/p.jpg',
+        '8.0', '120', 'PG-13', 'Someone',
+      ], full);
+      expect(complete.needsImdbFetch, isFalse);
+
+      final missingRating = CatalogEntry.fromRow([
+        'X', '2024-01-01', 'Action', 'A plot.', 'https://example.com/p.jpg',
+        '', '120', 'PG-13', 'Someone',
+      ], full);
+      expect(missingRating.needsImdbFetch, isTrue);
+    });
+  });
+
+  // ── CatalogEntry.mergeImdb — sheet-wins ─────────────────────────────────────
+
+  group('CatalogEntry.mergeImdb sheet-wins', () {
+    const apiData = ImdbData(
+      id: 'tt1',
+      kind: ImdbKind.movie,
+      title: 'API Title',
+      plot: 'API plot.',
+      genres: ['Drama'],
+      releaseDate: null,
+      posterUrl: 'https://api.example.com/poster.jpg',
+      rating: 7.5,
+      voteCount: 1000,
+      runtimeSeconds: 6000,
+      stars: ['API Star'],
+      certificate: 'R',
+    );
+
+    test('sheet-populated fields survive the merge untouched', () {
+      const sheetEntry = CatalogEntry(
+        imdbId: 'tt1',
+        title: 'Sheet Title',
+        date: null,
+        genres: ['Action'],
+        tags: [],
+        plot: 'Sheet plot.',
+        thumbnailUrl: 'https://sheet.example.com/poster.jpg',
+        videoUrl: '',
+        sizeMb: null,
+        encoded: false,
+        imdbRating: 9.0,
+        runtimeSeconds: 7200,
+        certificate: 'PG-13',
+        stars: ['Sheet Star'],
+      );
+      final merged = sheetEntry.mergeImdb(apiData);
+      expect(merged.title, equals('Sheet Title'));
+      expect(merged.plot, equals('Sheet plot.'));
+      expect(merged.thumbnailUrl, equals('https://sheet.example.com/poster.jpg'));
+      expect(merged.imdbRating, equals(9.0));
+      expect(merged.runtimeSeconds, equals(7200));
+      expect(merged.certificate, equals('PG-13'));
+      expect(merged.stars, equals(['Sheet Star']));
+    });
+
+    test('blank sheet fields are filled from the API', () {
+      const sheetEntry = CatalogEntry(
+        imdbId: 'tt1',
+        title: '',
+        date: null,
+        genres: [],
+        tags: [],
+        plot: '',
+        thumbnailUrl: '',
+        videoUrl: '',
+        sizeMb: null,
+        encoded: false,
+      );
+      final merged = sheetEntry.mergeImdb(apiData);
+      expect(merged.title, equals('API Title'));
+      expect(merged.plot, equals('API plot.'));
+      expect(merged.imdbRating, equals(7.5));
+      expect(merged.runtimeSeconds, equals(6000));
+      expect(merged.certificate, equals('R'));
+      expect(merged.stars, equals(['API Star']));
+    });
+  });
+
+  // ── ImdbData API parsing — unit conversions ─────────────────────────────────
+
+  group('ImdbData.fromMovieApi', () {
+    test('runtime in minutes is converted to seconds', () {
+      final data = ImdbData.fromMovieApi({
+        'id': 'tt1375666',
+        'title': 'Inception',
+        'overview': 'A thief...',
+        'genres': [
+          {'id': 'Sci-Fi', 'name': 'Sci-Fi'}
+        ],
+        'release_date': '2010-07-16',
+        'poster_path': 'https://example.com/poster.jpg',
+        'vote_average': 8.8,
+        'vote_count': 2835518,
+        'runtime': 148,
+        'certificate': {'rating': 'PG-13', 'body': 'MPAA'},
+      });
+      expect(data.runtimeSeconds, equals(148 * 60));
+      expect(data.rating, equals(8.8));
+      expect(data.certificate, equals('PG-13'));
+      expect(data.genres, equals(['Sci-Fi']));
+      expect(data.releaseDate, equals(DateTime.parse('2010-07-16')));
+    });
+
+    test('cast names come from the paired credits response, top 3 only', () {
+      final data = ImdbData.fromMovieApi(
+        {'id': 'tt1', 'title': 'X', 'overview': '', 'genres': [], 'release_date': ''},
+        {
+          'cast': [
+            {'name': 'A', 'order': 0},
+            {'name': 'B', 'order': 1},
+            {'name': 'C', 'order': 2},
+            {'name': 'D', 'order': 3},
+          ],
+        },
+      );
+      expect(data.stars, equals(['A', 'B', 'C']));
+    });
+  });
+
+  group('ImdbData.fromTvApi', () {
+    test('ended series derives endYear from last_air_date', () {
+      final data = ImdbData.fromTvApi({
+        'id': 'tt0944947',
+        'name': 'Game of Thrones',
+        'overview': '',
+        'genres': [],
+        'first_air_date': '2011-04-17',
+        'last_air_date': '2019-12-31',
+        'in_production': false,
+      });
+      expect(data.endYear, equals(2019));
+    });
+
+    test('ongoing series has no endYear', () {
+      final data = ImdbData.fromTvApi({
+        'id': 'tt1',
+        'name': 'X',
+        'overview': '',
+        'genres': [],
+        'first_air_date': '2020-01-01',
+        'last_air_date': '2024-01-01',
+        'in_production': true,
+      });
+      expect(data.endYear, isNull);
+    });
+  });
+
+  group('ImdbData.fromEpisodeApi', () {
+    test('runtime from the episode endpoint is already seconds — no conversion', () {
+      final data = ImdbData.fromEpisodeApi({
+        'id': 'tt1480055',
+        'name': 'Winter Is Coming',
+        'overview': '',
+        'air_date': '2011-04-17',
+        'season_number': 1,
+        'episode_number': 1,
+        'runtime': 3720,
+      }, parentId: 'tt0944947');
+      expect(data.runtimeSeconds, equals(3720));
+      expect(data.parentId, equals('tt0944947'));
+      expect(data.seasonNumber, equals(1));
+      expect(data.episodeNumber, equals(1));
     });
   });
 }


### PR DESCRIPTION
## Summary
- `api.imdbapi.dev` is dead; migrated to `api.balloonerismm.workers.dev`. `ImdbService` rewritten around per-title fetches (`/movie`, `/tv`, `/tv/{id}/season/{s}/episode/{e}`) since the new API has no batch endpoint and isn't type-agnostic.
- Sheet-first architecture: `rating`/`runtime`/`certificate`/`stars` are now fetched once at admin-entry time and persisted to new sheet columns (append-only, backward compatible), instead of being re-fetched from the API on every catalog load. Sheet values win over the API for every field; the API is only called for rows still missing a column.
- Fixed two pre-existing bugs surfaced along the way: Series sheet's `rating` column was never read back, and Episodes sheet's `rating` was read but then silently overwritten on every enrichment.
- Admin episode fetch now uses series+season+episode instead of a flat ID lookup (the new API can't resolve episodes any other way). Image "load more" pagination removed since the new API returns everything in one call.
- Request flow tries `/movie` then `/tv` for unknown-type IDs, and gives an explicit message instead of silently guessing a type for links it can't resolve (including episode links).
- Series/episode UI gains certificate and stars display, matching what movie cards already had.

Full analysis and design doc: `MIGRATION_ANALYSIS_v1.7.0.md`. New sheet header cheat-sheet: `columns.txt`.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests pass, including new unit tests for the runtime unit conversion (movie/series minutes vs. episode seconds) and the sheet-wins merge behavior
- [x] Manually verified against the real app: cleared all local caches (IMDB metadata, sheet CSV, image blobs) and confirmed a full cold-cache relaunch re-fetches everything correctly from the new API — catalog renders with live ratings/posters, series detail shows correct per-episode runtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)