### PR TITLE
v1.7.2 — fix invalid filename characters in titles

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -7,7 +7,7 @@
 ; Output: installer\mStorage_Setup.exe
 
 #define AppName        "mStorage"
-#define AppVersion     "1.7.1"
+#define AppVersion     "1.7.2"
 #define AppPublisher   "Seshu Tarapatla"
 #define AppURL         "https://github.com/SeshuTarapatla/mStorage"
 #define AppExeName     "m_storage.exe"

--- a/lib/core/util/filename_sanitizer.dart
+++ b/lib/core/util/filename_sanitizer.dart
@@ -1,0 +1,20 @@
+final _invalidFilenameChars = RegExp(r'[<>:"/\\|?*\x00-\x1F]');
+final _trailingDotsOrSpaces = RegExp(r'[. ]+$');
+final _repeatedSpaces = RegExp(r' {2,}');
+
+/// Makes [name] safe to use as a Windows file or directory name.
+///
+/// Movie/episode titles routinely contain characters Windows forbids in
+/// paths (e.g. the colon in "Avengers: Endgame"), which throws a
+/// [FileSystemException] on `Directory.create`/`File` calls. Invalid
+/// characters are replaced with a space rather than dropped outright, so
+/// "Avengers: Endgame" reads as "Avengers Endgame" instead of the more
+/// jarring "AvengersEndgame".
+String sanitizeFilename(String name) {
+  final sanitized = name
+      .replaceAll(_invalidFilenameChars, ' ')
+      .replaceAll(_repeatedSpaces, ' ')
+      .trim()
+      .replaceAll(_trailingDotsOrSpaces, '');
+  return sanitized.isEmpty ? 'untitled' : sanitized;
+}

--- a/lib/features/catalog/catalog_notifier.dart
+++ b/lib/features/catalog/catalog_notifier.dart
@@ -9,6 +9,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/catalog_cache_manager.dart';
 import '../../core/services/settings_service.dart';
+import '../../core/util/filename_sanitizer.dart';
 import 'imdb_service.dart';
 import 'models/catalog_entry.dart';
 import 'models/imdb_data.dart';
@@ -554,6 +555,7 @@ class DownloadNotifier extends Notifier<DownloadState> {
           m?.group(1)?.trim().replaceAll(RegExp(r'''["']'''), '') ?? '';
     }
     if (filename.isEmpty) filename = '${job.title}.mp4';
+    filename = sanitizeFilename(filename);
 
     final total = response.contentLength ?? 0;
     final downloadDir = _resolveDir();

--- a/lib/features/catalog/catalog_screen.dart
+++ b/lib/features/catalog/catalog_screen.dart
@@ -15,6 +15,7 @@ import '../../core/providers/player_request_provider.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
+import '../../core/util/filename_sanitizer.dart';
 import '../shell/app_shell.dart';
 import 'catalog_notifier.dart';
 import 'config_service.dart';
@@ -1449,7 +1450,7 @@ class _DownloadsListView extends ConsumerWidget {
   /// Returns the path of the first video file found in the decoded folder for
   /// this record, or null if not yet decoded.
   String? _decodedVideoPath(String decodeDir, DownloadRecord record) {
-    final folder = Directory(p.join(decodeDir, record.title));
+    final folder = Directory(p.join(decodeDir, sanitizeFilename(record.title)));
     if (!folder.existsSync()) return null;
     try {
       for (final entry in folder.listSync()) {

--- a/lib/features/catalog/screens/series_detail_screen.dart
+++ b/lib/features/catalog/screens/series_detail_screen.dart
@@ -10,6 +10,7 @@ import '../../../core/services/catalog_cache_manager.dart';
 import '../../../core/services/settings_service.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/theme/tab_colors.dart';
+import '../../../core/util/filename_sanitizer.dart';
 import '../catalog_notifier.dart'
     show DownloadActive, DownloadRecord, downloadHistoryProvider, downloadProvider;
 import '../models/series_entry.dart';
@@ -676,7 +677,7 @@ class _EpisodeDetailRowState extends ConsumerState<_EpisodeDetailRow> {
   static const _kVideoExts = {'mp4', 'mkv', 'avi', 'mov', 'webm'};
 
   static String? _decodedVideoPath(String decodeDir, String title) {
-    final folder = Directory(p.join(decodeDir, title));
+    final folder = Directory(p.join(decodeDir, sanitizeFilename(title)));
     if (!folder.existsSync()) return null;
     try {
       for (final entry in folder.listSync()) {

--- a/lib/features/catalog/widgets/catalog_card.dart
+++ b/lib/features/catalog/widgets/catalog_card.dart
@@ -13,6 +13,7 @@ import '../../../core/services/catalog_cache_manager.dart';
 import '../../../core/services/settings_service.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/theme/tab_colors.dart';
+import '../../../core/util/filename_sanitizer.dart';
 import '../../shell/app_shell.dart';
 import '../catalog_notifier.dart';
 import '../imdb_service.dart';
@@ -481,7 +482,7 @@ class _EntryActionButton extends ConsumerWidget {
   static const _kVideoExts = {'mp4', 'mkv', 'avi', 'mov', 'webm'};
 
   static String? _decodedVideoPath(String decodeDir, String title) {
-    final folder = Directory(p.join(decodeDir, title));
+    final folder = Directory(p.join(decodeDir, sanitizeFilename(title)));
     if (!folder.existsSync()) return null;
     try {
       for (final e in folder.listSync()) {

--- a/lib/features/decode/decode_notifier.dart
+++ b/lib/features/decode/decode_notifier.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import '../../core/models/decode_config.dart';
 import '../../core/services/archive_service.dart';
 import '../../core/services/format_service.dart';
+import '../../core/util/filename_sanitizer.dart';
 
 enum DecodeStep { idle, extractingArchive, extractingFiles, done, error }
 
@@ -57,7 +58,7 @@ class DecodeNotifier extends Notifier<DecodeState> {
       final cacheDir = Directory(p.join(tmpDir.path, 'mstorage_cache', uid));
       await cacheDir.create(recursive: true);
 
-      final title = p.basenameWithoutExtension(config.videoPath);
+      final title = sanitizeFilename(p.basenameWithoutExtension(config.videoPath));
       final archivePath = p.join(cacheDir.path, '$title.archive');
 
       // Step 1 — split out the archive payload

--- a/lib/features/encode/encode_screen.dart
+++ b/lib/features/encode/encode_screen.dart
@@ -10,6 +10,7 @@ import '../../core/models/encode_config.dart';
 import '../../core/services/settings_service.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/theme/tab_colors.dart';
+import '../../core/util/filename_sanitizer.dart';
 import '../shell/app_shell.dart';
 import '../shell/widgets/shared_widgets.dart';
 import 'encode_notifier.dart';
@@ -222,9 +223,9 @@ class _EncodeScreenState extends ConsumerState<EncodeScreen> {
     if (!mounted) return;
 
     final settings = ref.read(settingsProvider);
-    final title = _titleCtrl.text.trim().isEmpty
+    final title = sanitizeFilename(_titleCtrl.text.trim().isEmpty
         ? p.basenameWithoutExtension(_videoPath!)
-        : _titleCtrl.text.trim();
+        : _titleCtrl.text.trim());
     final outDir = settings.encodeOutputDirectory.isEmpty
         ? AppDirectories.encoded
         : settings.encodeOutputDirectory;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_storage
 description: "mStorage — hide movies inside mask MP4 containers."
 publish_to: 'none'
-version: 1.7.1+20
+version: 1.7.2+21
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
## Summary
- Titles containing characters Windows forbids in file paths (e.g. the colon in "Avengers: Endgame") broke directory/file creation in Decode and Encode, and broke the "already decoded" folder lookups.
- Added a shared `sanitizeFilename()` util and applied it everywhere a title is converted into a file or folder name, so encode, decode, download, and lookup paths stay consistent with each other.
- Bumped version to 1.7.2 (pubspec.yaml build +1, installer.iss AppVersion).

## Test plan
- [x] `dart analyze` clean
- [ ] Encode a video with a title containing `:` and confirm the output file/archive entries are created without error
- [ ] Decode a mask MP4 whose filename contains `:` and confirm extraction succeeds
- [ ] Confirm the "already decoded" indicator still shows correctly for a title with `:`